### PR TITLE
Update ADT location - Berlios is no more

### DIFF
--- a/help/ddi-transfer.html
+++ b/help/ddi-transfer.html
@@ -28,7 +28,7 @@ it is working it is very fast and convenient.</p>
 <p>
 Common programs for doing this work are ADT and ADTPro:</p>
 <ul>
-<li>Apple Disk Transfer (ADT) - <a target="_blank" href="http://adt.berlios.de">http://adt.berlios.de</a>
+<li>Apple Disk Transfer (ADT) - <a target="_blank" href="https://github.com/david-schmidt/adt">https://github.com/david-schmidt/adt</a>
  - runs natively on Windows, but is limited to transferring 5-1/4" disks.</li>
 <li>Apple Disk Transfer ProDOS (ADTPro) - <a target="_blank" href="http://adtpro.sourceforge.net/connectionsserial.html">http://adtpro.sourceforge.net/connectionsserial.html</a>
  - requires Java, but is capable of transferring all disk types and sizes.</li>


### PR DESCRIPTION
A quick change to the help - updating the location of ADT since Berlios went away.
