### PR TITLE
Save-state v2

### DIFF
--- a/AppleWinExpress2012.vcxproj
+++ b/AppleWinExpress2012.vcxproj
@@ -59,6 +59,7 @@
     <ClInclude Include="source\Debugger\Debugger_Range.h" />
     <ClInclude Include="source\Debugger\Debugger_Symbols.h" />
     <ClInclude Include="source\Debugger\Debugger_Types.h" />
+    <ClInclude Include="source\Debugger\Util_MemoryTextFile.h" />
     <ClInclude Include="source\Debugger\Util_Text.h" />
     <ClInclude Include="source\Disk.h" />
     <ClInclude Include="source\DiskDefs.h" />
@@ -74,6 +75,7 @@
     <ClInclude Include="source\MouseInterface.h" />
     <ClInclude Include="source\NoSlotClock.h" />
     <ClInclude Include="source\ParallelPrinter.h" />
+    <ClInclude Include="source\Pravets.h" />
     <ClInclude Include="source\Registry.h" />
     <ClInclude Include="source\Riff.h" />
     <ClInclude Include="source\SaveState.h" />
@@ -94,7 +96,6 @@
     <ClInclude Include="source\Tfe\Tfearch.h" />
     <ClInclude Include="source\Tfe\Tfesupp.h" />
     <ClInclude Include="source\Tfe\Uilib.h" />
-    <ClInclude Include="source\Debugger\Util_MemoryTextFile.h" />
     <ClInclude Include="source\Video.h" />
     <ClInclude Include="source\z80emu.h" />
     <ClInclude Include="source\Z80VICE\daa.h" />
@@ -136,6 +137,7 @@
     <ClCompile Include="source\Debugger\Debugger_Parser.cpp" />
     <ClCompile Include="source\Debugger\Debugger_Range.cpp" />
     <ClCompile Include="source\Debugger\Debugger_Symbols.cpp" />
+    <ClCompile Include="source\Debugger\Util_MemoryTextFile.cpp" />
     <ClCompile Include="source\Disk.cpp" />
     <ClCompile Include="source\DiskImage.cpp" />
     <ClCompile Include="source\DiskImageHelper.cpp" />
@@ -149,6 +151,7 @@
     <ClCompile Include="source\MouseInterface.cpp" />
     <ClCompile Include="source\NoSlotClock.cpp" />
     <ClCompile Include="source\ParallelPrinter.cpp" />
+    <ClCompile Include="source\Pravets.cpp" />
     <ClCompile Include="source\Registry.cpp" />
     <ClCompile Include="source\Riff.cpp" />
     <ClCompile Include="source\SaveState.cpp" />
@@ -187,7 +190,6 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release NoDX|Win32'">NotUsing</PrecompiledHeader>
     </ClCompile>
-    <ClCompile Include="source\Debugger\Util_MemoryTextFile.cpp" />
     <ClCompile Include="source\Video.cpp" />
     <ClCompile Include="source\z80emu.cpp" />
     <ClCompile Include="source\Z80VICE\daa.cpp">

--- a/AppleWinExpress2012.vcxproj.filters
+++ b/AppleWinExpress2012.vcxproj.filters
@@ -30,6 +30,9 @@
     <Filter Include="Source Files\Emulator">
       <UniqueIdentifier>{9b13bfc1-31ab-4f55-bb69-b8620ebdc2be}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source Files\Model">
+      <UniqueIdentifier>{15b450e4-f89f-4d80-9c44-48b32f33f3e3}</UniqueIdentifier>
+    </Filter>
     <Filter Include="Source Files\Uthernet">
       <UniqueIdentifier>{9bcc8097-f610-4843-bd76-a313aa54fbb0}</UniqueIdentifier>
     </Filter>
@@ -291,6 +294,9 @@
     <ClInclude Include="source\Debugger\Util_Text.h">
       <Filter>Source Files\Debugger</Filter>
     </ClInclude>
+    <ClInclude Include="source\Pravets.h">
+      <Filter>Source Files\Model</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Text Include="docs\CodingConventions.txt">
@@ -483,6 +489,9 @@
     </ClCompile>
     <ClCompile Include="source\Tfe\Uilib.cpp">
       <Filter>Source Files\Uthernet</Filter>
+    </ClCompile>
+    <ClCompile Include="source\Pravets.cpp">
+      <Filter>Source Files\Model</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/AppleWinExpress2013.vcxproj
+++ b/AppleWinExpress2013.vcxproj
@@ -75,6 +75,7 @@
     <ClInclude Include="source\MouseInterface.h" />
     <ClInclude Include="source\NoSlotClock.h" />
     <ClInclude Include="source\ParallelPrinter.h" />
+    <ClInclude Include="source\Pravets.h" />
     <ClInclude Include="source\Registry.h" />
     <ClInclude Include="source\Riff.h" />
     <ClInclude Include="source\SaveState.h" />
@@ -106,7 +107,7 @@
     <Text Include="docs\CodingConventions.txt" />
     <Text Include="docs\Debugger_Changelog.txt" />
     <Text Include="docs\FAQ.txt" />
-    <Text Include="docs\History.txt" />
+    <Text Include="bin\History.txt" />
     <Text Include="docs\ToDo.txt" />
     <Text Include="docs\Video_Cleanup.txt" />
     <Text Include="docs\Wishlist.txt" />
@@ -150,6 +151,7 @@
     <ClCompile Include="source\MouseInterface.cpp" />
     <ClCompile Include="source\NoSlotClock.cpp" />
     <ClCompile Include="source\ParallelPrinter.cpp" />
+    <ClCompile Include="source\Pravets.cpp" />
     <ClCompile Include="source\Registry.cpp" />
     <ClCompile Include="source\Riff.cpp" />
     <ClCompile Include="source\SaveState.cpp" />

--- a/AppleWinExpress2013.vcxproj.filters
+++ b/AppleWinExpress2013.vcxproj.filters
@@ -169,6 +169,9 @@
     <ClCompile Include="source\Debugger\Util_MemoryTextFile.cpp">
       <Filter>Source Files\Debugger</Filter>
     </ClCompile>
+    <ClCompile Include="source\Pravets.cpp">
+      <Filter>Source Files\Model</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="source\Applewin.h">
@@ -417,6 +420,9 @@
     <ClInclude Include="source\DiskDefs.h">
       <Filter>Source Files\Disk</Filter>
     </ClInclude>
+    <ClInclude Include="source\Pravets.h">
+      <Filter>Source Files\Model</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Image Include="resource\Applewin.bmp">
@@ -637,6 +643,9 @@
     </Filter>
     <Filter Include="Resource Files">
       <UniqueIdentifier>{b5c6889e-727d-4339-96c8-e4284e1d6e0f}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\Model">
+      <UniqueIdentifier>{15b450e4-f89f-4d80-9c44-48b32f33f3e3}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/ApplewinExpress9.00.vcproj
+++ b/ApplewinExpress9.00.vcproj
@@ -755,11 +755,19 @@
 					>
 				</File>
 				<File
-					RelativePath=".\source\SSI263Phonemes.h"
+					RelativePath=".\source\SaveState_Structs_common.h"
 					>
 				</File>
 				<File
-					RelativePath=".\source\Structs.h"
+					RelativePath=".\source\SaveState_Structs_v1.h"
+					>
+				</File>
+				<File
+					RelativePath=".\source\SaveState_Structs_v2.h"
+					>
+				</File>
+				<File
+					RelativePath=".\source\SSI263Phonemes.h"
 					>
 				</File>
 			</Filter>

--- a/ApplewinExpress9.00.vcproj
+++ b/ApplewinExpress9.00.vcproj
@@ -955,6 +955,18 @@
 					>
 				</File>
 			</Filter>
+			<Filter
+				Name="Model"
+				>
+				<File
+					RelativePath=".\source\Pravets.cpp"
+					>
+				</File>
+				<File
+					RelativePath=".\source\Pravets.h"
+					>
+				</File>
+			</Filter>
 		</Filter>
 		<Filter
 			Name="Docs"

--- a/source/6821.h
+++ b/source/6821.h
@@ -32,6 +32,21 @@ typedef struct
 	mem_write_handler func;
 } STWriteHandler;
 
+struct mc6821_s {
+	/* MC6821 register.  */
+	BYTE pra;
+	BYTE ddra;
+	BYTE cra;
+	BYTE prb;
+	BYTE ddrb;
+	BYTE crb;
+
+	/* Drive structure */
+//    struct drive_s *drive;
+};
+typedef struct mc6821_s mc6821_t;
+
+
 class C6821
 {
 public:
@@ -64,6 +79,18 @@ public:
 		m_stOutB.objTo = objTo;
 		m_stOutB.func = func;
 	}
+	void Get6821(mc6821_t& r6821, BYTE& byIA, BYTE& byIB)
+	{
+		r6821 = mc6821[0];
+		byIA = m_byIA;
+		byIB = m_byIB;
+	}
+	void Set6821(const mc6821_t& r6821, const BYTE byIA, const BYTE byIB)
+	{
+		mc6821[0] = r6821;
+		m_byIA = byIA;
+		m_byIB = byIB;
+	}
 	// AppleWin:TC END
 
 private:
@@ -74,20 +101,6 @@ private:
 	#define MC6821_SIG_CB2 3
 
 	//struct drive_s;
-
-	struct mc6821_s {
-		/* MC6821 register.  */
-		BYTE pra;
-		BYTE ddra;
-		BYTE cra;
-		BYTE prb;
-		BYTE ddrb;
-		BYTE crb;
-
-		/* Drive structure */
-	//    struct drive_s *drive;
-	};
-	typedef struct mc6821_s mc6821_t;
 
 	//struct drive_context_s;
 	void mc6821_init(/*struct drive_context_s *drv*/);

--- a/source/AY8910.h
+++ b/source/AY8910.h
@@ -17,6 +17,9 @@ BYTE* AY8910_GetRegsPtr(UINT uChip);
 
 void AY8910UpdateSetCycles();
 
+UINT AY8910_GetSnapshot(const HANDLE hFile, UINT uChip);
+UINT AY8910_SetSnapshot(const HANDLE hFile, UINT uChip);
+
 //-------------------------------------
 // FUSE stuff
 
@@ -43,8 +46,12 @@ public:
 	void sound_frame( void );
 	BYTE* GetAYRegsPtr( void ) { return &sound_ay_registers[0]; }
 	static void SetCLK( double CLK ) { m_fCurrentCLK_AY8910 = CLK; }
+	void ClearAYChangeCount( void ) { ay_change_count = 0; }
+	UINT GetSnapshot(const HANDLE hFile);
+	UINT SetSnapshot(const HANDLE hFile);
 
 private:
+	void init( void );
 	void sound_end( void );
 	void sound_ay_overlay( void );
 

--- a/source/AY8910.h
+++ b/source/AY8910.h
@@ -46,7 +46,6 @@ public:
 	void sound_frame( void );
 	BYTE* GetAYRegsPtr( void ) { return &sound_ay_registers[0]; }
 	static void SetCLK( double CLK ) { m_fCurrentCLK_AY8910 = CLK; }
-	void ClearAYChangeCount( void ) { ay_change_count = 0; }
 	UINT GetSnapshot(const HANDLE hFile);
 	UINT SetSnapshot(const HANDLE hFile);
 

--- a/source/Applewin.cpp
+++ b/source/Applewin.cpp
@@ -494,11 +494,6 @@ void LoadConfiguration(void)
 	if(REGLOAD(TEXT(REGVALUE_SLOT5), &dwTmp))
 		g_Slot5 = (SS_CARDTYPE) dwTmp;
 
-	if (g_Slot4 == CT_MockingboardC || g_Slot4 == CT_Phasor)
-		MB_SetSoundcardType(g_Slot4);
-	else
-		MB_SetSoundcardType(CT_Empty);
-
 	//
 
 	char szFilename[MAX_PATH] = {0};

--- a/source/Applewin.cpp
+++ b/source/Applewin.cpp
@@ -64,9 +64,6 @@ eApple2Type	g_Apple2Type = A2TYPE_APPLE2EENHANCED;
 
 bool      g_bFullSpeed      = false;
 
-//Pravets 8A/C variables
-bool P8CAPS_ON = false;
-bool P8Shift = false;
 //=================================================
 
 // Win32

--- a/source/Applewin.cpp
+++ b/source/Applewin.cpp
@@ -807,8 +807,8 @@ int APIENTRY WinMain(HINSTANCE passinstance, HINSTANCE, LPSTR lpCmdLine, int)
 			lpCmdLine = GetCurrArg(lpNextArg);
 			lpNextArg = GetNextArg(lpNextArg);
 			g_uMaxExPages = atoi(lpCmdLine);
-			if (g_uMaxExPages > 127)
-				g_uMaxExPages = 128;
+			if (g_uMaxExPages > kMaxExMemoryBanks)
+				g_uMaxExPages = kMaxExMemoryBanks;
 			else if (g_uMaxExPages < 1)
 				g_uMaxExPages = 1;
 		}

--- a/source/Applewin.cpp
+++ b/source/Applewin.cpp
@@ -469,12 +469,6 @@ void LoadConfiguration(void)
 	if(REGLOAD(TEXT(REGVALUE_HDD_ENABLED), &dwTmp))
 		HD_SetEnabled(dwTmp ? true : false);
 
-	char szHDVPathname[MAX_PATH] = {0};
-	if(RegLoadString(TEXT(REG_PREFS), TEXT(REGVALUE_PREF_LAST_HARDDISK_1), 1, szHDVPathname, sizeof(szHDVPathname)))
-		HD_InsertDisk(HARDDISK_1, szHDVPathname);
-	if(RegLoadString(TEXT(REG_PREFS), TEXT(REGVALUE_PREF_LAST_HARDDISK_2), 1, szHDVPathname, sizeof(szHDVPathname)))
-		HD_InsertDisk(HARDDISK_2, szHDVPathname);
-
 	if(REGLOAD(TEXT(REGVALUE_PDL_XTRIM), &dwTmp))
 		JoySetTrim((short)dwTmp, true);
 	if(REGLOAD(TEXT(REGVALUE_PDL_YTRIM), &dwTmp))
@@ -508,6 +502,16 @@ void LoadConfiguration(void)
 	//
 
 	char szFilename[MAX_PATH] = {0};
+
+	RegLoadString(TEXT(REG_PREFS), TEXT(REGVALUE_PREF_HDV_START_DIR), 1, szFilename, MAX_PATH);
+	if (szFilename[0] == 0)
+		GetCurrentDirectory(sizeof(szFilename), szFilename);
+	SetCurrentImageDir(szFilename);
+
+	HD_LoadLastDiskImage(HARDDISK_1);
+	HD_LoadLastDiskImage(HARDDISK_2);
+
+	//
 
 	// Current/Starting Dir is the "root" of where the user keeps his disk images
 	RegLoadString(TEXT(REG_PREFS), TEXT(REGVALUE_PREF_START_DIR), 1, szFilename, MAX_PATH);

--- a/source/Applewin.h
+++ b/source/Applewin.h
@@ -15,9 +15,6 @@ extern eApple2Type g_Apple2Type;
 
 extern bool       g_bFullSpeed;
 
-//Pravets 8A/C only variables
-extern bool     P8CAPS_ON;
-extern bool		P8Shift; 
 //===========================================
 
 // Win32

--- a/source/Applewin.h
+++ b/source/Applewin.h
@@ -6,7 +6,7 @@
 void SetCurrentCLK6502();
 void SetCurrentImageDir(const char* pszImageDir);
 
-
+extern const UINT16* GetAppleWinVersion(void);
 extern char VERSIONSTRING[];	// Constructed in WinMain()
 
 extern TCHAR     *g_pAppTitle;

--- a/source/Applewin.h
+++ b/source/Applewin.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Structs.h"
+#include "SaveState_Structs_common.h"
 #include "Common.h"
 
 void SetCurrentCLK6502();

--- a/source/CPU.h
+++ b/source/CPU.h
@@ -1,6 +1,7 @@
 #pragma once
 
-typedef struct _regsrec {
+struct regsrec
+{
   BYTE a;   // accumulator
   BYTE x;   // index X
   BYTE y;   // index Y
@@ -8,7 +9,7 @@ typedef struct _regsrec {
   WORD pc;  // program counter
   WORD sp;  // stack pointer
   BYTE bJammed; // CPU has crashed (NMOS 6502 only)
-} regsrec, *regsptr;
+};
 
 extern regsrec    regs;
 extern unsigned __int64 g_nCumulativeCycles;
@@ -26,8 +27,9 @@ void	CpuNmiReset();
 void	CpuNmiAssert(eIRQSRC Device);
 void	CpuNmiDeassert(eIRQSRC Device);
 void    CpuReset ();
-DWORD   CpuGetSnapshot(SS_CPU6502* pSS);
-DWORD   CpuSetSnapshot(SS_CPU6502* pSS);
+void    CpuSetSnapshot_v1(const BYTE A, const BYTE X, const BYTE Y, const BYTE P, const BYTE SP, const USHORT PC, const unsigned __int64 CumulativeCycles);
+void    CpuGetSnapshot(struct SS_CPU6502_v2& CPU);
+void    CpuSetSnapshot(const struct SS_CPU6502_v2& CPU);
 
 BYTE	CpuRead(USHORT addr, ULONG uExecutedCycles);
 void	CpuWrite(USHORT addr, BYTE a, ULONG uExecutedCycles);

--- a/source/Common.h
+++ b/source/Common.h
@@ -164,7 +164,7 @@ enum eIRQSRC {IS_6522=0, IS_SPEECH, IS_SSC, IS_MOUSE};
 #define IS_APPLE2C		(g_Apple2Type & APPLE2C_MASK)
 #define IS_CLONE()		(g_Apple2Type & APPLECLONE_MASK)
 
-// NB. These get persisted to the Registry, so don't change the values for these enums!
+// NB. These get persisted to the Registry & save-state file, so don't change the values for these enums!
 enum eApple2Type {
 					A2TYPE_APPLE2=0,
 					A2TYPE_APPLE2PLUS,

--- a/source/Configuration/Config.h
+++ b/source/Configuration/Config.h
@@ -15,6 +15,7 @@ public:
 		m_bEnableHDD = HD_CardIsEnabled();
 		m_bEnableTheFreezesF8Rom = bEnableTheFreezesF8Rom;
 		memset(&m_Slot, 0, sizeof(m_Slot));
+		m_SlotAux = CT_Empty;
 		m_Slot[4] = g_Slot4;
 		m_Slot[5] = g_Slot5;
 	}
@@ -47,6 +48,7 @@ public:
 
 	eApple2Type	m_Apple2Type;
 	SS_CARDTYPE m_Slot[NUM_SLOTS];	// 0..7
+	SS_CARDTYPE m_SlotAux;
 	BOOL m_bEnhanceDisk;
 	bool m_bEnableHDD;
 	UINT m_bEnableTheFreezesF8Rom;

--- a/source/Configuration/IPropertySheet.h
+++ b/source/Configuration/IPropertySheet.h
@@ -1,10 +1,13 @@
 #pragma once
 
+class CConfigNeedingRestart;
+
 __interface IPropertySheet
 {
 	void Init(void);
 	DWORD GetVolumeMax(void);								// TODO:TC: Move out of here
 	bool SaveStateSelectImage(HWND hWindow, bool bSave);	// TODO:TC: Move out of here
+	void ApplyNewConfig(const CConfigNeedingRestart& ConfigNew, const CConfigNeedingRestart& ConfigOld);
 
 	UINT GetScrollLockToggle(void);
 	void SetScrollLockToggle(UINT uValue);

--- a/source/Configuration/PageAdvanced.cpp
+++ b/source/Configuration/PageAdvanced.cpp
@@ -22,7 +22,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
 #include "StdAfx.h"
-#include "..\Structs.h"
 #include "..\Common.h"
 
 #include "..\ParallelPrinter.h"

--- a/source/Configuration/PageInput.cpp
+++ b/source/Configuration/PageInput.cpp
@@ -214,12 +214,12 @@ void CPageInput::DlgOK(HWND hWnd)
 
 	if (JoySetEmulationType(hWnd, m_nJoy0ChoiceTranlationTbl[uNewJoyType0], JN_JOYSTICK0, bIsSlot4Mouse))
 	{
-		REGSAVE(TEXT(REGVALUE_JOYSTICK0_EMU_TYPE), joytype[0]);
+		REGSAVE(TEXT(REGVALUE_JOYSTICK0_EMU_TYPE), JoyGetJoyType(0));
 	}
 
 	if (JoySetEmulationType(hWnd, m_nJoy1ChoiceTranlationTbl[uNewJoyType1], JN_JOYSTICK1, bIsSlot4Mouse))
 	{
-		REGSAVE(TEXT(REGVALUE_JOYSTICK1_EMU_TYPE), joytype[1]);
+		REGSAVE(TEXT(REGVALUE_JOYSTICK1_EMU_TYPE), JoyGetJoyType(1));
 	}
 
 	JoySetTrim((short)SendDlgItemMessage(hWnd, IDC_SPIN_XTRIM, UDM_GETPOS, 0, 0), true);
@@ -305,7 +305,7 @@ void CPageInput::InitJoystickChoices(HWND hWnd, int nJoyNum, int nIdcValue)
 	for(UINT i=nJC_KEYBD_CURSORS; i<nJC_MAX; i++)
 	{
 		if( ( (i == nJC_KEYBD_CURSORS) || (i == nJC_KEYBD_NUMPAD) ) &&
-			( (joytype[nOtherJoyNum] == nJC_KEYBD_CURSORS) || (joytype[nOtherJoyNum] == nJC_KEYBD_NUMPAD) )
+			( (JoyGetJoyType(nOtherJoyNum) == nJC_KEYBD_CURSORS) || (JoyGetJoyType(nOtherJoyNum) == nJC_KEYBD_NUMPAD) )
 		  )
 		{
 			continue;
@@ -314,7 +314,7 @@ void CPageInput::InitJoystickChoices(HWND hWnd, int nJoyNum, int nIdcValue)
 		if (i == nJC_MOUSE && bIsSlot4Mouse)
 			continue;
 
-		if(joytype[nOtherJoyNum] != i)
+		if (JoyGetJoyType(nOtherJoyNum) != i)
 		{
 			memcpy(pszMem, ppszJoyChoices[i], strlen(ppszJoyChoices[i])+1);
 			pszMem += strlen(ppszJoyChoices[i])+1;
@@ -324,7 +324,7 @@ void CPageInput::InitJoystickChoices(HWND hWnd, int nJoyNum, int nIdcValue)
 
 	*pszMem = 0x00;	// Doubly null terminated
 
-	m_PropertySheetHelper.FillComboBox(hWnd, nIdcValue, pnzJoystickChoices, joytype[nJoyNum]);
+	m_PropertySheetHelper.FillComboBox(hWnd, nIdcValue, pnzJoystickChoices, JoyGetJoyType(nJoyNum));
 }
 
 void CPageInput::InitSlotOptions(HWND hWnd)

--- a/source/Configuration/PageInput.cpp
+++ b/source/Configuration/PageInput.cpp
@@ -22,7 +22,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
 #include "StdAfx.h"
-#include "..\Structs.h"
+#include "..\SaveState_Structs_common.h"
 #include "..\Common.h"
 
 #include "..\Keyboard.h"

--- a/source/Configuration/PageSound.cpp
+++ b/source/Configuration/PageSound.cpp
@@ -22,7 +22,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
 #include "StdAfx.h"
-#include "..\Structs.h"
+#include "..\SaveState_Structs_common.h"
 #include "..\Common.h"
 
 #include "..\Mockingboard.h"

--- a/source/Configuration/PropertySheet.h
+++ b/source/Configuration/PropertySheet.h
@@ -24,6 +24,10 @@ public:
 	virtual void Init(void);
 	virtual DWORD GetVolumeMax(void);								// TODO:TC: Move out of here
 	virtual bool SaveStateSelectImage(HWND hWindow, bool bSave);	// TODO:TC: Move out of here
+	void ApplyNewConfig(const CConfigNeedingRestart& ConfigNew, const CConfigNeedingRestart& ConfigOld)
+	{
+		m_PropertySheetHelper.ApplyNewConfig(ConfigNew, ConfigOld);
+	}
 
 	virtual UINT GetScrollLockToggle(void){ return m_PageInput.GetScrollLockToggle(); }
 	virtual void SetScrollLockToggle(UINT uValue){ m_PageInput.SetScrollLockToggle(uValue); }

--- a/source/Configuration/PropertySheetHelper.cpp
+++ b/source/Configuration/PropertySheetHelper.cpp
@@ -242,18 +242,17 @@ int CPropertySheetHelper::SaveStateSelectImage(HWND hWindow, TCHAR* pszTitle, bo
 
 	if(nRes)
 	{
-		strcpy(m_szSSNewFilename, &szFilename[ofn.nFileOffset]);
-
 		if (bSave)	// Only for saving (allow loading of any file for backwards compatibility)
 		{
 			// Append .aws if it's not there
 			const char szAWS_EXT[] = ".aws";
-			const UINT uStrLenFile = strlen(m_szSSNewFilename);
+			const UINT uStrLenFile = strlen(&szFilename[ofn.nFileOffset]);
 			const UINT uStrLenExt  = strlen(szAWS_EXT);
-			if ((uStrLenFile <= uStrLenExt) || (strcmp(&m_szSSNewFilename[uStrLenFile-uStrLenExt], szAWS_EXT) != 0))
-				strcpy(&m_szSSNewFilename[uStrLenFile], szAWS_EXT);
+			if ((uStrLenFile <= uStrLenExt) || (strcmp(&szFilename[ofn.nFileOffset+uStrLenFile-uStrLenExt], szAWS_EXT) != 0))
+				strcpy(&szFilename[ofn.nFileOffset+uStrLenFile], szAWS_EXT);
 		}
 
+		strcpy(m_szSSNewFilename, &szFilename[ofn.nFileOffset]);
 		strcpy(m_szSSNewPathname, szFilename);
 
 		szFilename[ofn.nFileOffset] = 0;

--- a/source/Configuration/PropertySheetHelper.cpp
+++ b/source/Configuration/PropertySheetHelper.cpp
@@ -319,35 +319,40 @@ bool CPropertySheetHelper::CheckChangesForRestart(HWND hWnd)
 	return true;		// OK
 }
 
-#define CONFIG_CHANGED(var) \
-	(m_ConfigOld.var != m_ConfigNew.var)
+#define CONFIG_CHANGED_LOCAL(var) \
+	(ConfigOld.var != ConfigNew.var)
 
 // Apply changes to Registry
+void CPropertySheetHelper::ApplyNewConfig(const CConfigNeedingRestart& ConfigNew, const CConfigNeedingRestart& ConfigOld)
+{
+	if (CONFIG_CHANGED_LOCAL(m_Apple2Type))
+	{
+		SaveComputerType(ConfigNew.m_Apple2Type);
+	}
+
+	if (CONFIG_CHANGED_LOCAL(m_Slot[4]))
+		SetSlot4(ConfigNew.m_Slot[4]);
+
+	if (CONFIG_CHANGED_LOCAL(m_Slot[5]))
+		SetSlot5(ConfigNew.m_Slot[5]);
+
+	if (CONFIG_CHANGED_LOCAL(m_bEnhanceDisk))
+		REGSAVE(TEXT(REGVALUE_ENHANCE_DISK_SPEED), ConfigNew.m_bEnhanceDisk);
+
+	if (CONFIG_CHANGED_LOCAL(m_bEnableHDD))
+	{
+		REGSAVE(TEXT(REGVALUE_HDD_ENABLED), ConfigNew.m_bEnableHDD ? 1 : 0);
+	}
+
+	if (CONFIG_CHANGED_LOCAL(m_bEnableTheFreezesF8Rom))
+	{
+		REGSAVE(TEXT(REGVALUE_THE_FREEZES_F8_ROM), ConfigNew.m_bEnableTheFreezesF8Rom);
+	}
+}
+
 void CPropertySheetHelper::ApplyNewConfig(void)
 {
-	if (CONFIG_CHANGED(m_Apple2Type))
-	{
-		SaveComputerType(m_ConfigNew.m_Apple2Type);
-	}
-
-	if (CONFIG_CHANGED(m_Slot[4]))
-		SetSlot4(m_ConfigNew.m_Slot[4]);
-
-	if (CONFIG_CHANGED(m_Slot[5]))
-		SetSlot5(m_ConfigNew.m_Slot[5]);
-
-	if (CONFIG_CHANGED(m_bEnhanceDisk))
-		REGSAVE(TEXT(REGVALUE_ENHANCE_DISK_SPEED), m_ConfigNew.m_bEnhanceDisk);
-
-	if (CONFIG_CHANGED(m_bEnableHDD))
-	{
-		REGSAVE(TEXT(REGVALUE_HDD_ENABLED), m_ConfigNew.m_bEnableHDD ? 1 : 0);
-	}
-
-	if (CONFIG_CHANGED(m_bEnableTheFreezesF8Rom))
-	{
-		REGSAVE(TEXT(REGVALUE_THE_FREEZES_F8_ROM), m_ConfigNew.m_bEnableTheFreezesF8Rom);
-	}
+	ApplyNewConfig(m_ConfigNew, m_ConfigOld);
 }
 
 void CPropertySheetHelper::SaveCurrentConfig(void)
@@ -410,6 +415,9 @@ bool CPropertySheetHelper::IsOkToRestart(HWND hWnd)
 
 	return true;
 }
+
+#define CONFIG_CHANGED(var) \
+	(m_ConfigOld.var != m_ConfigNew.var)
 
 bool CPropertySheetHelper::HardwareConfigChanged(HWND hWnd)
 {

--- a/source/Configuration/PropertySheetHelper.h
+++ b/source/Configuration/PropertySheetHelper.h
@@ -37,6 +37,7 @@ public:
 	CConfigNeedingRestart& GetConfigNew(void) { return m_ConfigNew; }
 	bool IsConfigChanged(void) { return m_ConfigNew != m_ConfigOld; }
 	void SetDoBenchmark(void) { m_bDoBenchmark = true; }
+	void ApplyNewConfig(const CConfigNeedingRestart& ConfigNew, const CConfigNeedingRestart& ConfigOld);
 
 private:
 	bool IsOkToSaveLoadState(HWND hWnd, const bool bConfigChanged);

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -4285,7 +4285,7 @@ Update_t CmdMemoryLoad (int nArgs)
 
 		if (bBankSpecified)
 		{
-			MemUpdatePaging(1);
+			MemUpdatePaging(TRUE);
 		}
 		else
 		{

--- a/source/Debugger/Debug.h
+++ b/source/Debugger/Debug.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "..\Structs.h"
+#include "..\SaveState_Structs_v1.h"	// For SS_CARD_MOCKINGBOARD
 #include "..\Common.h"
 
 #include "Debugger_Types.h"

--- a/source/Debugger/Debugger_Display.cpp
+++ b/source/Debugger/Debugger_Display.cpp
@@ -2437,7 +2437,7 @@ void DrawMemory ( int line, int iMemDump )
 	SS_CARD_MOCKINGBOARD SS_MB;
 
 	if ((eDevice == DEV_SY6522) || (eDevice == DEV_AY8910))
-		MB_GetSnapshot(&SS_MB, 4+(nAddr>>1));		// Slot4 or Slot5
+		MB_GetSnapshot_v1(&SS_MB, 4+(nAddr>>1));		// Slot4 or Slot5
 
 	int nFontWidth = g_aFontConfig[ FONT_INFO ]._nFontWidthAvg;
 

--- a/source/Debugger/Debugger_Display.cpp
+++ b/source/Debugger/Debugger_Display.cpp
@@ -2434,7 +2434,7 @@ void DrawMemory ( int line, int iMemDump )
 	DEVICE_e     eDevice = pMD->eDevice;
 	MemoryView_e iView   = pMD->eView;
 
-	SS_CARD_MOCKINGBOARD SS_MB;
+	SS_CARD_MOCKINGBOARD_v1 SS_MB;
 
 	if ((eDevice == DEV_SY6522) || (eDevice == DEV_AY8910))
 		MB_GetSnapshot_v1(&SS_MB, 4+(nAddr>>1));		// Slot4 or Slot5

--- a/source/Disk.cpp
+++ b/source/Disk.cpp
@@ -1178,7 +1178,7 @@ struct SS_CARD_DISK2_v2
 {
 	SS_CARD_HDR	Hdr;
 	DISK2_Unit_v2	Unit[2];
-    WORD    Phases;
+	WORD	Phases;
 	WORD	CurrDrive;
 	BOOL	DiskAccessed;
 	BOOL	EnhanceDisk;
@@ -1200,7 +1200,7 @@ void DiskGetSnapshot(const HANDLE hFile)
 	pSS->Hdr.Slot = g_uSlot;
 	pSS->Hdr.Type = CT_Disk2;
 
-	pSS->Phases			    = phases;
+	pSS->Phases				= phases;
 	pSS->CurrDrive			= currdrive;
 	pSS->DiskAccessed		= diskaccessed;
 	pSS->EnhanceDisk		= enhancedisk;

--- a/source/Disk.cpp
+++ b/source/Disk.cpp
@@ -117,6 +117,7 @@ static bool IsDriveValid( const int iDrive );
 static void ReadTrack (int drive);
 static void RemoveDisk (int drive);
 static void WriteTrack (int drive);
+static LPCTSTR DiskGetFullPathName(const int iDrive);
 
 //===========================================================================
 
@@ -195,6 +196,17 @@ void Disk_SaveLastDiskImage(const int iDrive)
 		RegSaveString(TEXT(REG_PREFS), REGVALUE_PREF_LAST_DISK_1, TRUE, pFileName);
 	else
 		RegSaveString(TEXT(REG_PREFS), REGVALUE_PREF_LAST_DISK_2, TRUE, pFileName);
+
+	//
+
+	char szPathName[MAX_PATH];
+	strcpy(szPathName, DiskGetFullPathName(iDrive));
+	if (_tcsrchr(szPathName, TEXT('\\')))
+	{
+		char* pPathEnd = _tcsrchr(szPathName, TEXT('\\'))+1;
+		*pPathEnd = 0;
+		RegSaveString(TEXT(REG_PREFS), TEXT(REGVALUE_PREF_START_DIR), 1, szPathName);
+	}
 }
 
 //===========================================================================
@@ -847,9 +859,6 @@ static bool DiskSelectImage(const int iDrive, LPCSTR pszFilename)
 		ImageError_e Error = DiskInsert(iDrive, filename, ofn.Flags & OFN_READONLY, IMAGE_CREATE);
 		if (Error == eIMAGE_ERROR_NONE)
 		{
-			filename[ofn.nFileOffset] = 0;
-			if (_tcsicmp(directory, filename))
-				RegSaveString(TEXT(REG_PREFS), TEXT(REGVALUE_PREF_START_DIR), 1, filename);
 			bRes = true;
 		}
 		else

--- a/source/Disk.h
+++ b/source/Disk.h
@@ -40,7 +40,7 @@ const bool IMAGE_DONT_CREATE = false;
 const bool IMAGE_CREATE = true;
 
 extern BOOL enhancedisk;
-const std::string& DiskGetDiskPathFilename(const int iDrive);
+const char* DiskGetDiskPathFilename(const int iDrive);
 
 void    DiskInitialize(void); // DiskIIManagerStartup()
 void    DiskDestroy(void); // no, doesn't "destroy" the disk image.  DiskIIManagerShutdown()
@@ -70,8 +70,10 @@ void    DiskSelect(const int iDrive);
 void    DiskUpdatePosition(DWORD);
 bool    DiskDriveSwap(void);
 void    DiskLoadRom(LPBYTE pCxRomPeripheral, UINT uSlot);
-DWORD   DiskGetSnapshot(SS_CARD_DISK2* pSS, DWORD dwSlot);
-DWORD   DiskSetSnapshot(SS_CARD_DISK2* pSS, DWORD dwSlot);
+
+int     DiskSetSnapshot_v1(const struct SS_CARD_DISK2* const pSS);
+void    DiskGetSnapshot(const HANDLE hFile);
+void    DiskSetSnapshot(const HANDLE hFile);
 
 void Disk_LoadLastDiskImage(const int iDrive);
 void Disk_SaveLastDiskImage(const int iDrive);

--- a/source/DiskImage.h
+++ b/source/DiskImage.h
@@ -55,9 +55,14 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 		eIMAGE_ERROR_UNABLE_TO_OPEN,
 		eIMAGE_ERROR_UNABLE_TO_OPEN_GZ,
 		eIMAGE_ERROR_UNABLE_TO_OPEN_ZIP,
+		eIMAGE_ERROR_FAILED_TO_GET_PATHNAME,
 	};
 
-ImageError_e ImageOpen(LPCTSTR pszImageFilename, HIMAGE* hDiskImage_, bool* pWriteProtected_, const bool bCreateIfNecessary, std::string& strFilenameInZip);
+	const int MAX_DISK_IMAGE_NAME = 15;
+	const int MAX_DISK_FULL_NAME  = 127;
+
+
+ImageError_e ImageOpen(LPCTSTR pszImageFilename, HIMAGE* hDiskImage, bool* pWriteProtected, const bool bCreateIfNecessary, std::string& strFilenameInZip, const bool bExpectFloppy=true);
 void ImageClose(const HIMAGE hDiskImage, const bool bOpenError=false);
 BOOL ImageBoot(const HIMAGE hDiskImage);
 void ImageDestroy(void);
@@ -65,7 +70,13 @@ void ImageInitialize(void);
 
 void ImageReadTrack(const HIMAGE hDiskImage, int nTrack, int nQuarterTrack, LPBYTE pTrackImageBuffer, int* pNibbles);
 void ImageWriteTrack(const HIMAGE hDiskImage, int nTrack, int nQuarterTrack, LPBYTE pTrackImage, int nNibbles);
+bool ImageReadBlock(const HIMAGE hDiskImage, UINT nBlock, LPBYTE pBlockBuffer);
+bool ImageWriteBlock(const HIMAGE hDiskImage, UINT nBlock, LPBYTE pBlockBuffer);
 
 int ImageGetNumTracks(const HIMAGE hDiskImage);
 bool ImageIsWriteProtected(const HIMAGE hDiskImage);
 bool ImageIsMultiFileZip(const HIMAGE hDiskImage);
+const char* ImageGetPathname(const HIMAGE hDiskImage);
+UINT ImageGetImageSize(const HIMAGE hDiskImage);
+
+void GetImageTitle(LPCTSTR pPathname, TCHAR* pImageName, TCHAR* pFullName);

--- a/source/DiskImageHelper.cpp
+++ b/source/DiskImageHelper.cpp
@@ -28,7 +28,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
 #include "stdafx.h"
-#include "Structs.h"
 #include "Common.h"
 
 #include "zlib.h"
@@ -1435,7 +1434,9 @@ ImageError_e CImageHelperBase::Open(	LPCTSTR pszImageFilename,
 	if (Err != eIMAGE_ERROR_NONE)
 		return Err;
 
-	_tcsncpy(pImageInfo->szFilename, pszImageFilename, MAX_PATH);
+	DWORD uNameLen = GetFullPathName(pszImageFilename, MAX_PATH, pImageInfo->szFilename, NULL);
+	if (uNameLen == 0 || uNameLen >= MAX_PATH)
+		Err = eIMAGE_ERROR_FAILED_TO_GET_PATHNAME;
 
 	return eIMAGE_ERROR_NONE;
 }
@@ -1453,8 +1454,9 @@ void CImageHelperBase::Close(ImageInfo* pImageInfo, const bool bDeleteFile)
 	if (bDeleteFile)
 	{
 		DeleteFile(pImageInfo->szFilename);
-		pImageInfo->szFilename[0] = 0;
 	}
+
+	pImageInfo->szFilename[0] = 0;
 
 	delete [] pImageInfo->pImageBuffer;
 	pImageInfo->pImageBuffer = NULL;

--- a/source/Frame.cpp
+++ b/source/Frame.cpp
@@ -41,6 +41,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "Mockingboard.h"
 #include "MouseInterface.h"
 #include "ParallelPrinter.h"
+#include "Pravets.h"
 #include "Registry.h"
 #include "SaveState.h"
 #include "SerialComms.h"
@@ -1992,12 +1993,15 @@ void RelayEvent (UINT message, WPARAM wparam, LPARAM lparam) {
 }
 
 //===========================================================================
+
+// todo: consolidate CtrlReset() and ResetMachineState()
 void ResetMachineState ()
 {
   DiskReset();		// Set floppymotoron=0
   g_bFullSpeed = 0;	// Might've hit reset in middle of InternalCpuExecute() - so beep may get (partially) muted
 
   MemReset();
+  PravetsReset();
   DiskBoot();
   VideoResetState();
   sg_SSC.CommReset();
@@ -2016,12 +2020,15 @@ void ResetMachineState ()
 
 
 //===========================================================================
+
+// todo: consolidate CtrlReset() and ResetMachineState()
 void CtrlReset()
 {
 	// Ctrl+Reset - TODO: This is a terrible place for this code!
 	if (!IS_APPLE2)
 		MemResetPaging();
 
+	PravetsReset();
 	DiskReset();
 	KeybReset();
 	if (!IS_APPLE2)

--- a/source/Frame.cpp
+++ b/source/Frame.cpp
@@ -563,7 +563,8 @@ static void DrawFrameWindow ()
 	else if (g_nAppMode == MODE_DEBUG)
 		DebugDisplay(1);
 	else
-		// Win7: In fullscreen mode with 1 redraw, the the screen doesn't get redraw.
+		// Win7: In fullscreen mode with 1 redraw, the screen doesn't get redraw.
+		// TC: 07/01/2015: Tryed with MP's double-buffered DX full-screen code, but still the same.
 		VideoRedrawScreen(g_bIsFullScreen ? 2 : 1);	// TC: 22/06/2014: Why 2 redraws in full-screen mode (32-bit only)? (8-bit doesn't need this nor does Win8, just Win7 or older OS's)
 
 	// DD Full-Screen Palette: BUGFIX: needs to come _after_ all drawing...
@@ -617,6 +618,9 @@ void FrameDrawDiskLEDS( HDC passdc )
 //===========================================================================
 void FrameDrawDiskStatus( HDC passdc )
 {
+	if (mem == NULL)
+		return;
+
 	// We use the actual drive since probing from memory doesn't tell us anything we don't already know.
 	//        DOS3.3   ProDOS
 	// Drive  $B7EA    $BE3D
@@ -1023,7 +1027,7 @@ LRESULT CALLBACK FrameWndProc (
       if (!restart) {
         DiskDestroy();
         ImageDestroy();
-        HD_Cleanup();
+        HD_Destroy();
       }
       PrintDestroy();
       sg_SSC.CommDestroy();

--- a/source/Harddisk.cpp
+++ b/source/Harddisk.cpp
@@ -4,7 +4,7 @@ AppleWin : An Apple //e emulator for Windows
 Copyright (C) 1994-1996, Michael O'Brien
 Copyright (C) 1999-2001, Oliver Schmidt
 Copyright (C) 2002-2005, Tom Charlesworth
-Copyright (C) 2006-2007, Tom Charlesworth, Michael Pohoreski
+Copyright (C) 2006-2015, Tom Charlesworth, Michael Pohoreski
 
 AppleWin is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -114,22 +114,23 @@ Overview
 struct HDD
 {
 	// From Disk_t
-	TCHAR	imagename[16];				// Not used
-	TCHAR	fullname[128];
+	TCHAR	imagename[ MAX_DISK_IMAGE_NAME + 1 ];	// <FILENAME> (ie. no extension)    [not used]
+	TCHAR	fullname[ MAX_DISK_FULL_NAME  + 1 ];	// <FILENAME.EXT> or <FILENAME.zip>
+	std::string strFilenameInZip;					// ""             or <FILENAME.EXT> [not used]
+	HIMAGE	imagehandle;				// Init'd by HD_Insert() -> ImageOpen()
+	bool	bWriteProtected;			// Needed for ImageOpen() [otherwise not used]
 	//
 	BYTE	hd_error;
 	WORD	hd_memblock;
 	UINT	hd_diskblock;
 	WORD	hd_buf_ptr;
 	BOOL	hd_imageloaded;
-	BYTE	hd_buf[HD_BLOCK_SIZE+1];	// Why +1?
+	BYTE	hd_buf[HD_BLOCK_SIZE+1];	// Why +1? Probably for erroreous reads beyond the block size (ie. reads from I/O addr 0xC0F8)
 
 #if HD_LED
 	Disk_Status_e hd_status_next;
 	Disk_Status_e hd_status_prev;
 #endif
-
-	ImageInfo Info;
 };
 
 static bool	g_bHD_RomLoaded = false;
@@ -143,114 +144,85 @@ static BYTE	g_nHD_Command;
 
 static HDD g_HardDisk[NUM_HARDDISKS] = {0};
 
+static bool g_bSaveDiskImage = true;	// Save the DiskImage name to Registry
 static UINT g_uSlot = 7;
 
 static CHardDiskImageHelper sg_HardDiskImageHelper;
 
 //===========================================================================
 
+static void HD_SaveLastDiskImage(const int iDrive);
+
 static void HD_CleanupDrive(const int iDrive)
 {
-	sg_HardDiskImageHelper.Close(&g_HardDisk[iDrive].Info, false);
-
-	g_HardDisk[iDrive].hd_imageloaded = false;
-	g_HardDisk[iDrive].imagename[0] = 0;
-	g_HardDisk[iDrive].fullname[0] = 0;
-	g_HardDisk[iDrive].Info.szFilename[0] = 0;
-}
-
-static ImageError_e ImageOpen(	LPCTSTR pszImageFilename,
-								const int iDrive,
-								const bool bCreateIfNecessary,
-								std::string& strFilenameInZip)
-{
-	if (!pszImageFilename)
-		return eIMAGE_ERROR_BAD_POINTER;
-
-	HDD* pHDD = &g_HardDisk[iDrive];
-	ImageInfo* pImageInfo = &pHDD->Info;
-	pImageInfo->bWriteProtected = false;
-
-	ImageError_e Err = sg_HardDiskImageHelper.Open(pszImageFilename, pImageInfo, bCreateIfNecessary, strFilenameInZip);
-
-	if (Err != eIMAGE_ERROR_NONE)
+	if (g_HardDisk[iDrive].imagehandle)
 	{
-		HD_CleanupDrive(iDrive);
-		return Err;
+		ImageClose(g_HardDisk[iDrive].imagehandle);
+		g_HardDisk[iDrive].imagehandle = (HIMAGE)0;
 	}
 
-	return eIMAGE_ERROR_NONE;
+	g_HardDisk[iDrive].hd_imageloaded = false;
+
+	g_HardDisk[iDrive].imagename[0] = 0;
+	g_HardDisk[iDrive].fullname[0] = 0;
+	g_HardDisk[iDrive].strFilenameInZip = "";
+
+	HD_SaveLastDiskImage(iDrive);
 }
 
 //-----------------------------------------------------------------------------
-
-static void GetImageTitle(LPCTSTR pszImageFilename, HDD* pHardDrive)
-{
-	TCHAR   imagetitle[128];
-	LPCTSTR startpos = pszImageFilename;
-	
-	// imagetitle = <FILENAME.EXT>
-	if (_tcsrchr(startpos,TEXT('\\')))
-		startpos = _tcsrchr(startpos,TEXT('\\'))+1;
-	_tcsncpy(imagetitle,startpos,127);
-	imagetitle[127] = 0;
-	
-	// if imagetitle contains a lowercase char, then found=1 (why?)
-	BOOL found = 0;
-	int  loop  = 0;
-	while (imagetitle[loop] && !found)
-	{
-		if (IsCharLower(imagetitle[loop]))
-			found = 1;
-		else
-			loop++;
-	}
-		
-	if ((!found) && (loop > 2))
-		CharLowerBuff(imagetitle+1,_tcslen(imagetitle+1));
-	
-	// hdptr->fullname = <FILENAME.EXT>
-	_tcsncpy(pHardDrive->fullname,imagetitle,127);
-	pHardDrive->fullname[127] = 0;
-	
-	if (imagetitle[0])
-	{
-		LPTSTR dot = imagetitle;
-		if (_tcsrchr(dot,TEXT('.')))
-			dot = _tcsrchr(dot,TEXT('.'));
-		if (dot > imagetitle)
-			*dot = 0;
-	}
-	
-	// hdptr->imagename = <FILENAME> (ie. no extension)
-	_tcsncpy(pHardDrive->imagename,imagetitle,15);
-	pHardDrive->imagename[15] = 0;
-}
 
 static void NotifyInvalidImage(TCHAR* pszImageFilename)
 {
 	// TC: TO DO
 }
 
-static BOOL HD_Load_Image(const int iDrive, LPCSTR pszImageFilename)
+//===========================================================================
+
+BOOL HD_Insert(const int iDrive, LPCTSTR pszImageFilename);
+
+void HD_LoadLastDiskImage(const int iDrive)
 {
-	const bool bCreateIfNecessary = false;	// NB. Don't allow creation of HDV files
-	std::string strFilenameInZip;				// TODO: Use this
-	ImageError_e Error = ImageOpen(pszImageFilename, iDrive, bCreateIfNecessary, strFilenameInZip);
+	_ASSERT(iDrive == HARDDISK_1 || iDrive == HARDDISK_2);
 
-	g_HardDisk[iDrive].hd_imageloaded = (Error == eIMAGE_ERROR_NONE);
+	char sFilePath[ MAX_PATH + 1];
+	sFilePath[0] = 0;
 
-#if HD_LED
-	g_HardDisk[iDrive].hd_status_next = DISK_STATUS_OFF;
-	g_HardDisk[iDrive].hd_status_prev = DISK_STATUS_OFF;
-#endif
+	char *pRegKey = (iDrive == HARDDISK_1)
+		? REGVALUE_PREF_LAST_HARDDISK_1
+		: REGVALUE_PREF_LAST_HARDDISK_2;
 
-	return g_HardDisk[iDrive].hd_imageloaded;
+	if (RegLoadString(TEXT(REG_PREFS), pRegKey, 1, sFilePath, MAX_PATH))
+	{
+		sFilePath[ MAX_PATH ] = 0;
+
+		g_bSaveDiskImage = false;
+		// Pass in ptr to local copy of filepath, since RemoveDisk() sets DiskPathFilename = ""		// todo: update comment for HD func
+		HD_Insert(iDrive, sFilePath);
+		g_bSaveDiskImage = true;
+	}
 }
 
 //===========================================================================
 
-// everything below is global
+static void HD_SaveLastDiskImage(const int iDrive)
+{
+	_ASSERT(iDrive == HARDDISK_1 || iDrive == HARDDISK_2);
+
+	if (!g_bSaveDiskImage)
+		return;
+
+	const char *pFileName = g_HardDisk[iDrive].fullname;
+
+	if (iDrive == HARDDISK_1)
+		RegSaveString(TEXT(REG_PREFS), REGVALUE_PREF_LAST_HARDDISK_1, TRUE, pFileName);
+	else
+		RegSaveString(TEXT(REG_PREFS), REGVALUE_PREF_LAST_HARDDISK_2, TRUE, pFileName);
+}
+
+//===========================================================================
+
+// (Nearly) everything below is global
 
 static BYTE __stdcall HD_IO_EMUL(WORD pc, WORD addr, BYTE bWrite, BYTE d, ULONG nCyclesLeft);
 
@@ -263,7 +235,8 @@ bool HD_CardIsEnabled(void)
 
 // Called by:
 // . LoadConfiguration() - Done at each restart
-// . DiskDlg_OK() - When HD is enabled/disabled on UI
+// . RestoreCurrentConfig() - Done when Config dialog is cancelled
+// . Snapshot_LoadState_v2() - Done to default to disabled state
 void HD_SetEnabled(const bool bEnabled)
 {
 	if(g_bHD_Enabled == bEnabled)
@@ -298,17 +271,17 @@ LPCTSTR HD_GetFullName(const int iDrive)
 
 LPCTSTR HD_GetFullPathName(const int iDrive)
 {
-	return g_HardDisk[iDrive].Info.szFilename;
+	return ImageGetPathname(g_HardDisk[iDrive].imagehandle);
 }
 
-static LPCTSTR HD_DiskGetBaseName (const int iDrive)	// Not used
+static LPCTSTR HD_DiskGetBaseName(const int iDrive)	// Not used
 {
 	return g_HardDisk[iDrive].imagename;
 }
 
 //-------------------------------------
 
-VOID HD_Load_Rom(const LPBYTE pCxRomPeripheral, const UINT uSlot)
+void HD_Load_Rom(const LPBYTE pCxRomPeripheral, const UINT uSlot)
 {
 	if(!g_bHD_Enabled)
 		return;
@@ -336,45 +309,81 @@ VOID HD_Load_Rom(const LPBYTE pCxRomPeripheral, const UINT uSlot)
 	RegisterIoHandler(g_uSlot, HD_IO_EMUL, HD_IO_EMUL, NULL, NULL, NULL, NULL);
 }
 
-VOID HD_Cleanup(void)
+void HD_Destroy(void)
 {
-	for(int i=HARDDISK_1; i<HARDDISK_2; i++)
-	{
-		HD_CleanupDrive(i);
-	}
+	g_bSaveDiskImage = false;
+	HD_CleanupDrive(HARDDISK_1);
+
+	g_bSaveDiskImage = false;
+	HD_CleanupDrive(HARDDISK_2);
+
+	g_bSaveDiskImage = true;
 }
 
 // pszImageFilename is qualified with path
-BOOL HD_InsertDisk(const int iDrive, LPCTSTR pszImageFilename)
+static BOOL HD_Insert(const int iDrive, LPCTSTR pszImageFilename)
 {
 	if (*pszImageFilename == 0x00)
-		return false;
+		return FALSE;
 
 	if (g_HardDisk[iDrive].hd_imageloaded)
-		HD_CleanupDrive(iDrive);
+		HD_Unplug(iDrive);
 
 	// Check if image is being used by the other HDD, and unplug it in order to be swapped
-	if (!strcmp(HD_GetFullPathName(!iDrive), pszImageFilename)) {
-		HD_Unplug(!iDrive);
+	{
+		const char* pszOtherPathname = HD_GetFullPathName(!iDrive);
+
+		char szCurrentPathname[MAX_PATH]; 
+		DWORD uNameLen = GetFullPathName(pszImageFilename, MAX_PATH, szCurrentPathname, NULL);
+		if (uNameLen == 0 || uNameLen >= MAX_PATH)
+			strcpy_s(szCurrentPathname, MAX_PATH, pszImageFilename);
+
+ 		if (!strcmp(pszOtherPathname, szCurrentPathname))
+		{
+			HD_Unplug(!iDrive);
+			FrameRefreshStatus(DRAW_LEDS);
+		}
 	}
 
-	BOOL bResult = HD_Load_Image(iDrive, pszImageFilename);
+	const bool bCreateIfNecessary = false;		// NB. Don't allow creation of HDV files
+	const bool bExpectFloppy = false;
+	ImageError_e Error = ImageOpen(pszImageFilename,
+		&g_HardDisk[iDrive].imagehandle,
+		&g_HardDisk[iDrive].bWriteProtected,
+		bCreateIfNecessary,
+		g_HardDisk[iDrive].strFilenameInZip,	// TODO: Use this
+		bExpectFloppy);
 
-	if (bResult)
-		GetImageTitle(pszImageFilename, &g_HardDisk[iDrive]);
+	g_HardDisk[iDrive].hd_imageloaded = (Error == eIMAGE_ERROR_NONE);
 
-	return bResult;
+#if HD_LED
+	g_HardDisk[iDrive].hd_status_next = DISK_STATUS_OFF;
+	g_HardDisk[iDrive].hd_status_prev = DISK_STATUS_OFF;
+#endif
+
+	if (Error == eIMAGE_ERROR_NONE)
+	{
+		GetImageTitle(pszImageFilename, g_HardDisk[iDrive].imagename, g_HardDisk[iDrive].fullname);
+	}
+
+	HD_SaveLastDiskImage(iDrive);
+
+	return g_HardDisk[iDrive].hd_imageloaded;
 }
 
-void HD_Select(const int iDrive)
+static bool HD_SelectImage(const int iDrive, LPCSTR pszFilename)
 {
 	TCHAR directory[MAX_PATH] = TEXT("");
 	TCHAR filename[MAX_PATH]  = TEXT("");
 	TCHAR title[40];
 
+	strcpy(filename, pszFilename);
+
 	RegLoadString(TEXT(REG_PREFS), TEXT(REGVALUE_PREF_HDV_START_DIR), 1, directory, MAX_PATH);
 	_tcscpy(title, TEXT("Select HDV Image For HDD "));
 	_tcscat(title, iDrive ? TEXT("2") : TEXT("1"));
+
+	_ASSERT(sizeof(OPENFILENAME) == sizeof(OPENFILENAME_NT4));	// Required for Win98/ME support (selected by _WIN32_WINNT=0x0400 in stdafx.h)
 
 	OPENFILENAME ofn;
 	ZeroMemory(&ofn,sizeof(OPENFILENAME));
@@ -389,22 +398,32 @@ void HD_Select(const int iDrive)
 	ofn.Flags           = OFN_FILEMUSTEXIST | OFN_HIDEREADONLY;	// Don't allow creation & hide the read-only checkbox
 	ofn.lpstrTitle      = title;
 
+	bool bRes = false;
+
 	if (GetOpenFileName(&ofn))
 	{
 		if ((!ofn.nFileExtension) || !filename[ofn.nFileExtension])
 			_tcscat(filename,TEXT(".hdv"));
 		
-		if (HD_InsertDisk(iDrive, filename))
+		if (HD_Insert(iDrive, filename))
 		{
 			filename[ofn.nFileOffset] = 0;
 			if (_tcsicmp(directory, filename))
 				RegSaveString(TEXT(REG_PREFS), TEXT(REGVALUE_PREF_HDV_START_DIR), 1, filename);
+			bRes = true;
 		}
 		else
 		{
 			NotifyInvalidImage(filename);
 		}
 	}
+
+	return bRes;
+}
+
+void HD_Select(const int iDrive)
+{
+	HD_SelectImage(iDrive, TEXT(""));
 }
 
 void HD_Unplug(const int iDrive)
@@ -450,33 +469,33 @@ static BYTE __stdcall HD_IO_EMUL(WORD pc, WORD addr, BYTE bWrite, BYTE d, ULONG 
 					{
 						default:
 						case 0x00: //status
-							if (pHDD->Info.uImageSize == 0)
+							if (ImageGetImageSize(pHDD->imagehandle) == 0)
 							{
 								pHDD->hd_error = 1;
 								r = DEVICE_IO_ERROR;
 							}
 							break;
 						case 0x01: //read
-								if ((pHDD->hd_diskblock * HD_BLOCK_SIZE) < pHDD->Info.uImageSize)
+							if ((pHDD->hd_diskblock * HD_BLOCK_SIZE) < ImageGetImageSize(pHDD->imagehandle))
+							{
+								bool bRes = ImageReadBlock(pHDD->imagehandle, pHDD->hd_diskblock, pHDD->hd_buf);
+								if (bRes)
 								{
-									bool bRes = pHDD->Info.pImageType->Read(&pHDD->Info, pHDD->hd_diskblock, pHDD->hd_buf);
-									if (bRes)
-									{
-										pHDD->hd_error = 0;
-										r = 0;
-										pHDD->hd_buf_ptr = 0;
-									}
-									else
-									{
-										pHDD->hd_error = 1;
-										r = DEVICE_IO_ERROR;
-									}
+									pHDD->hd_error = 0;
+									r = 0;
+									pHDD->hd_buf_ptr = 0;
 								}
 								else
 								{
 									pHDD->hd_error = 1;
 									r = DEVICE_IO_ERROR;
 								}
+							}
+							else
+							{
+								pHDD->hd_error = 1;
+								r = DEVICE_IO_ERROR;
+							}
 							break;
 						case 0x02: //write
 							{
@@ -484,17 +503,17 @@ static BYTE __stdcall HD_IO_EMUL(WORD pc, WORD addr, BYTE bWrite, BYTE d, ULONG 
 								pHDD->hd_status_next = DISK_STATUS_WRITE;
 #endif
 								bool bRes = true;
-								const bool bAppendBlocks = (pHDD->hd_diskblock * HD_BLOCK_SIZE) >= pHDD->Info.uImageSize;
+								const bool bAppendBlocks = (pHDD->hd_diskblock * HD_BLOCK_SIZE) >= ImageGetImageSize(pHDD->imagehandle);
 
 								if (bAppendBlocks)
 								{
 									ZeroMemory(pHDD->hd_buf, HD_BLOCK_SIZE);
 
 									// Inefficient (especially for gzip/zip files!)
-									UINT uBlock = pHDD->Info.uImageSize / HD_BLOCK_SIZE;
+									UINT uBlock = ImageGetImageSize(pHDD->imagehandle) / HD_BLOCK_SIZE;
 									while (uBlock < pHDD->hd_diskblock)
 									{
-										bRes = pHDD->Info.pImageType->Write(&pHDD->Info, uBlock++, pHDD->hd_buf);
+										bRes = ImageWriteBlock(pHDD->imagehandle, uBlock++, pHDD->hd_buf);
 										_ASSERT(bRes);
 										if (!bRes)
 											break;
@@ -504,7 +523,7 @@ static BYTE __stdcall HD_IO_EMUL(WORD pc, WORD addr, BYTE bWrite, BYTE d, ULONG 
 								MoveMemory(pHDD->hd_buf, mem+pHDD->hd_memblock, HD_BLOCK_SIZE);
 
 								if (bRes)
-									bRes = pHDD->Info.pImageType->Write(&pHDD->Info, pHDD->hd_diskblock, pHDD->hd_buf);
+									bRes = ImageWriteBlock(pHDD->imagehandle, pHDD->hd_diskblock, pHDD->hd_buf);
 
 								if (bRes)
 								{
@@ -560,7 +579,8 @@ static BYTE __stdcall HD_IO_EMUL(WORD pc, WORD addr, BYTE bWrite, BYTE d, ULONG 
 			break;
 		case 0xF8:
 			r = pHDD->hd_buf[pHDD->hd_buf_ptr];
-			pHDD->hd_buf_ptr++;
+			if (pHDD->hd_buf_ptr < sizeof(pHDD->hd_buf)-1)
+				pHDD->hd_buf_ptr++;
 			break;
 		default:
 #if HD_LED
@@ -630,4 +650,160 @@ void HD_GetLightStatus (Disk_Status_e *pDisk1Status_)
 	{
 		*pDisk1Status_ = DISK_STATUS_OFF;
 	}
+}
+
+//===========================================================================
+
+struct HDD_Unit
+{
+	char	szFilename[MAX_PATH];
+	BYTE	error;
+	WORD	memblock;
+	UINT	diskblock;
+	WORD	buf_ptr;
+	BOOL	imageloaded;
+	BYTE	buf[HD_BLOCK_SIZE];
+	UINT	status_next;
+	UINT	status_prev;
+};
+
+struct SS_CARD_HDD
+{
+	SS_CARD_HDR	Hdr;
+	HDD_Unit	Unit[NUM_HARDDISKS];
+	BYTE		CurrUnit;
+	BYTE		Command;
+};
+
+void HD_GetSnapshot(const HANDLE hFile)
+{
+	if (!HD_CardIsEnabled())
+		return;
+
+	SS_CARD_HDD CardHDD;
+
+	CardHDD.Hdr.UnitHdr.hdr.v2.Length = sizeof(SS_CARD_HDD);
+	CardHDD.Hdr.UnitHdr.hdr.v2.Type = UT_Card;
+	CardHDD.Hdr.UnitHdr.hdr.v2.Version = 1;
+
+	CardHDD.Hdr.Slot = g_uSlot;
+	CardHDD.Hdr.Type = CT_GenericHDD;
+
+	CardHDD.CurrUnit = g_nHD_UnitNum;
+	CardHDD.Command = g_nHD_Command;
+
+	for (UINT i=0; i<NUM_HARDDISKS; i++)
+	{
+		strcpy(CardHDD.Unit[i].szFilename, g_HardDisk[i].fullname);
+		CardHDD.Unit[i].error = g_HardDisk[i].hd_error;
+		CardHDD.Unit[i].memblock = g_HardDisk[i].hd_memblock;
+		CardHDD.Unit[i].diskblock = g_HardDisk[i].hd_diskblock;
+		CardHDD.Unit[i].buf_ptr = g_HardDisk[i].hd_buf_ptr;
+		CardHDD.Unit[i].imageloaded = g_HardDisk[i].hd_imageloaded;
+		memcpy(CardHDD.Unit[i].buf, g_HardDisk[i].hd_buf, sizeof(CardHDD.Unit[i].buf));
+		CardHDD.Unit[i].status_next = g_HardDisk[i].hd_status_next;
+		CardHDD.Unit[i].status_prev = g_HardDisk[i].hd_status_prev;
+	}
+
+	//
+
+	DWORD dwBytesWritten;
+	BOOL bRes = WriteFile(	hFile,
+							&CardHDD,
+							CardHDD.Hdr.UnitHdr.hdr.v2.Length,
+							&dwBytesWritten,
+							NULL);
+
+	if(!bRes || (dwBytesWritten != CardHDD.Hdr.UnitHdr.hdr.v2.Length))
+	{
+		//dwError = GetLastError();
+		throw std::string("Save error: HDD");
+	}
+}
+
+void HD_SetSnapshot(const HANDLE hFile, const std::string strSaveStatePath)
+{
+	SS_CARD_HDD CardHDD;
+
+	DWORD dwBytesRead;
+	BOOL bRes = ReadFile(	hFile,
+							&CardHDD,
+							sizeof(CardHDD),
+							&dwBytesRead,
+							NULL);
+
+	if (dwBytesRead != sizeof(CardHDD))
+		throw std::string("Card: file corrupt");
+
+	if (CardHDD.Hdr.Slot != 7)	// fixme
+		throw std::string("Card: wrong slot");
+
+	if (CardHDD.Hdr.UnitHdr.hdr.v2.Version > 1)
+		throw std::string("Card: wrong version");
+
+	if (CardHDD.Hdr.UnitHdr.hdr.v2.Length != sizeof(SS_CARD_HDD))
+		throw std::string("Card: unit size mismatch");
+
+	g_nHD_UnitNum = CardHDD.CurrUnit;
+	g_nHD_Command = CardHDD.Command;
+
+	// Unplug all HDDs first in case HDD-2 is to be plugged in as HDD-1
+	for (UINT i=0; i<NUM_HARDDISKS; i++)
+	{
+		HD_Unplug(i);
+		ZeroMemory(&g_HardDisk[i], sizeof(HDD));
+	}
+
+	bool bResSelectImage = false;
+
+	for (UINT i=0; i<NUM_HARDDISKS; i++)
+	{
+		if (CardHDD.Unit[i].szFilename[0] == 0x00)
+			continue;
+
+		DWORD dwAttributes = GetFileAttributes(CardHDD.Unit[i].szFilename);
+		if (dwAttributes == INVALID_FILE_ATTRIBUTES)
+		{
+			// Get user to browse for file
+			bResSelectImage = HD_SelectImage(i, CardHDD.Unit[i].szFilename);
+
+			dwAttributes = GetFileAttributes(CardHDD.Unit[i].szFilename);
+		}
+
+		bool bImageError = (dwAttributes == INVALID_FILE_ATTRIBUTES);
+		if (!bImageError)
+		{
+			if (!HD_Insert(i, CardHDD.Unit[i].szFilename))
+				bImageError = true;
+
+			// HD_Insert() sets up:
+			// . imagename
+			// . fullname
+			// . hd_imageloaded
+		}
+
+		//
+
+//		strcpy(g_HardDisk[i].fullname, CardHDD.Unit[i].szFilename);
+		g_HardDisk[i].hd_error = CardHDD.Unit[i].error;
+		g_HardDisk[i].hd_memblock = CardHDD.Unit[i].memblock;
+		g_HardDisk[i].hd_diskblock = CardHDD.Unit[i].diskblock;
+		g_HardDisk[i].hd_buf_ptr = CardHDD.Unit[i].buf_ptr;
+//		g_HardDisk[i].hd_imageloaded = CardHDD.Unit[i].imageloaded;
+		memcpy(g_HardDisk[i].hd_buf, CardHDD.Unit[i].buf, sizeof(CardHDD.Unit[i].buf));
+		g_HardDisk[i].hd_status_next = (Disk_Status_e) CardHDD.Unit[i].status_next;
+		g_HardDisk[i].hd_status_prev = (Disk_Status_e) CardHDD.Unit[i].status_prev;
+
+		if (bImageError)
+		{
+			g_HardDisk[i].hd_imageloaded = FALSE;
+		}
+	}
+
+	if (!bResSelectImage)
+		RegSaveString(TEXT(REG_PREFS), TEXT(REGVALUE_PREF_HDV_START_DIR), 1, strSaveStatePath.c_str());
+
+	HD_SetEnabled(true);
+
+	FrameRefreshStatus(DRAW_LEDS);
 }

--- a/source/Harddisk.cpp
+++ b/source/Harddisk.cpp
@@ -218,6 +218,17 @@ static void HD_SaveLastDiskImage(const int iDrive)
 		RegSaveString(TEXT(REG_PREFS), REGVALUE_PREF_LAST_HARDDISK_1, TRUE, pFileName);
 	else
 		RegSaveString(TEXT(REG_PREFS), REGVALUE_PREF_LAST_HARDDISK_2, TRUE, pFileName);
+
+	//
+
+	char szPathName[MAX_PATH];
+	strcpy(szPathName, HD_GetFullPathName(iDrive));
+	if (_tcsrchr(szPathName, TEXT('\\')))
+	{
+		char* pPathEnd = _tcsrchr(szPathName, TEXT('\\'))+1;
+		*pPathEnd = 0;
+		RegSaveString(TEXT(REG_PREFS), TEXT(REGVALUE_PREF_HDV_START_DIR), 1, szPathName);
+	}
 }
 
 //===========================================================================
@@ -407,9 +418,6 @@ static bool HD_SelectImage(const int iDrive, LPCSTR pszFilename)
 		
 		if (HD_Insert(iDrive, filename))
 		{
-			filename[ofn.nFileOffset] = 0;
-			if (_tcsicmp(directory, filename))
-				RegSaveString(TEXT(REG_PREFS), TEXT(REGVALUE_PREF_HDV_START_DIR), 1, filename);
 			bRes = true;
 		}
 		else

--- a/source/Harddisk.h
+++ b/source/Harddisk.h
@@ -30,16 +30,19 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 		NUM_HARDDISKS
 	};
 
+	void HD_Destroy(void);
 	bool HD_CardIsEnabled(void);
 	void HD_SetEnabled(const bool bEnabled);
 	LPCTSTR HD_GetFullName(const int iDrive);
 	LPCTSTR HD_GetFullPathName(const int iDrive);
-	VOID HD_Load_Rom(const LPBYTE pCxRomPeripheral, const UINT uSlot);
-	VOID HD_Cleanup(void);
-	BOOL HD_InsertDisk(const int iDrive, LPCTSTR pszImageFilename);
+	void HD_Load_Rom(const LPBYTE pCxRomPeripheral, const UINT uSlot);
 	void HD_Select(const int iDrive);
 	void HD_Unplug(const int iDrive);
 	bool HD_IsDriveUnplugged(const int iDrive);
+	void HD_LoadLastDiskImage(const int iDrive);
 
 	// 1.19.0.0 Hard Disk Status/Indicator Light
 	void HD_GetLightStatus (Disk_Status_e *pDisk1Status_);
+
+	void HD_GetSnapshot(const HANDLE hFile);
+	void HD_SetSnapshot(const HANDLE hFile, const std::string strSaveStatePath);

--- a/source/Joystick.cpp
+++ b/source/Joystick.cpp
@@ -824,14 +824,19 @@ void JoyportControl(const UINT uControl)
 
 //===========================================================================
 
-DWORD JoyGetSnapshot(SS_IO_Joystick* pSS)
+void JoySetSnapshot_v1(const unsigned __int64 JoyCntrResetCycle)
 {
-	pSS->g_nJoyCntrResetCycle = g_nJoyCntrResetCycle;
-	return 0;
+	g_nJoyCntrResetCycle = JoyCntrResetCycle;
 }
 
-DWORD JoySetSnapshot(SS_IO_Joystick* pSS)
+//
+
+void JoyGetSnapshot(unsigned __int64& rJoyCntrResetCycle)
 {
-	g_nJoyCntrResetCycle = pSS->g_nJoyCntrResetCycle;
-	return 0;
+	rJoyCntrResetCycle = g_nJoyCntrResetCycle;
+}
+
+void JoySetSnapshot(const unsigned __int64 JoyCntrResetCycle)
+{
+	g_nJoyCntrResetCycle = JoyCntrResetCycle;
 }

--- a/source/Joystick.cpp
+++ b/source/Joystick.cpp
@@ -91,7 +91,7 @@ static int   joysubx[2]     = {0,0};
 static int   joysuby[2]     = {0,0};
 
 // Value persisted to Registry for REGVALUE_JOYSTICK0_EMU_TYPE
-DWORD joytype[2]            = {J0C_JOYSTICK1, J1C_DISABLED};	// Emulation Type for joysticks #0 & #1
+static DWORD joytype[2]            = {J0C_JOYSTICK1, J1C_DISABLED};	// Emulation Type for joysticks #0 & #1
 
 static BOOL  setbutton[3]   = {0,0,0};	// Used when a mouse button is pressed/released
 
@@ -753,6 +753,30 @@ void JoyDisableUsingMouse()
 
 //===========================================================================
 
+void JoySetJoyType(UINT num, DWORD type)
+{
+	_ASSERT(num <= JN_JOYSTICK1);
+	if (num > JN_JOYSTICK1)
+		return;
+
+	joytype[num] = type;
+
+	// Refresh centre positions whenever 'joytype' changes
+	JoySetTrim(JoyGetTrim(true) , true);
+	JoySetTrim(JoyGetTrim(false), false);
+}
+
+DWORD JoyGetJoyType(UINT num)
+{
+	_ASSERT(num <= JN_JOYSTICK1);
+	if (num > JN_JOYSTICK1)
+		return J0C_DISABLED;
+
+	return joytype[num];
+}
+
+//===========================================================================
+
 void JoySetTrim(short nValue, bool bAxisX)
 {
 	if(bAxisX)
@@ -831,12 +855,18 @@ void JoySetSnapshot_v1(const unsigned __int64 JoyCntrResetCycle)
 
 //
 
-void JoyGetSnapshot(unsigned __int64& rJoyCntrResetCycle)
+void JoyGetSnapshot(unsigned __int64& rJoyCntrResetCycle, short* pJoystick0Trim, short* pJoystick1Trim)
 {
 	rJoyCntrResetCycle = g_nJoyCntrResetCycle;
+	pJoystick0Trim[0] = JoyGetTrim(true);
+	pJoystick0Trim[1] = JoyGetTrim(false);
+	pJoystick1Trim[0] = 0;	// TBD: not implemented yet
+	pJoystick1Trim[1] = 0;	// TBD: not implemented yet
 }
 
-void JoySetSnapshot(const unsigned __int64 JoyCntrResetCycle)
+void JoySetSnapshot(const unsigned __int64 JoyCntrResetCycle, const short* pJoystick0Trim, const short* pJoystick1Trim)
 {
 	g_nJoyCntrResetCycle = JoyCntrResetCycle;
+	JoySetTrim(pJoystick0Trim[0], true);
+	JoySetTrim(pJoystick0Trim[1], false);
 }

--- a/source/Joystick.h
+++ b/source/Joystick.h
@@ -5,8 +5,6 @@ enum JOYNUM {JN_JOYSTICK0=0, JN_JOYSTICK1};
 enum JOY0CHOICE {J0C_DISABLED=0, J0C_JOYSTICK1, J0C_KEYBD_CURSORS, J0C_KEYBD_NUMPAD, J0C_MOUSE, J0C_MAX};
 enum JOY1CHOICE {J1C_DISABLED=0, J1C_JOYSTICK2, J1C_KEYBD_CURSORS, J1C_KEYBD_NUMPAD, J1C_MOUSE, J1C_MAX};
 
-extern DWORD      joytype[2];
-
 enum {JOYSTICK_MODE_FLOATING=0, JOYSTICK_MODE_CENTERING};	// Joystick centering control
 
 void    JoyInitialize();
@@ -21,12 +19,14 @@ BOOL    JoyUsingKeyboard();
 BOOL    JoyUsingKeyboardCursors();
 BOOL    JoyUsingKeyboardNumpad();
 void    JoyDisableUsingMouse();
+void    JoySetJoyType(UINT num, DWORD type);
+DWORD   JoyGetJoyType(UINT num);
 void    JoySetTrim(short nValue, bool bAxisX);
 short   JoyGetTrim(bool bAxisX);
 void	JoyportControl(const UINT uControl);
 void    JoySetSnapshot_v1(const unsigned __int64 JoyCntrResetCycle);
-void    JoyGetSnapshot(unsigned __int64& rJoyCntrResetCycle);
-void    JoySetSnapshot(const unsigned __int64 JoyCntrResetCycle);
+void    JoyGetSnapshot(unsigned __int64& rJoyCntrResetCycle, short* pJoystick0Trim, short* pJoystick1Trim);
+void    JoySetSnapshot(const unsigned __int64 JoyCntrResetCycle, const short* pJoystick0Trim, const short* pJoystick1Trim);
 
 BYTE __stdcall JoyReadButton(WORD pc, WORD addr, BYTE bWrite, BYTE d, ULONG nCyclesLeft);
 BYTE __stdcall JoyReadPosition(WORD pc, WORD addr, BYTE bWrite, BYTE d, ULONG nCyclesLeft);

--- a/source/Joystick.h
+++ b/source/Joystick.h
@@ -24,8 +24,9 @@ void    JoyDisableUsingMouse();
 void    JoySetTrim(short nValue, bool bAxisX);
 short   JoyGetTrim(bool bAxisX);
 void	JoyportControl(const UINT uControl);
-DWORD   JoyGetSnapshot(SS_IO_Joystick* pSS);
-DWORD   JoySetSnapshot(SS_IO_Joystick* pSS);
+void    JoySetSnapshot_v1(const unsigned __int64 JoyCntrResetCycle);
+void    JoyGetSnapshot(unsigned __int64& rJoyCntrResetCycle);
+void    JoySetSnapshot(const unsigned __int64 JoyCntrResetCycle);
 
 BYTE __stdcall JoyReadButton(WORD pc, WORD addr, BYTE bWrite, BYTE d, ULONG nCyclesLeft);
 BYTE __stdcall JoyReadPosition(WORD pc, WORD addr, BYTE bWrite, BYTE d, ULONG nCyclesLeft);

--- a/source/Keyboard.cpp
+++ b/source/Keyboard.cpp
@@ -31,6 +31,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "AppleWin.h"
 #include "Frame.h"
 #include "Keyboard.h"
+#include "Pravets.h"
 #include "Tape.h"
 
 static bool g_bKeybBufferEnable = false;

--- a/source/Keyboard.cpp
+++ b/source/Keyboard.cpp
@@ -50,7 +50,6 @@ static bool  g_bCapsLock = true; //Caps lock key for Apple2 and Lat/Cyr lock for
 static bool  g_bP8CapsLock = true; //Caps lock key of Pravets 8A/C
 static int   lastvirtkey     = 0;	// Current PC keycode
 static BYTE  keycode         = 0;	// Current Apple keycode
-static DWORD keyboardqueries = 0;
 
 #ifdef KEY_OLD
 // Original
@@ -158,14 +157,6 @@ void KeybUpdateCtrlShiftStatus()
 BYTE KeybGetKeycode ()		// Used by MemCheckPaging() & VideoCheckMode()
 {
 	return keycode;
-}
-
-//===========================================================================
-DWORD KeybGetNumQueries ()	// Used in determining 'idleness' of Apple system
-{
-	DWORD result = keyboardqueries;
-	keyboardqueries = 0;
-	return result;
 }
 
 //===========================================================================
@@ -425,10 +416,6 @@ static char ClipboardCurrChar(bool bIncPtr)
 
 BYTE __stdcall KeybReadData (WORD, WORD, BYTE, BYTE, ULONG)
 {
-	keyboardqueries++;
-
-	//
-
 	if(g_bPasteFromClipboard)
 		ClipboardInit();
 
@@ -463,10 +450,6 @@ BYTE __stdcall KeybReadData (WORD, WORD, BYTE, BYTE, ULONG)
 
 BYTE __stdcall KeybReadFlag (WORD, WORD, BYTE, BYTE, ULONG)
 {
-	keyboardqueries++;
-
-	//
-
 	if(g_bPasteFromClipboard)
 		ClipboardInit();
 
@@ -516,16 +499,19 @@ void KeybToggleP8ACapsLock ()
 
 //===========================================================================
 
-DWORD KeybGetSnapshot(SS_IO_Keyboard* pSS)
+void KeybSetSnapshot_v1(const BYTE LastKey)
 {
-	pSS->keyboardqueries	= keyboardqueries;
-	pSS->nLastKey			= g_nLastKey;
-	return 0;
+	g_nLastKey = LastKey;
 }
 
-DWORD KeybSetSnapshot(SS_IO_Keyboard* pSS)
+//
+
+void KeybGetSnapshot(BYTE& rLastKey)
 {
-	keyboardqueries	= pSS->keyboardqueries;
-	g_nLastKey		= pSS->nLastKey;
-	return 0;
+	rLastKey = g_nLastKey;
+}
+
+void KeybSetSnapshot(const BYTE LastKey)
+{
+	g_nLastKey = LastKey;
 }

--- a/source/Keyboard.h
+++ b/source/Keyboard.h
@@ -11,12 +11,12 @@ bool    KeybGetShiftStatus();
 bool    KeybGetCapsAllowed(); //For Pravets8A/C only
 void    KeybUpdateCtrlShiftStatus();
 BYTE    KeybGetKeycode ();
-DWORD   KeybGetNumQueries ();
 void    KeybQueueKeypress (int,BOOL);
 void    KeybToggleCapsLock ();
 void    KeybToggleP8ACapsLock ();
-DWORD   KeybGetSnapshot(SS_IO_Keyboard* pSS);
-DWORD   KeybSetSnapshot(SS_IO_Keyboard* pSS);
+void    KeybSetSnapshot_v1(const BYTE LastKey);
+void    KeybGetSnapshot(BYTE& rLastKey);
+void    KeybSetSnapshot(const BYTE LastKey);
 
 BYTE __stdcall KeybReadData (WORD pc, WORD addr, BYTE bWrite, BYTE d, ULONG nCyclesLeft);
 BYTE __stdcall KeybReadFlag (WORD pc, WORD addr, BYTE bWrite, BYTE d, ULONG nCyclesLeft);

--- a/source/Memory.cpp
+++ b/source/Memory.cpp
@@ -200,7 +200,6 @@ static LPBYTE	RWpages[kMaxExMemoryBanks];		// pointers to RW memory banks
 #endif
 
 BYTE __stdcall IO_Annunciator(WORD programcounter, WORD address, BYTE write, BYTE value, ULONG nCycles);
-void UpdatePaging(BOOL initialize);
 
 //=============================================================================
 
@@ -811,6 +810,16 @@ static void SetMemMode(const DWORD uNewMemMode)
 
 //===========================================================================
 
+static void ResetPaging(BOOL initialize);
+static void UpdatePaging(BOOL initialize);
+
+// Call by:
+// . CtrlReset() Soft-reset (Ctrl+Reset)
+void MemResetPaging()
+{
+	ResetPaging(0);		// Initialize=0
+}
+
 static void ResetPaging(BOOL initialize)
 {
 	lastwriteram = 0;
@@ -1330,7 +1339,8 @@ inline DWORD getRandomTime()
 // Called by:
 // . MemInitialize()
 // . ResetMachineState()	eg. Power-cycle ('Apple-Go' button)
-// . Snapshot_LoadState()
+// . Snapshot_LoadState_v1()
+// . Snapshot_LoadState_v2()
 void MemReset()
 {
 	// INITIALIZE THE PAGING TABLES
@@ -1481,22 +1491,6 @@ void MemReset()
 	//Sets Caps Lock = false (Pravets 8A/C only)
 
 	z80_reset();	// NB. Also called above in CpuInitialize()
-}
-
-//===========================================================================
-
-// Call by:
-// . Soft-reset (Ctrl+Reset)
-// . Snapshot_LoadState()
-void MemResetPaging()
-{
-	ResetPaging(0);		// Initialize=0
-	if (g_Apple2Type == A2TYPE_PRAVETS8A)
-	{
-		P8CAPS_ON = false; 
-		TapeWrite (0, 0, 0, 0 ,0);
-		FrameRefreshStatus(DRAW_LEDS);
-	}
 }
 
 //===========================================================================

--- a/source/Memory.h
+++ b/source/Memory.h
@@ -44,14 +44,18 @@ LPBYTE  MemGetMainPtr(const WORD);
 LPBYTE  MemGetBankPtr(const UINT nBank);
 LPBYTE  MemGetCxRomPeripheral();
 void    MemInitialize ();
+void    MemInitializeROM(void);
+void    MemInitializeCustomF8ROM(void);
+void    MemInitializeIO(void);
 BYTE    MemReadFloatingBus(const ULONG uExecutedCycles);
 BYTE    MemReadFloatingBus(const BYTE highbit, const ULONG uExecutedCycles);
 void    MemReset ();
 void    MemResetPaging ();
 void    MemUpdatePaging(BOOL initialize);
 LPVOID	MemGetSlotParameters (UINT uSlot);
-DWORD   MemGetSnapshot(SS_BaseMemory* pSS);
-DWORD   MemSetSnapshot(SS_BaseMemory* pSS);
+void    MemSetSnapshot_v1(const DWORD MemMode, const BOOL LastWriteRam, const BYTE* const pMemMain, const BYTE* const pMemAux);
+void    MemGetSnapshot(struct SS_BaseMemory_v2& Memory);
+void    MemSetSnapshot(const struct SS_BaseMemory_v2& Memory);
 
 BYTE __stdcall IO_Null(WORD programcounter, WORD address, BYTE write, BYTE value, ULONG nCycles);
 

--- a/source/Memory.h
+++ b/source/Memory.h
@@ -56,6 +56,8 @@ LPVOID	MemGetSlotParameters (UINT uSlot);
 void    MemSetSnapshot_v1(const DWORD MemMode, const BOOL LastWriteRam, const BYTE* const pMemMain, const BYTE* const pMemAux);
 void    MemGetSnapshot(struct SS_BaseMemory_v2& Memory);
 void    MemSetSnapshot(const struct SS_BaseMemory_v2& Memory);
+void    MemGetSnapshotAux(const HANDLE hFile);
+void    MemSetSnapshotAux(const HANDLE hFile);
 
 BYTE __stdcall IO_Null(WORD programcounter, WORD address, BYTE write, BYTE value, ULONG nCycles);
 

--- a/source/Memory.h
+++ b/source/Memory.h
@@ -32,6 +32,7 @@ extern LPBYTE     mem;
 extern LPBYTE     memdirty;
 
 #ifdef RAMWORKS
+const UINT kMaxExMemoryBanks = 127;	// 127 * aux mem(64K) + main mem(64K) = 8MB
 extern UINT       g_uMaxExPages;	// user requested ram pages (from cmd line)
 #endif
 

--- a/source/Mockingboard.cpp
+++ b/source/Mockingboard.cpp
@@ -1000,7 +1000,7 @@ static DWORD WINAPI SSI263Thread(LPVOID lpParameter)
 
 //-----------------------------------------------------------------------------
 
-// Warning! Data-race!
+// Warning! Data-race! [FIXME]
 // . SSI263Thread() can asynchronously set /g_nCurrentActivePhoneme/ to -1
 // . I have seen it on a call to Play(0,0,0)
 // . eg. could occur between [1] and [2]

--- a/source/Mockingboard.h
+++ b/source/Mockingboard.h
@@ -22,5 +22,8 @@ double  MB_GetFramePeriod();
 bool    MB_IsActive();
 DWORD   MB_GetVolume();
 void    MB_SetVolume(DWORD dwVolume, DWORD dwVolumeMax);
-DWORD   MB_GetSnapshot(SS_CARD_MOCKINGBOARD* pSS, DWORD dwSlot);
-DWORD   MB_SetSnapshot(SS_CARD_MOCKINGBOARD* pSS, DWORD dwSlot);
+
+void    MB_GetSnapshot_v1(struct SS_CARD_MOCKINGBOARD* const pSS, const DWORD dwSlot);	// For debugger
+int     MB_SetSnapshot_v1(const struct SS_CARD_MOCKINGBOARD* const pSS, const DWORD dwSlot);
+void    MB_GetSnapshot(const HANDLE hFile, const UINT uSlot);
+void    MB_SetSnapshot(const HANDLE hFile);

--- a/source/Mockingboard.h
+++ b/source/Mockingboard.h
@@ -23,7 +23,10 @@ bool    MB_IsActive();
 DWORD   MB_GetVolume();
 void    MB_SetVolume(DWORD dwVolume, DWORD dwVolumeMax);
 
-void    MB_GetSnapshot_v1(struct SS_CARD_MOCKINGBOARD* const pSS, const DWORD dwSlot);	// For debugger
-int     MB_SetSnapshot_v1(const struct SS_CARD_MOCKINGBOARD* const pSS, const DWORD dwSlot);
+void    MB_GetSnapshot_v1(struct SS_CARD_MOCKINGBOARD_v1* const pSS, const DWORD dwSlot);	// For debugger
+int     MB_SetSnapshot_v1(const struct SS_CARD_MOCKINGBOARD_v1* const pSS, const DWORD dwSlot);
 void    MB_GetSnapshot(const HANDLE hFile, const UINT uSlot);
 void    MB_SetSnapshot(const HANDLE hFile);
+
+void Phasor_GetSnapshot(const HANDLE hFile);
+void Phasor_SetSnapshot(const HANDLE hFile);

--- a/source/MouseInterface.h
+++ b/source/MouseInterface.h
@@ -12,7 +12,6 @@ public:
 	void Initialize(LPBYTE pCxRomPeripheral, UINT uSlot);
 	void Uninitialize();
 	void Reset();
-	void SetSlotRom();
 	static BYTE __stdcall IORead(WORD PC, WORD uAddr, BYTE bWrite, BYTE uValue, ULONG nCyclesLeft);
 	static BYTE __stdcall IOWrite(WORD PC, WORD uAddr, BYTE bWrite, BYTE uValue, ULONG nCyclesLeft);
 
@@ -38,7 +37,11 @@ public:
 		m_iY = iY;
 	}
 
+	int GetSnapshot(const HANDLE hFile);
+	void SetSnapshot(const HANDLE hFile);
+
 protected:
+	void SetSlotRom();
 	void On6821_A(BYTE byData);
 	void On6821_B(BYTE byData);
 	void OnCommand();

--- a/source/ParallelPrinter.cpp
+++ b/source/ParallelPrinter.cpp
@@ -36,17 +36,18 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "..\resource\resource.h"
 
 static DWORD inactivity = 0;
+static int g_iPrinterIdleLimit = 10;
 static FILE* file = NULL;
 DWORD const PRINTDRVR_SIZE = APPLE_SLOT_SIZE;
-TCHAR filepath[MAX_PATH * 2];
 #define DEFAULT_PRINT_FILENAME "Printer.txt"
 static char g_szPrintFilename[MAX_PATH] = {0};
 bool g_bDumpToPrinter = false;
 bool g_bConvertEncoding = true;
 bool g_bFilterUnprintable = true;
 bool g_bPrinterAppend = false;
-int  g_iPrinterIdleLimit = 10;
 bool g_bEnableDumpToRealPrinter = false;
+
+static UINT g_uSlot = 0;
 
 //===========================================================================
 
@@ -79,6 +80,8 @@ VOID PrintLoadRom(LPBYTE pCxRomPeripheral, const UINT uSlot)
 	//
 
 	RegisterIoHandler(uSlot, PrintStatus, PrintTransmit, NULL, NULL, NULL, NULL);
+
+	g_uSlot = uSlot;
 }
 
 //===========================================================================
@@ -245,8 +248,110 @@ unsigned int Printer_GetIdleLimit()
 	return g_iPrinterIdleLimit;
 }
 
-//unsigned int
 void Printer_SetIdleLimit(unsigned int Duration)
 {	
 	g_iPrinterIdleLimit = Duration;
+}
+
+//===========================================================================
+
+struct PrinterCard_Unit
+{
+	DWORD Inactivity;
+	UINT PrinterIdleLimit;
+	char PrintFilename[MAX_PATH];
+	BOOL IsFileOpen;
+	BOOL DumpToPrinter;
+	BOOL ConvertEncoding;
+	BOOL FilterUnprintable;
+	BOOL PrinterAppend;
+	BOOL EnableDumpToRealPrinter;
+};
+
+struct SS_CARD_PRINTER
+{
+	SS_CARD_HDR			Hdr;
+	PrinterCard_Unit	Unit;
+};
+
+void Printer_GetSnapshot(const HANDLE hFile)
+{
+	SS_CARD_PRINTER CardPrinter;
+
+	SS_CARD_PRINTER* const pSS = &CardPrinter;
+
+	pSS->Hdr.UnitHdr.hdr.v2.Length = sizeof(SS_CARD_PRINTER);
+	pSS->Hdr.UnitHdr.hdr.v2.Type = UT_Card;
+	pSS->Hdr.UnitHdr.hdr.v2.Version = 1;
+
+	pSS->Hdr.Slot = g_uSlot;
+	pSS->Hdr.Type = CT_GenericPrinter;
+
+	CardPrinter.Unit.Inactivity = inactivity;
+	CardPrinter.Unit.PrinterIdleLimit = g_iPrinterIdleLimit;
+	memcpy(CardPrinter.Unit.PrintFilename, g_szPrintFilename, sizeof(CardPrinter.Unit.PrintFilename));
+	CardPrinter.Unit.IsFileOpen = (file != NULL);
+	CardPrinter.Unit.DumpToPrinter = g_bDumpToPrinter;
+	CardPrinter.Unit.ConvertEncoding = g_bConvertEncoding;
+	CardPrinter.Unit.FilterUnprintable = g_bFilterUnprintable;
+	CardPrinter.Unit.PrinterAppend = g_bPrinterAppend;
+	CardPrinter.Unit.EnableDumpToRealPrinter = g_bEnableDumpToRealPrinter;
+
+	//
+
+	DWORD dwBytesWritten;
+	BOOL bRes = WriteFile(	hFile,
+							&CardPrinter,
+							CardPrinter.Hdr.UnitHdr.hdr.v2.Length,
+							&dwBytesWritten,
+							NULL);
+
+	if(!bRes || (dwBytesWritten != CardPrinter.Hdr.UnitHdr.hdr.v2.Length))
+	{
+		//dwError = GetLastError();
+		throw std::string("Save error: Printer Card");
+	}
+}
+
+void Printer_SetSnapshot(const HANDLE hFile)
+{
+	SS_CARD_PRINTER CardPrinter;
+
+	DWORD dwBytesRead;
+	BOOL bRes = ReadFile(	hFile,
+							&CardPrinter,
+							sizeof(CardPrinter),
+							&dwBytesRead,
+							NULL);
+
+	if (dwBytesRead != sizeof(CardPrinter))
+		throw std::string("Card: file corrupt");
+
+	if (CardPrinter.Hdr.Slot != 1)	// fixme
+		throw std::string("Card: wrong slot");
+
+	if (CardPrinter.Hdr.UnitHdr.hdr.v2.Version > 1)
+		throw std::string("Card: wrong version");
+
+	if (CardPrinter.Hdr.UnitHdr.hdr.v2.Length != sizeof(SS_CARD_PRINTER))
+		throw std::string("Card: unit size mismatch");
+
+	ClosePrint();	// Close current print session (and close file handle)
+
+	inactivity = CardPrinter.Unit.Inactivity;
+	g_iPrinterIdleLimit = CardPrinter.Unit.PrinterIdleLimit;
+	memcpy(g_szPrintFilename, CardPrinter.Unit.PrintFilename, sizeof(g_szPrintFilename));
+	if (CardPrinter.Unit.IsFileOpen)
+	{
+		g_bPrinterAppend = true;	// Re-open print-file in append mode
+		BOOL bRes = CheckPrint();
+		if (!bRes)
+			throw std::string("Printer Card: Unable to resume printing to file");
+	}
+
+	g_bDumpToPrinter = CardPrinter.Unit.DumpToPrinter == TRUE;
+	g_bConvertEncoding = CardPrinter.Unit.ConvertEncoding == TRUE;
+	g_bFilterUnprintable = CardPrinter.Unit.FilterUnprintable == TRUE;
+	g_bPrinterAppend = CardPrinter.Unit.PrinterAppend == TRUE;
+	g_bEnableDumpToRealPrinter = CardPrinter.Unit.EnableDumpToRealPrinter == TRUE;
 }

--- a/source/ParallelPrinter.h
+++ b/source/ParallelPrinter.h
@@ -9,11 +9,11 @@ char*			Printer_GetFilename();
 void			Printer_SetIdleLimit(unsigned int Duration);
 unsigned int	Printer_GetIdleLimit();
 
+void Printer_GetSnapshot(const HANDLE hFile);
+void Printer_SetSnapshot(const HANDLE hFile);
+
 extern bool		g_bDumpToPrinter;
 extern bool		g_bConvertEncoding;
-extern bool		g_bFilterUnprintable;
-extern bool		g_bPrinterAppend;
-extern int		g_iPrinterIdleLimit;
 extern bool		g_bFilterUnprintable;
 extern bool		g_bPrinterAppend;
 extern bool		g_bEnableDumpToRealPrinter;	// Set by cmd-line: -printer-real

--- a/source/Pravets.cpp
+++ b/source/Pravets.cpp
@@ -1,0 +1,48 @@
+/*
+AppleWin : An Apple //e emulator for Windows
+
+Copyright (C) 1994-1996, Michael O'Brien
+Copyright (C) 1999-2001, Oliver Schmidt
+Copyright (C) 2002-2005, Tom Charlesworth
+Copyright (C) 2006-2015, Tom Charlesworth, Michael Pohoreski
+
+AppleWin is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+AppleWin is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with AppleWin; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+/* Description: Pravets - Apple II clone
+ *
+ * Author: Various
+ */
+
+#include "StdAfx.h"
+
+#include "AppleWin.h"
+#include "Frame.h"
+#include "Keyboard.h"
+#include "Tape.h"
+
+//Pravets 8A/C variables
+bool P8CAPS_ON = false;
+bool P8Shift = false;
+
+void PravetsReset(void)
+{
+	if (g_Apple2Type == A2TYPE_PRAVETS8A)
+	{
+		P8CAPS_ON = false; 
+		TapeWrite(0, 0, 0, 0 ,0);
+		FrameRefreshStatus(DRAW_LEDS);
+	}
+}

--- a/source/Pravets.h
+++ b/source/Pravets.h
@@ -1,0 +1,7 @@
+#pragma once
+
+//Pravets 8A/C only variables
+extern bool P8CAPS_ON;
+extern bool	P8Shift; 
+
+void PravetsReset(void);

--- a/source/SaveState.cpp
+++ b/source/SaveState.cpp
@@ -474,6 +474,9 @@ static void Snapshot_LoadState_v2(DWORD dwVersion)
 		for (UINT i=0; i<NUM_SLOTS; i++)
 			m_ConfigNew.m_Slot[i] = CT_Empty;
 		m_ConfigNew.m_SlotAux = CT_Empty;
+		m_ConfigNew.m_bEnableHDD = false;
+		//m_ConfigNew.m_bEnableTheFreezesF8Rom = ?;	// todo: when support saving config
+		//m_ConfigNew.m_bEnhanceDisk = ?;			// todo: when support saving config
 
 		MemReset();
 		PravetsReset();

--- a/source/SaveState.cpp
+++ b/source/SaveState.cpp
@@ -23,10 +23,13 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 /* Description: Save-state (snapshot) module
  *
- * Author: Copyright (c) 2004-2006 Tom Charlesworth
+ * Author: Copyright (c) 2004-2015 Tom Charlesworth
  */
 
 #include "StdAfx.h"
+
+#include "SaveState_Structs_v1.h"
+#include "SaveState_Structs_v2.h"
 
 #include "AppleWin.h"
 #include "CPU.h"
@@ -36,9 +39,14 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "Keyboard.h"
 #include "Memory.h"
 #include "Mockingboard.h"
+#include "MouseInterface.h"
+#include "ParallelPrinter.h"
 #include "SerialComms.h"
 #include "Speaker.h"
 #include "Video.h"
+
+#include "Configuration\Config.h"
+#include "Configuration\IPropertySheet.h"
 
 
 #define DEFAULT_SNAPSHOT_NAME "SaveState.aws"
@@ -93,22 +101,27 @@ const char* Snapshot_GetPath()
 
 //-----------------------------------------------------------------------------
 
-void Snapshot_LoadState()
+static void Snapshot_LoadState_v1()	// .aws v1.0.0.1, up to (and including) AppleWin v1.25.0
 {
-	char szMessage[32 + MAX_PATH];
-	std::string strOldImageDir;
+	std::string strOldImageDir(g_sCurrentDir);
 
-	APPLEWIN_SNAPSHOT* pSS = (APPLEWIN_SNAPSHOT*) new char[sizeof(APPLEWIN_SNAPSHOT)];
+	APPLEWIN_SNAPSHOT_v1* pSS = (APPLEWIN_SNAPSHOT_v1*) new char[sizeof(APPLEWIN_SNAPSHOT_v1)];	// throw's bad_alloc
 
 	try
 	{
-		strOldImageDir = g_sCurrentDir;
+#if _MSC_VER >= 1600	// static_assert supported from VS2010 (cl.exe v16.00)
+		static_assert(kSnapshotSize_v1 == sizeof(APPLEWIN_SNAPSHOT_v1), "Save-state v1 struct size mismatch");
+#else
+		// A compile error here means sizeof(APPLEWIN_SNAPSHOT_v1) is wrong, eg. one of the constituent structs has been modified
+		typedef char VerifySizesAreEqual[kSnapshotSize_v1 == sizeof(APPLEWIN_SNAPSHOT_v1) ? 1 : -1];
+#endif
+
+		if (kSnapshotSize_v1 != sizeof(APPLEWIN_SNAPSHOT_v1))
+			throw std::string("Save-state v1 struct size mismatch");
+
 		SetCurrentImageDir(g_strSaveStatePath.c_str());	// Allow .dsk's load without prompting
 
-		if(pSS == NULL)
-			throw(0);
-
-		memset(pSS, 0, sizeof(APPLEWIN_SNAPSHOT));
+		memset(pSS, 0, sizeof(APPLEWIN_SNAPSHOT_v1));
 
 		//
 
@@ -121,39 +134,26 @@ void Snapshot_LoadState()
 									NULL);
 
 		if(hFile == INVALID_HANDLE_VALUE)
-		{
-			strcpy(szMessage, "File not found: ");
-			strcpy(szMessage + strlen(szMessage), g_strSaveStatePathname.c_str());
-			throw(0);
-		}
+			throw std::string("File not found: ") + g_strSaveStatePathname;
 
 		DWORD dwBytesRead;
 		BOOL bRes = ReadFile(	hFile,
 								pSS,
-								sizeof(APPLEWIN_SNAPSHOT),
+								sizeof(APPLEWIN_SNAPSHOT_v1),
 								&dwBytesRead,
 								NULL);
 
 		CloseHandle(hFile);
 
-		if(!bRes || (dwBytesRead != sizeof(APPLEWIN_SNAPSHOT)))
-		{
+		if(!bRes || (dwBytesRead != sizeof(APPLEWIN_SNAPSHOT_v1)))
 			// File size wrong: probably because of version mismatch or corrupt file
-			strcpy(szMessage, "File size mismatch");
-			throw(0);
-		}
+			throw std::string("File size mismatch");
 
 		if(pSS->Hdr.dwTag != AW_SS_TAG)
-		{
-			strcpy(szMessage, "File corrupt");
-			throw(0);
-		}
+			throw std::string("File corrupt");
 
 		if(pSS->Hdr.dwVersion != MAKE_VERSION(1,0,0,1))
-		{
-			strcpy(szMessage, "Version mismatch");
-			throw(0);
-		}
+			throw std::string("Version mismatch");
 
 		// TO DO: Verify checksum
 
@@ -173,34 +173,40 @@ void Snapshot_LoadState()
 		// Apple2 unit
 		//
 
-		CpuSetSnapshot(&pSS->Apple2Unit.CPU6502);
-		sg_SSC.CommSetSnapshot(&pSS->Apple2Unit.Comms);
-		JoySetSnapshot(&pSS->Apple2Unit.Joystick);
-		KeybSetSnapshot(&pSS->Apple2Unit.Keyboard);
-		SpkrSetSnapshot(&pSS->Apple2Unit.Speaker);
-		VideoSetSnapshot(&pSS->Apple2Unit.Video);
-		MemSetSnapshot(&pSS->Apple2Unit.Memory);
+		SS_CPU6502& CPU = pSS->Apple2Unit.CPU6502;
+		CpuSetSnapshot_v1(CPU.A, CPU.X, CPU.Y, CPU.P, CPU.S, CPU.PC, CPU.nCumulativeCycles);
+
+		SS_IO_Comms& SSC = pSS->Apple2Unit.Comms;
+		sg_SSC.SetSnapshot_v1(SSC.baudrate, SSC.bytesize, SSC.commandbyte, SSC.comminactivity, SSC.controlbyte, SSC.parity, SSC.stopbits);
+
+		JoySetSnapshot_v1(pSS->Apple2Unit.Joystick.nJoyCntrResetCycle);
+		KeybSetSnapshot_v1(pSS->Apple2Unit.Keyboard.nLastKey);
+		SpkrSetSnapshot_v1(pSS->Apple2Unit.Speaker.nSpkrLastCycle);
+		VideoSetSnapshot_v1(pSS->Apple2Unit.Video.bAltCharSet, pSS->Apple2Unit.Video.dwVidMode);
+		MemSetSnapshot_v1(pSS->Apple2Unit.Memory.dwMemMode, pSS->Apple2Unit.Memory.bLastWriteRam, pSS->Apple2Unit.Memory.nMemMain, pSS->Apple2Unit.Memory.nMemAux);
 
 		//
 
 		//
 		// Slot4: Mockingboard
-		MB_SetSnapshot(&pSS->Mockingboard1, 4);
+		MB_SetSnapshot_v1(&pSS->Mockingboard1, 4);
 
 		//
 		// Slot5: Mockingboard
-		MB_SetSnapshot(&pSS->Mockingboard2, 5);
+		MB_SetSnapshot_v1(&pSS->Mockingboard2, 5);
 
 		//
 		// Slot6: Disk][
-		DiskSetSnapshot(&pSS->Disk2, 6);
+		DiskSetSnapshot_v1(&pSS->Disk2);
 
 		SetLoadedSaveStateFlag(true);
+
+		MemUpdatePaging(TRUE);
 	}
-	catch(int)
+	catch(std::string szMessage)
 	{
 		MessageBox(	g_hFrameWindow,
-					szMessage,
+					szMessage.c_str(),
 					TEXT("Load State"),
 					MB_ICONEXCLAMATION | MB_SETFOREGROUND);
 
@@ -212,104 +218,429 @@ void Snapshot_LoadState()
 
 //-----------------------------------------------------------------------------
 
-void Snapshot_SaveState()
+HANDLE m_hFile = INVALID_HANDLE_VALUE;
+CConfigNeedingRestart m_ConfigNew;
+
+static void Snapshot_LoadState_FileHdr(SS_FILE_HDR& Hdr)
 {
-	APPLEWIN_SNAPSHOT* pSS = (APPLEWIN_SNAPSHOT*) new char[sizeof(APPLEWIN_SNAPSHOT)];
-	if(pSS == NULL)
+	try
 	{
-		// To do
+		m_hFile = CreateFile(	g_strSaveStatePathname.c_str(),
+							GENERIC_READ,
+							0,
+							NULL,
+							OPEN_EXISTING,
+							FILE_ATTRIBUTE_NORMAL,
+							NULL);
+
+		if(m_hFile == INVALID_HANDLE_VALUE)
+			throw std::string("File not found: ") + g_strSaveStatePathname;
+
+		DWORD dwBytesRead;
+		BOOL bRes = ReadFile(	m_hFile,
+								&Hdr,
+								sizeof(Hdr),
+								&dwBytesRead,
+								NULL);
+
+		if(!bRes || (dwBytesRead != sizeof(Hdr)))
+			throw std::string("File size mismatch");
+
+		if(Hdr.dwTag != AW_SS_TAG)
+			throw std::string("File corrupt");
+	}
+	catch(std::string szMessage)
+	{
+		MessageBox(	g_hFrameWindow,
+					szMessage.c_str(),
+					TEXT("Load State"),
+					MB_ICONEXCLAMATION | MB_SETFOREGROUND);
+
+		if(m_hFile == INVALID_HANDLE_VALUE)
+		{
+			CloseHandle(m_hFile);
+			m_hFile = INVALID_HANDLE_VALUE;
+		}
+	}
+}
+
+#define UNIT_APPLE2_VER 1
+#define UNIT_CARD_VER 1
+#define UNIT_CONFIG_VER 1
+
+static void LoadUnitApple2(DWORD Length, DWORD Version)
+{
+	SS_APPLE2_Unit_v2 Apple2Unit;
+
+	if (Version != UNIT_APPLE2_VER)
+		throw std::string("Apple2: Version mismatch");
+
+	if (Length != sizeof(Apple2Unit))
+		throw std::string("Apple2: Length mismatch");
+
+	if (SetFilePointer(m_hFile, -(LONG)sizeof(Apple2Unit.UnitHdr), NULL, FILE_CURRENT) == INVALID_SET_FILE_POINTER)
+		throw std::string("Apple2: file corrupt");
+
+	DWORD dwBytesRead;
+	BOOL bRes = ReadFile(	m_hFile,
+							&Apple2Unit,
+							Length,
+							&dwBytesRead,
+							NULL);
+
+	if (dwBytesRead != Length)
+		throw std::string("Apple2: file corrupt");
+
+	g_Apple2Type = (eApple2Type) Apple2Unit.Apple2Type;
+	m_ConfigNew.m_Apple2Type = g_Apple2Type;
+
+	CpuSetSnapshot(Apple2Unit.CPU6502);
+	JoySetSnapshot(Apple2Unit.Joystick.JoyCntrResetCycle);
+	KeybSetSnapshot(Apple2Unit.Keyboard.LastKey);
+	SpkrSetSnapshot(Apple2Unit.Speaker.SpkrLastCycle);
+	VideoSetSnapshot(Apple2Unit.Video);
+	MemSetSnapshot(Apple2Unit.Memory);
+}
+
+//===
+
+static void LoadCardDisk2(void)
+{
+	DiskSetSnapshot(m_hFile);
+}
+
+static void LoadCardMockingboardC(void)
+{
+	MB_SetSnapshot(m_hFile);
+}
+
+static void LoadCardMouseInterface(void)
+{
+	sg_Mouse.SetSnapshot(m_hFile);
+}
+
+static void LoadCardSSC(void)
+{
+	sg_SSC.SetSnapshot(m_hFile);
+}
+
+static void LoadCardPrinter(void)
+{
+	Printer_SetSnapshot(m_hFile);
+}
+
+static void LoadCardHDD(void)
+{
+	HD_SetSnapshot(m_hFile, g_strSaveStatePath);
+	m_ConfigNew.m_bEnableHDD = true;
+}
+
+//===
+
+static void LoadUnitCard(DWORD Length, DWORD Version)
+{
+	SS_CARD_HDR Card;
+
+	if (Version != UNIT_APPLE2_VER)
+		throw std::string("Card: Version mismatch");
+
+	if (Length < sizeof(Card))
+		throw std::string("Card: file corrupt");
+
+	if (SetFilePointer(m_hFile, -(LONG)sizeof(Card.UnitHdr), NULL, FILE_CURRENT) == INVALID_SET_FILE_POINTER)
+		throw std::string("Card: file corrupt");
+
+	DWORD dwBytesRead;
+	BOOL bRes = ReadFile(	m_hFile,
+							&Card,
+							sizeof(Card),
+							&dwBytesRead,
+							NULL);
+
+	if (dwBytesRead != sizeof(Card))
+		throw std::string("Card: file corrupt");
+
+	//currently cards are changed by restarting machine (ie. all slot empty) then adding cards (most of which are hardcoded to specific slots)
+
+	if (SetFilePointer(m_hFile, -(LONG)sizeof(SS_CARD_HDR), NULL, FILE_CURRENT) == INVALID_SET_FILE_POINTER)
+		throw std::string("Card: file corrupt");
+
+	bool bIsCardSupported = true;
+
+	switch(Card.Type)
+	{
+	case CT_Empty:
+		throw std::string("Card: todo");
+		break;
+	case CT_Disk2:
+		LoadCardDisk2();
+		break;
+	case CT_SSC:
+		LoadCardSSC();
+		break;
+	case CT_MockingboardC:
+		LoadCardMockingboardC();
+		break;
+	case CT_GenericPrinter:
+		LoadCardPrinter();
+		break;
+	case CT_GenericHDD:
+		LoadCardHDD();
+		break;
+	case CT_MouseInterface:
+		LoadCardMouseInterface();
+		break;
+	case CT_Z80:
+		throw std::string("Card: todo");
+		break;
+	case CT_Phasor:
+		throw std::string("Card: todo");
+		break;
+	default:
+		//throw std::string("Card: unsupported");
+		bIsCardSupported = false;
+		if (SetFilePointer(m_hFile, Card.UnitHdr.hdr.v2.Length, NULL, FILE_CURRENT) == INVALID_SET_FILE_POINTER)
+			throw std::string("Card: failed to skip unsupported card");
+	}
+
+	if (bIsCardSupported)
+		m_ConfigNew.m_Slot[Card.Slot] = (SS_CARDTYPE) Card.Type;
+}
+
+static void LoadUnitConfig(DWORD Length, DWORD Version)
+{
+	SS_APPLEWIN_CONFIG Cfg;
+
+	if (Version != UNIT_CONFIG_VER)
+		throw std::string("Config: Version mismatch");
+
+	if (Length != sizeof(Cfg))
+		throw std::string("Config: Length mismatch");
+
+	if (SetFilePointer(m_hFile, -(LONG)sizeof(Cfg.UnitHdr), NULL, FILE_CURRENT) == INVALID_SET_FILE_POINTER)
+		throw std::string("Config: file corrupt");
+
+	DWORD dwBytesRead;
+	BOOL bRes = ReadFile(	m_hFile,
+							&Cfg,
+							Length,
+							&dwBytesRead,
+							NULL);
+
+	if (dwBytesRead != Length)
+		throw std::string("Config: file corrupt");
+
+	// todo:
+	//m_ConfigNew.m_bEnhanceDisk;
+	//m_ConfigNew.m_bEnableHDD;
+}
+
+static void Snapshot_LoadState_v2(DWORD dwVersion)
+{
+	try
+	{
+		if (dwVersion != MAKE_VERSION(2,0,0,0))
+			throw std::string("Version mismatch");
+
+		CConfigNeedingRestart ConfigOld;
+		ConfigOld.m_Slot[1] = CT_GenericPrinter;	// fixme
+		ConfigOld.m_Slot[2] = CT_SSC;				// fixme
+		ConfigOld.m_Slot[6] = CT_Disk2;				// fixme
+		ConfigOld.m_Slot[7] = ConfigOld.m_bEnableHDD ? CT_GenericHDD : CT_Empty;	// fixme
+
+		for (UINT i=0; i<NUM_SLOTS; i++)
+			m_ConfigNew.m_Slot[i] = CT_Empty;
+
+		MemReset();
+
+		if (!IS_APPLE2)
+			MemResetPaging();
+
+		DiskReset();
+		KeybReset();
+		VideoResetState();
+		MB_Reset();
+		sg_Mouse.Uninitialize();
+		sg_Mouse.Reset();
+		HD_SetEnabled(false);
+
+		while(1)
+		{
+			SS_UNIT_HDR UnitHdr;
+			DWORD dwBytesRead;
+			BOOL bRes = ReadFile(	m_hFile,
+									&UnitHdr,
+									sizeof(UnitHdr),
+									&dwBytesRead,
+									NULL);
+
+			if (dwBytesRead == 0)
+				break;	// EOF (OK)
+
+			if(!bRes || (dwBytesRead != sizeof(UnitHdr)))
+				throw std::string("File size mismatch");
+
+			switch (UnitHdr.hdr.v2.Type)
+			{
+			case UT_Apple2:
+				LoadUnitApple2(UnitHdr.hdr.v2.Length, UnitHdr.hdr.v2.Version);
+				break;
+			case UT_Card:
+				LoadUnitCard(UnitHdr.hdr.v2.Length, UnitHdr.hdr.v2.Version);
+				break;
+			case UT_Config:
+				LoadUnitConfig(UnitHdr.hdr.v2.Length, UnitHdr.hdr.v2.Version);
+				break;
+			default:
+				// Log then skip unsupported unit type
+				break;
+			}
+		}
+
+		SetLoadedSaveStateFlag(true);
+
+		// NB. The following disparity should be resolved:
+		// . A change in h/w via the Configuration property sheets results in a the VM completely restarting (via WM_USER_RESTART)
+		// . A change in h/w via loading a save-state avoids this VM restart
+		// The latter is the desired approach (as the former needs a "power-on" / F2 to start things again)
+
+		sg_PropertySheet.ApplyNewConfig(m_ConfigNew, ConfigOld);
+
+		MemInitializeROM();
+		MemInitializeCustomF8ROM();
+		MemInitializeIO();
+
+		MemUpdatePaging(TRUE);
+
+		//PostMessage(g_hFrameWindow, WM_USER_RESTART, 0, 0);	// No, as this power-cycles VM (undoing all the new state just loaded)
+	}
+	catch(std::string szMessage)
+	{
+		MessageBox(	g_hFrameWindow,
+					szMessage.c_str(),
+					TEXT("Load State"),
+					MB_ICONEXCLAMATION | MB_SETFOREGROUND);
+	}
+
+	CloseHandle(m_hFile);
+	m_hFile = INVALID_HANDLE_VALUE;
+}
+
+void Snapshot_LoadState()
+{
+	SS_FILE_HDR Hdr;
+	Snapshot_LoadState_FileHdr(Hdr);
+
+	if (m_hFile == INVALID_HANDLE_VALUE)
+		return;
+
+	if(Hdr.dwVersion <= MAKE_VERSION(1,0,0,1))
+	{
+		CloseHandle(m_hFile);
+		m_hFile = INVALID_HANDLE_VALUE;
+
+		Snapshot_LoadState_v1();
 		return;
 	}
 
-	memset(pSS, 0, sizeof(APPLEWIN_SNAPSHOT));
+	Snapshot_LoadState_v2(Hdr.dwVersion);
+}
 
-	pSS->Hdr.dwTag = AW_SS_TAG;
-	pSS->Hdr.dwVersion = MAKE_VERSION(1,0,0,1);
-	pSS->Hdr.dwChecksum = 0;	// TO DO
+//-----------------------------------------------------------------------------
 
-	//
-	// Apple2 unit
-	//
-
-	pSS->Apple2Unit.UnitHdr.dwLength = sizeof(SS_APPLE2_Unit);
-	pSS->Apple2Unit.UnitHdr.dwVersion = MAKE_VERSION(1,0,0,0);
-
-	CpuGetSnapshot(&pSS->Apple2Unit.CPU6502);
-	sg_SSC.CommGetSnapshot(&pSS->Apple2Unit.Comms);
-	JoyGetSnapshot(&pSS->Apple2Unit.Joystick);
-	KeybGetSnapshot(&pSS->Apple2Unit.Keyboard);
-	SpkrGetSnapshot(&pSS->Apple2Unit.Speaker);
-	VideoGetSnapshot(&pSS->Apple2Unit.Video);
-	MemGetSnapshot(&pSS->Apple2Unit.Memory);
-
-	//
-	// Slot1: Empty
-	pSS->Empty1.Hdr.UnitHdr.dwLength = sizeof(SS_CARD_EMPTY);
-	pSS->Empty1.Hdr.UnitHdr.dwVersion = MAKE_VERSION(1,0,0,0);
-	pSS->Empty1.Hdr.dwSlot = 1;
-	pSS->Empty1.Hdr.dwType = CT_Empty;
-
-	//
-	// Slot2: Empty
-	pSS->Empty2.Hdr.UnitHdr.dwLength = sizeof(SS_CARD_EMPTY);
-	pSS->Empty2.Hdr.UnitHdr.dwVersion = MAKE_VERSION(1,0,0,0);
-	pSS->Empty2.Hdr.dwSlot = 2;
-	pSS->Empty2.Hdr.dwType = CT_Empty;
-
-	//
-	// Slot3: Empty
-	pSS->Empty3.Hdr.UnitHdr.dwLength = sizeof(SS_CARD_EMPTY);
-	pSS->Empty3.Hdr.UnitHdr.dwVersion = MAKE_VERSION(1,0,0,0);
-	pSS->Empty3.Hdr.dwSlot = 3;
-	pSS->Empty3.Hdr.dwType = CT_Empty;
-
-	//
-	// Slot4: Mockingboard
-	MB_GetSnapshot(&pSS->Mockingboard1, 4);
-
-	//
-	// Slot5: Mockingboard
-	MB_GetSnapshot(&pSS->Mockingboard2, 5);
-
-	//
-	// Slot6: Disk][
-	DiskGetSnapshot(&pSS->Disk2, 6);
-
-	//
-
-	HANDLE hFile = CreateFile(	g_strSaveStatePathname.c_str(),
-								GENERIC_WRITE,
-								0,
-								NULL,
-								CREATE_ALWAYS,
-								FILE_ATTRIBUTE_NORMAL,
-								NULL);
-
-	DWORD dwError = GetLastError();
-	_ASSERT((dwError == 0) || (dwError == ERROR_ALREADY_EXISTS));
-
-	if(hFile != INVALID_HANDLE_VALUE)
+void Snapshot_SaveState()
+{
+	try
 	{
+		// todo: append '.aws' if missing
+
+		m_hFile = CreateFile(	g_strSaveStatePathname.c_str(),
+									GENERIC_WRITE,
+									0,
+									NULL,
+									CREATE_ALWAYS,
+									FILE_ATTRIBUTE_NORMAL,
+									NULL);
+
+		DWORD dwError = GetLastError();
+		_ASSERT((dwError == 0) || (dwError == ERROR_ALREADY_EXISTS));
+
+		// todo: handle ERROR_ALREADY_EXISTS - ask if user wants to replace existing file
+
+		if(m_hFile == INVALID_HANDLE_VALUE)
+		{
+			//dwError = GetLastError();
+			throw std::string("Save error");
+		}
+
+		//
+
+		APPLEWIN_SNAPSHOT_v2 AppleSnapshotv2;
+
+		AppleSnapshotv2.Hdr.dwTag = AW_SS_TAG;
+		AppleSnapshotv2.Hdr.dwVersion = MAKE_VERSION(2,0,0,0);
+		AppleSnapshotv2.Hdr.dwChecksum = 0;	// TO DO
+
+		SS_APPLE2_Unit_v2& Apple2Unit = AppleSnapshotv2.Apple2Unit;
+
+		//
+		// Apple2 unit
+		//
+
+		Apple2Unit.UnitHdr.hdr.v2.Length = sizeof(SS_APPLE2_Unit_v2);
+		Apple2Unit.UnitHdr.hdr.v2.Type = UT_Apple2;
+		Apple2Unit.UnitHdr.hdr.v2.Version = UNIT_APPLE2_VER;
+
+		Apple2Unit.Apple2Type = g_Apple2Type;
+
+		CpuGetSnapshot(Apple2Unit.CPU6502);
+		JoyGetSnapshot(Apple2Unit.Joystick.JoyCntrResetCycle);
+		KeybGetSnapshot(Apple2Unit.Keyboard.LastKey);
+		SpkrGetSnapshot(Apple2Unit.Speaker.SpkrLastCycle);
+		VideoGetSnapshot(Apple2Unit.Video);
+		MemGetSnapshot(Apple2Unit.Memory);
+
 		DWORD dwBytesWritten;
-		BOOL bRes = WriteFile(	hFile,
-								pSS,
-								sizeof(APPLEWIN_SNAPSHOT),
+		BOOL bRes = WriteFile(	m_hFile,
+								&AppleSnapshotv2,
+								sizeof(APPLEWIN_SNAPSHOT_v2),
 								&dwBytesWritten,
 								NULL);
 
-		if(!bRes || (dwBytesWritten != sizeof(APPLEWIN_SNAPSHOT)))
-			dwError = GetLastError();
+		if(!bRes || (dwBytesWritten != sizeof(APPLEWIN_SNAPSHOT_v2)))
+		{
+			//dwError = GetLastError();
+			throw std::string("Save error");
+		}
 
-		CloseHandle(hFile);
+		//
+
+		Printer_GetSnapshot(m_hFile);
+
+		sg_SSC.GetSnapshot(m_hFile);
+
+		sg_Mouse.GetSnapshot(m_hFile);
+
+		if (g_Slot4 == CT_MockingboardC)
+			MB_GetSnapshot(m_hFile, 4);
+
+		if (g_Slot5 == CT_MockingboardC)
+			MB_GetSnapshot(m_hFile, 5);
+
+		DiskGetSnapshot(m_hFile);
+
+		HD_GetSnapshot(m_hFile);
 	}
-	else
+	catch(std::string szMessage)
 	{
-		dwError = GetLastError();
+		MessageBox(	g_hFrameWindow,
+					szMessage.c_str(),
+					TEXT("Save State"),
+					MB_ICONEXCLAMATION | MB_SETFOREGROUND);
 	}
 
-	_ASSERT((dwError == 0) || (dwError == ERROR_ALREADY_EXISTS));
-
-	delete [] pSS;
+	CloseHandle(m_hFile);
+	m_hFile = INVALID_HANDLE_VALUE;
 }
 
 //-----------------------------------------------------------------------------

--- a/source/SaveState.cpp
+++ b/source/SaveState.cpp
@@ -428,6 +428,12 @@ static void LoadUnitCard(DWORD Length, DWORD Version)
 	}
 }
 
+// Todo:
+// . Should this newly loaded config state be persisted to the Registry?
+//   - NB. it will get saved if the user opens the Config dialog + makes a change. Is this confusing to the user?
+// Notes:
+// . WindowScale - don't think this needs restoring (eg. like FullScreen)
+
 static void LoadUnitConfig(DWORD Length, DWORD Version)
 {
 	SS_APPLEWIN_CONFIG Config;
@@ -458,7 +464,7 @@ static void LoadUnitConfig(DWORD Length, DWORD Version)
 	g_uHalfScanLines = Config.Cfg.IsHalfScanLines;
 	g_bConfirmReboot = Config.Cfg.IsConfirmReboot;
 	monochrome = Config.Cfg.MonochromeColor;
-	SetViewportScale(Config.Cfg.WindowScale);
+	//Config.Cfg.WindowScale		// NB. Just calling SetViewportScale() is no good. Use PostMessage() instead.
 
 	g_dwSpeed = Config.Cfg.CpuSpeed;
 	SetCurrentCLK6502();
@@ -603,8 +609,10 @@ void Snapshot_LoadState()
 
 //-----------------------------------------------------------------------------
 
-// todo:
-// . "Uthernet Active"
+// Todo:
+// . "Uthernet Active" - save this in slot3 card's state?
+// Notes:
+// . Full Screen - don't think this needs save/restoring
 
 static void SaveUnitConfig()
 {

--- a/source/SaveState_Structs_common.h
+++ b/source/SaveState_Structs_common.h
@@ -73,6 +73,7 @@ enum SS_CARDTYPE
 	CT_80Col,			// 80 column card (no memory)
 	CT_Extended80Col,	// Extended 80-col card (64K)
 	CT_RamWorksIII,		// RamWorksIII (up to 8MB)
+	CT_Uthernet,
 };
 
 /////////////////////////////////////////////////////////////////////////////////

--- a/source/SaveState_Structs_common.h
+++ b/source/SaveState_Structs_common.h
@@ -1,0 +1,77 @@
+#pragma once
+
+// Structs used by save-state file
+
+// *** DON'T CHANGE ANY STRUCT WITHOUT CONSIDERING BACKWARDS COMPATIBILITY WITH .AWS FORMAT ***
+
+/////////////////////////////////////////////////////////////////////////////////
+
+#define MAKE_VERSION(a,b,c,d) ((a<<24) | (b<<16) | (c<<8) | (d))
+
+#define AW_SS_TAG 'SSWA'	// 'AWSS' = AppleWin SnapShot
+
+struct SS_FILE_HDR
+{
+	DWORD dwTag;		// "AWSS"
+	DWORD dwVersion;
+	DWORD dwChecksum;
+};
+
+struct SS_UNIT_HDR
+{
+	union
+	{
+		struct
+		{
+			DWORD dwLength;		// Byte length of this unit struct
+			DWORD dwVersion;
+		} v1;
+		struct
+		{
+			DWORD Length;		// Byte length of this unit struct
+			WORD Type;			// SS_UNIT_TYPE
+			WORD Version;		// Incrementing value from 1
+		} v2;
+	} hdr;
+};
+
+enum SS_UNIT_TYPE
+{
+	UT_Reserved = 0,
+	UT_Apple2,
+	UT_Card,
+	UT_Config,
+};
+
+const UINT nMemMainSize = 64*1024;
+const UINT nMemAuxSize = 64*1024;
+
+struct SS_CARD_HDR
+{
+	SS_UNIT_HDR UnitHdr;
+	DWORD Type;			// SS_CARDTYPE
+	DWORD Slot;			// [1..7], 0=Language card, 8=Aux
+};
+
+enum SS_CARDTYPE
+{
+	CT_Empty = 0,
+	CT_Disk2,			// Apple Disk][
+	CT_SSC,				// Apple Super Serial Card
+	CT_MockingboardC,	// Soundcard
+	CT_GenericPrinter,
+	CT_GenericHDD,		// Hard disk
+	CT_GenericClock,
+	CT_MouseInterface,
+	CT_Z80,
+	CT_Phasor,			// Soundcard
+	CT_Echo,			// Soundcard
+	CT_SAM,				// Soundcard: Software Automated Mouth
+};
+
+/////////////////////////////////////////////////////////////////////////////////
+
+struct SS_CARD_EMPTY
+{
+	SS_CARD_HDR	Hdr;
+};

--- a/source/SaveState_Structs_common.h
+++ b/source/SaveState_Structs_common.h
@@ -46,6 +46,9 @@ enum SS_UNIT_TYPE
 const UINT nMemMainSize = 64*1024;
 const UINT nMemAuxSize = 64*1024;
 
+const UINT kSLOT_LANG = 0;
+const UINT kSLOT_AUX = 8;
+
 struct SS_CARD_HDR
 {
 	SS_UNIT_HDR UnitHdr;
@@ -67,6 +70,9 @@ enum SS_CARDTYPE
 	CT_Phasor,			// Soundcard
 	CT_Echo,			// Soundcard
 	CT_SAM,				// Soundcard: Software Automated Mouth
+	CT_80Col,			// 80 column card (no memory)
+	CT_Extended80Col,	// Extended 80-col card (64K)
+	CT_RamWorksIII,		// RamWorksIII (up to 8MB)
 };
 
 /////////////////////////////////////////////////////////////////////////////////
@@ -74,4 +80,56 @@ enum SS_CARDTYPE
 struct SS_CARD_EMPTY
 {
 	SS_CARD_HDR	Hdr;
+};
+
+/////////////////////////////////////////////////////////////////////////////////
+
+struct IWORD
+{
+	union
+	{
+		struct
+		{
+			BYTE l;
+			BYTE h;
+		};
+		USHORT w;
+	};
+};
+
+struct SY6522
+{
+	BYTE ORB;				// $00 - Port B
+	BYTE ORA;				// $01 - Port A (with handshaking)
+	BYTE DDRB;				// $02 - Data Direction Register B
+	BYTE DDRA;				// $03 - Data Direction Register A
+	//
+	// $04 - Read counter (L) / Write latch (L)
+	// $05 - Read / Write & initiate count (H)
+	// $06 - Read / Write & latch (L)
+	// $07 - Read / Write & latch (H)
+	// $08 - Read counter (L) / Write latch (L)
+	// $09 - Read counter (H) / Write latch (H)
+	IWORD TIMER1_COUNTER;
+	IWORD TIMER1_LATCH;
+	IWORD TIMER2_COUNTER;
+	IWORD TIMER2_LATCH;
+	//
+	BYTE SERIAL_SHIFT;		// $0A
+	BYTE ACR;				// $0B - Auxiliary Control Register
+	BYTE PCR;				// $0C - Peripheral Control Register
+	BYTE IFR;				// $0D - Interrupt Flag Register
+	BYTE IER;				// $0E - Interrupt Enable Register
+	BYTE ORA_NO_HS;			// $0F - Port A (without handshaking)
+};
+
+struct SSI263A
+{
+	BYTE DurationPhonome;
+	BYTE Inflection;		// I10..I3
+	BYTE RateInflection;
+	BYTE CtrlArtAmp;
+	BYTE FilterFreq;
+	//
+	BYTE CurrentMode;		// b7:6=Mode; b0=D7 pin (for IRQ)
 };

--- a/source/SaveState_Structs_v1.h
+++ b/source/SaveState_Structs_v1.h
@@ -110,57 +110,7 @@ struct SS_CARD_DISK2
 
 /////////////////////////////////////////////////////////////////////////////////
 
-struct IWORD
-{
-	union
-	{
-		struct
-		{
-			BYTE l;
-			BYTE h;
-		};
-		USHORT w;
-	};
-};
-
-struct SY6522
-{
-	BYTE ORB;				// $00 - Port B
-	BYTE ORA;				// $01 - Port A (with handshaking)
-	BYTE DDRB;				// $02 - Data Direction Register B
-	BYTE DDRA;				// $03 - Data Direction Register A
-	//
-	// $04 - Read counter (L) / Write latch (L)
-	// $05 - Read / Write & initiate count (H)
-	// $06 - Read / Write & latch (L)
-	// $07 - Read / Write & latch (H)
-	// $08 - Read counter (L) / Write latch (L)
-	// $09 - Read counter (H) / Write latch (H)
-	IWORD TIMER1_COUNTER;
-	IWORD TIMER1_LATCH;
-	IWORD TIMER2_COUNTER;
-	IWORD TIMER2_LATCH;
-	//
-	BYTE SERIAL_SHIFT;		// $0A
-	BYTE ACR;				// $0B - Auxiliary Control Register
-	BYTE PCR;				// $0C - Peripheral Control Register
-	BYTE IFR;				// $0D - Interrupt Flag Register
-	BYTE IER;				// $0E - Interrupt Enable Register
-	BYTE ORA_NO_HS;			// $0F - Port A (without handshaking)
-};
-
-struct SSI263A
-{
-	BYTE DurationPhonome;
-	BYTE Inflection;		// I10..I3
-	BYTE RateInflection;
-	BYTE CtrlArtAmp;
-	BYTE FilterFreq;
-	//
-	BYTE CurrentMode;		// b7:6=Mode; b0=D7 pin (for IRQ)
-};
-
-struct MB_Unit
+struct MB_Unit_v1
 {
 	SY6522		RegsSY6522;
 	BYTE		RegsAY8910[16];
@@ -171,12 +121,12 @@ struct MB_Unit
 	bool		bSpeechIrqPending;
 };
 
-const UINT MB_UNITS_PER_CARD = 2;
+const UINT MB_UNITS_PER_CARD_v1 = 2;
 
-struct SS_CARD_MOCKINGBOARD
+struct SS_CARD_MOCKINGBOARD_v1
 {
 	SS_CARD_HDR	Hdr;
-	MB_Unit		Unit[MB_UNITS_PER_CARD];
+	MB_Unit_v1	Unit[MB_UNITS_PER_CARD_v1];
 };
 
 /////////////////////////////////////////////////////////////////////////////////
@@ -185,13 +135,13 @@ struct APPLEWIN_SNAPSHOT_v1
 {
 	SS_FILE_HDR Hdr;
 	SS_APPLE2_Unit Apple2Unit;
-	SS_CARD_EMPTY Empty1;				// Slot1
-	SS_CARD_EMPTY Empty2;				// Slot2
-	SS_CARD_EMPTY Empty3;				// Slot3
-	SS_CARD_MOCKINGBOARD Mockingboard1;	// Slot4
-	SS_CARD_MOCKINGBOARD Mockingboard2;	// Slot5
-	SS_CARD_DISK2 Disk2;				// Slot6
-	SS_CARD_EMPTY Empty7;				// Slot7
+	SS_CARD_EMPTY Empty1;					// Slot1
+	SS_CARD_EMPTY Empty2;					// Slot2
+	SS_CARD_EMPTY Empty3;					// Slot3
+	SS_CARD_MOCKINGBOARD_v1 Mockingboard1;	// Slot4
+	SS_CARD_MOCKINGBOARD_v1 Mockingboard2;	// Slot5
+	SS_CARD_DISK2 Disk2;					// Slot6
+	SS_CARD_EMPTY Empty7;					// Slot7
 };
 
-const UINT kSnapshotSize_v1 = 145400;	// Const size for v1
+const UINT kSnapshotSize_v1 = 145400;		// Const size for v1

--- a/source/SaveState_Structs_v1.h
+++ b/source/SaveState_Structs_v1.h
@@ -1,34 +1,15 @@
 #pragma once
 
 #include "DiskDefs.h"
+#include "SaveState_Structs_common.h"
 
-// Structs used by save-state file
+// Structs used by save-state file v1
 
 // *** DON'T CHANGE ANY STRUCT WITHOUT CONSIDERING BACKWARDS COMPATIBILITY WITH .AWS FORMAT ***
 
-#define MAKE_VERSION(a,b,c,d) ((a<<24) | (b<<16) | (c<<8) | (d))
-
-#define AW_SS_TAG 'SSWA'	// 'AWSS' = AppleWin SnapShot
-
-typedef struct
-{
-	DWORD dwTag;		// "AWSS"
-	DWORD dwVersion;
-	DWORD dwChecksum;
-} SS_FILE_HDR;
-
-typedef struct
-{
-	DWORD dwLength;		// Byte length of this unit struct
-	DWORD dwVersion;
-} SS_UNIT_HDR;
-
 /////////////////////////////////////////////////////////////////////////////////
 
-const UINT nMemMainSize = 64*1024;
-const UINT nMemAuxSize = 64*1024;
-
-typedef struct
+struct SS_CPU6502
 {
 	BYTE A;
 	BYTE X;
@@ -36,13 +17,13 @@ typedef struct
 	BYTE P;
 	BYTE S;
 	USHORT PC;
-	unsigned __int64 g_nCumulativeCycles;
+	unsigned __int64 nCumulativeCycles;
 	// IRQ = OR-sum of all interrupt sources
-} SS_CPU6502;
+};
 
 const UINT uRecvBufferSize = 9;
 
-typedef struct
+struct SS_IO_Comms
 {
 	DWORD  baudrate;
 	BYTE   bytesize;
@@ -53,121 +34,53 @@ typedef struct
 	BYTE   recvbuffer[uRecvBufferSize];
 	DWORD  recvbytes;
 	BYTE   stopbits;
-} SS_IO_Comms;
+};
 
-typedef struct
+struct SS_IO_Joystick
 {
-	unsigned __int64 g_nJoyCntrResetCycle;
-} SS_IO_Joystick;
+	unsigned __int64 nJoyCntrResetCycle;
+};
 
-typedef struct
+struct SS_IO_Keyboard
 {
 	DWORD keyboardqueries;
 	BYTE nLastKey;
-} SS_IO_Keyboard;
+};
 
-//typedef struct
-//{
-//} SS_IO_Memory;
-
-typedef struct
+struct SS_IO_Speaker
 {
-	unsigned __int64 g_nSpkrLastCycle;
-} SS_IO_Speaker;
+	unsigned __int64 nSpkrLastCycle;
+};
 
-typedef struct
+struct SS_IO_Video
 {
 	bool bAltCharSet;	// charoffs
 	DWORD dwVidMode;
-} SS_IO_Video;
+};
 
-typedef struct
+struct SS_BaseMemory
 {
 	DWORD dwMemMode;
 	BOOL bLastWriteRam;
 	BYTE nMemMain[nMemMainSize];
 	BYTE nMemAux[nMemAuxSize];
-} SS_BaseMemory;
+};
 
-typedef struct
+struct SS_APPLE2_Unit
 {
 	SS_UNIT_HDR UnitHdr;
 	SS_CPU6502 CPU6502;
 	SS_IO_Comms Comms;
 	SS_IO_Joystick Joystick;
 	SS_IO_Keyboard Keyboard;
-//	SS_IO_Memory Memory;
 	SS_IO_Speaker Speaker;
 	SS_IO_Video Video;
 	SS_BaseMemory Memory;
-} SS_APPLE2_Unit;
-
-/////////////////////////////////////////////////////////////////////////////////
-
-typedef struct
-{
-	DWORD dwComputerEmulation;
-	bool bCustomSpeed;
-	DWORD dwEmulationSpeed;
-	bool bEnhancedDiskSpeed;
-	DWORD dwJoystickType[2];
-	bool bMockingboardEnabled;
-	DWORD dwMonochromeColor;
-	DWORD dwSerialPort;
-	DWORD dwSoundType;	// Sound Emulation
-	DWORD dwVideoType;	// Video Emulation
-} SS_AW_CFG;
-
-typedef struct
-{
-	char StartingDir[MAX_PATH];
-	DWORD dwWindowXpos;
-	DWORD dwWindowYpos;
-} SS_AW_PREFS;
-
-typedef struct
-{
-	SS_UNIT_HDR UnitHdr;
-	DWORD dwAppleWinVersion;
-	SS_AW_PREFS Prefs;
-	SS_AW_CFG Cfg;
-} SS_APPLEWIN_CONFIG;
-
-/////////////////////////////////////////////////////////////////////////////////
-
-typedef struct
-{
-	SS_UNIT_HDR UnitHdr;
-	DWORD dwType;		// SS_CARDTYPE
-	DWORD dwSlot;		// [1..7]
-} SS_CARD_HDR;
-
-enum SS_CARDTYPE
-{
-	CT_Empty = 0,
-	CT_Disk2,			// Apple Disk][
-	CT_SSC,				// Apple Super Serial Card
-	CT_MockingboardC,	// Soundcard
-	CT_GenericPrinter,
-	CT_GenericHDD,		// Hard disk
-	CT_GenericClock,
-	CT_MouseInterface,
-	CT_Z80,
-	CT_Phasor,			// Soundcard
-	CT_Echo,			// Soundcard
-	CT_SAM,				// Soundcard: Software Automated Mouth
 };
 
 /////////////////////////////////////////////////////////////////////////////////
 
-typedef struct
-{
-	SS_CARD_HDR	Hdr;
-} SS_CARD_EMPTY;
-
-/////////////////////////////////////////////////////////////////////////////////
-
-typedef struct
+struct DISK2_Unit
 {
 	char	szFileName[MAX_PATH];
 	int		track;
@@ -180,9 +93,9 @@ typedef struct
 	DWORD	writelight;
 	int		nibbles;
 	BYTE	nTrack[NIBBLES_PER_TRACK];
-} DISK2_Unit;
+};
 
-typedef struct
+struct SS_CARD_DISK2
 {
 	SS_CARD_HDR	Hdr;
 	DISK2_Unit	Unit[2];
@@ -193,11 +106,11 @@ typedef struct
 	BYTE	floppylatch;
 	BOOL	floppymotoron;
 	BOOL	floppywritemode;
-} SS_CARD_DISK2;
+};
 
 /////////////////////////////////////////////////////////////////////////////////
 
-typedef struct
+struct IWORD
 {
 	union
 	{
@@ -208,9 +121,9 @@ typedef struct
 		};
 		USHORT w;
 	};
-} IWORD;
+};
 
-typedef struct
+struct SY6522
 {
 	BYTE ORB;				// $00 - Port B
 	BYTE ORA;				// $01 - Port A (with handshaking)
@@ -234,9 +147,9 @@ typedef struct
 	BYTE IFR;				// $0D - Interrupt Flag Register
 	BYTE IER;				// $0E - Interrupt Enable Register
 	BYTE ORA_NO_HS;			// $0F - Port A (without handshaking)
-} SY6522;
+};
 
-typedef struct
+struct SSI263A
 {
 	BYTE DurationPhonome;
 	BYTE Inflection;		// I10..I3
@@ -245,9 +158,9 @@ typedef struct
 	BYTE FilterFreq;
 	//
 	BYTE CurrentMode;		// b7:6=Mode; b0=D7 pin (for IRQ)
-} SSI263A;
+};
 
-typedef struct
+struct MB_Unit
 {
 	SY6522		RegsSY6522;
 	BYTE		RegsAY8910[16];
@@ -256,23 +169,22 @@ typedef struct
 	bool		bTimer1IrqPending;
 	bool		bTimer2IrqPending;
 	bool		bSpeechIrqPending;
-} MB_Unit;
+};
 
 const UINT MB_UNITS_PER_CARD = 2;
 
-typedef struct
+struct SS_CARD_MOCKINGBOARD
 {
 	SS_CARD_HDR	Hdr;
 	MB_Unit		Unit[MB_UNITS_PER_CARD];
-} SS_CARD_MOCKINGBOARD;
+};
 
 /////////////////////////////////////////////////////////////////////////////////
 
-typedef struct
+struct APPLEWIN_SNAPSHOT_v1
 {
 	SS_FILE_HDR Hdr;
 	SS_APPLE2_Unit Apple2Unit;
-//	SS_APPLEWIN_CONFIG AppleWinCfg;
 	SS_CARD_EMPTY Empty1;				// Slot1
 	SS_CARD_EMPTY Empty2;				// Slot2
 	SS_CARD_EMPTY Empty3;				// Slot3
@@ -280,6 +192,6 @@ typedef struct
 	SS_CARD_MOCKINGBOARD Mockingboard2;	// Slot5
 	SS_CARD_DISK2 Disk2;				// Slot6
 	SS_CARD_EMPTY Empty7;				// Slot7
-} APPLEWIN_SNAPSHOT;
+};
 
-/////////////////////////////////////////////////////////////////////////////////
+const UINT kSnapshotSize_v1 = 145400;	// Const size for v1

--- a/source/SaveState_Structs_v2.h
+++ b/source/SaveState_Structs_v2.h
@@ -8,6 +8,10 @@
 
 /////////////////////////////////////////////////////////////////////////////////
 
+#define UNIT_APPLE2_VER 1
+#define UNIT_CARD_VER 1
+#define UNIT_CONFIG_VER 1
+
 struct SS_CPU6502_v2
 {
 	BYTE A;

--- a/source/SaveState_Structs_v2.h
+++ b/source/SaveState_Structs_v2.h
@@ -27,6 +27,8 @@ struct SS_CPU6502_v2
 struct SS_IO_Joystick_v2
 {
 	unsigned __int64 JoyCntrResetCycle;
+	short Joystick0Trim[2];	// [x,y]
+	short Joystick1Trim[2];	// [x,y]
 };
 
 struct SS_IO_Keyboard_v2
@@ -90,27 +92,31 @@ struct APPLEWIN_SNAPSHOT_v2
 
 struct SS_AW_CFG
 {
-	UINT32 AppleWinVersion;
+	UINT16 AppleWinVersion[4];	// major,minor,fix,fix_minor
 	UINT32 VideoMode;
+	UINT32 IsHalfScanLines;
+	UINT32 IsConfirmReboot;
 	UINT32 MonochromeColor;
-	float ClockFreqMHz;
+	UINT32 WindowScale;
+	UINT32 CpuSpeed;
 	//
 	UINT32 JoystickType[2];
-	UINT32 JoystickTrim[2];
 	UINT32 IsAllowCursorsToBeRead;
 	UINT32 IsAutofire;
 	UINT32 IsKeyboardAutocentering;
 	UINT32 IsSwapButton0and1;
+	UINT32 IsScrollLockToggle;
+	UINT32 IsMouseShowCrosshair;
+	UINT32 IsMouseRestrictToWindow;
 	//
+	UINT32 SoundType;
 	UINT32 SpeakerVolume;
 	UINT32 MockingboardVolume;
 	//
 	UINT32 IsEnhancedDiskSpeed;
+	UINT32 IsSaveStateOnExit;
 	//
-	UINT32 IsEncodingConversionForClones;
-	UINT32 IsFilterUnprintableChars;
 	UINT32 IsAppendToFile;
-	UINT32 TerminatePrintingAfterIdleSecs;
 	UINT32 IsUsingFreezesF8Rom;
 };
 

--- a/source/SaveState_Structs_v2.h
+++ b/source/SaveState_Structs_v2.h
@@ -1,0 +1,114 @@
+#pragma once
+
+#include "SaveState_Structs_common.h"
+
+// Structs used by save-state file v2
+
+// *** DON'T CHANGE ANY STRUCT WITHOUT CONSIDERING BACKWARDS COMPATIBILITY WITH .AWS FORMAT ***
+
+/////////////////////////////////////////////////////////////////////////////////
+
+struct SS_CPU6502_v2
+{
+	BYTE A;
+	BYTE X;
+	BYTE Y;
+	BYTE P;
+	BYTE S;
+	USHORT PC;
+	unsigned __int64 CumulativeCycles;
+	// IRQ = OR-sum of all interrupt sources
+};
+
+struct SS_IO_Joystick_v2
+{
+	unsigned __int64 JoyCntrResetCycle;
+};
+
+struct SS_IO_Keyboard_v2
+{
+	BYTE LastKey;
+};
+
+struct SS_IO_Speaker_v2
+{
+	unsigned __int64 SpkrLastCycle;
+};
+
+struct SS_IO_Video_v2
+{
+	UINT32 AltCharSet;
+	UINT32 VideoMode;
+	UINT32 CyclesThisVideoFrame;
+};
+
+struct SS_BaseMemory_v2
+{
+	DWORD dwMemMode;
+	BOOL bLastWriteRam;
+	BYTE MemMain[nMemMainSize];
+	BYTE MemAux[nMemAuxSize];
+};
+
+struct SS_APPLE2_Unit_v2
+{
+	SS_UNIT_HDR UnitHdr;
+	UINT32 Apple2Type;
+	SS_CPU6502_v2 CPU6502;
+	SS_IO_Joystick_v2 Joystick;
+	SS_IO_Keyboard_v2 Keyboard;
+	SS_IO_Speaker_v2 Speaker;
+	SS_IO_Video_v2 Video;
+	SS_BaseMemory_v2 Memory;
+};
+
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma pack(push,4)	// push current alignment to stack & set alignment to 4
+						// - need so that 12-byte Hdr doesn't get padded to 16 bytes
+						// - NB. take care not to affect the old v2 structs
+
+struct APPLEWIN_SNAPSHOT_v2
+{
+	SS_FILE_HDR Hdr;
+	SS_APPLE2_Unit_v2 Apple2Unit;
+//	SS_CARD_EMPTY[7] Slots;				// Slot 0..7 (0=language card for Apple][)
+//	SS_CARD_EMPTY AuxSlot;				// Apple//e auxiliary slot (including optional RAMworks memory)
+//	SS_APPLEWIN_CONFIG AppleWinCfg;
+};
+
+#pragma pack(pop)
+
+/////////////////////////////////////////////////////////////////////////////////
+
+struct SS_AW_CFG
+{
+	UINT32 AppleWinVersion;
+	UINT32 VideoMode;
+	UINT32 MonochromeColor;
+	float ClockFreqMHz;
+	//
+	UINT32 JoystickType[2];
+	UINT32 JoystickTrim[2];
+	UINT32 IsAllowCursorsToBeRead;
+	UINT32 IsAutofire;
+	UINT32 IsKeyboardAutocentering;
+	UINT32 IsSwapButton0and1;
+	//
+	UINT32 SpeakerVolume;
+	UINT32 MockingboardVolume;
+	//
+	UINT32 IsEnhancedDiskSpeed;
+	//
+	UINT32 IsEncodingConversionForClones;
+	UINT32 IsFilterUnprintableChars;
+	UINT32 IsAppendToFile;
+	UINT32 TerminatePrintingAfterIdleSecs;
+	UINT32 IsUsingFreezesF8Rom;
+};
+
+struct SS_APPLEWIN_CONFIG
+{
+	SS_UNIT_HDR UnitHdr;
+	SS_AW_CFG Cfg;
+};

--- a/source/SaveState_Structs_v2.h
+++ b/source/SaveState_Structs_v2.h
@@ -46,8 +46,11 @@ struct SS_BaseMemory_v2
 {
 	DWORD dwMemMode;
 	BOOL bLastWriteRam;
+	BYTE IO_SELECT;
+	BYTE IO_SELECT_InternalROM;
+	UINT ExpansionRomType;
+	UINT PeripheralRomSlot;
 	BYTE MemMain[nMemMainSize];
-	BYTE MemAux[nMemAuxSize];
 };
 
 struct SS_APPLE2_Unit_v2
@@ -72,7 +75,7 @@ struct APPLEWIN_SNAPSHOT_v2
 {
 	SS_FILE_HDR Hdr;
 	SS_APPLE2_Unit_v2 Apple2Unit;
-//	SS_CARD_EMPTY[7] Slots;				// Slot 0..7 (0=language card for Apple][)
+//	SS_CARD_EMPTY[8] Slots;				// Slot 0..7 (0=language card for Apple][)
 //	SS_CARD_EMPTY AuxSlot;				// Apple//e auxiliary slot (including optional RAMworks memory)
 //	SS_APPLEWIN_CONFIG AppleWinCfg;
 };

--- a/source/SerialComms.cpp
+++ b/source/SerialComms.cpp
@@ -1348,11 +1348,7 @@ struct SS_CARD_SSC
 	SSC_Unit Unit;
 };
 
-// Post:
-//  0 = No card
-// >0 = Card saved OK from slot n
-// -1 = File error
-int CSuperSerialCard::GetSnapshot(const HANDLE hFile)
+void CSuperSerialCard::GetSnapshot(const HANDLE hFile)
 {
 	SS_CARD_SSC CardSuperSerial;
 
@@ -1391,11 +1387,9 @@ int CSuperSerialCard::GetSnapshot(const HANDLE hFile)
 
 	if(!bRes || (dwBytesWritten != CardSuperSerial.Hdr.UnitHdr.hdr.v2.Length))
 		throw std::string("Save error: SSC");
-
-	return m_uSlot;
 }
 
-int CSuperSerialCard::SetSnapshot(const HANDLE hFile)
+void CSuperSerialCard::SetSnapshot(const HANDLE hFile)
 {
 	SS_CARD_SSC CardSuperSerial;
 
@@ -1434,6 +1428,4 @@ int CSuperSerialCard::SetSnapshot(const HANDLE hFile)
 	m_vbTxIrqPending	= Unit.vbTxIrqPending;
 	m_vbRxIrqPending	= Unit.vbRxIrqPending;
 	m_bWrittenTx		= Unit.bWrittenTx;
-
-	return 0;
 }

--- a/source/SerialComms.cpp
+++ b/source/SerialComms.cpp
@@ -1340,6 +1340,8 @@ struct SSC_Unit
 	bool	vbRxIrqPending;
 
 	bool	bWrittenTx;
+
+	char	SerialPortName[8];
 };
 
 struct SS_CARD_SSC
@@ -1375,6 +1377,8 @@ void CSuperSerialCard::GetSnapshot(const HANDLE hFile)
 	Unit.vbTxIrqPending		= m_vbTxIrqPending;
 	Unit.vbRxIrqPending		= m_vbRxIrqPending;
 	Unit.bWrittenTx			= m_bWrittenTx;
+
+	strncpy_s(Unit.SerialPortName, sizeof(Unit.SerialPortName), GetSerialPortName(), _TRUNCATE);
 
 	//
 
@@ -1428,4 +1432,6 @@ void CSuperSerialCard::SetSnapshot(const HANDLE hFile)
 	m_vbTxIrqPending	= Unit.vbTxIrqPending;
 	m_vbRxIrqPending	= Unit.vbRxIrqPending;
 	m_bWrittenTx		= Unit.bWrittenTx;
+
+	SetSerialPortName(Unit.SerialPortName);
 }

--- a/source/SerialComms.h
+++ b/source/SerialComms.h
@@ -33,8 +33,9 @@ public:
 	void    CommDestroy();
 	void    CommSetSerialPort(HWND hWindow, DWORD dwNewSerialPortItem);
 	void    CommUpdate(DWORD);
-	DWORD   CommGetSnapshot(SS_IO_Comms* pSS);
-	DWORD   CommSetSnapshot(SS_IO_Comms* pSS);
+	void    SetSnapshot_v1(const DWORD baudrate, const BYTE bytesize, const BYTE commandbyte, const DWORD comminactivity, const BYTE controlbyte, const BYTE parity, const BYTE stopbits);
+	int     GetSnapshot(const HANDLE hFile);
+	int     SetSnapshot(const HANDLE hFile);
 
 	char*	GetSerialPortChoices();
 	DWORD	GetSerialPort() { return m_dwSerialPortItem; }	// Drop-down list item
@@ -134,4 +135,5 @@ private:
 	OVERLAPPED m_o;
 
 	BYTE* m_pExpansionRom;
+	UINT m_uSlot;
 };

--- a/source/SerialComms.h
+++ b/source/SerialComms.h
@@ -34,8 +34,8 @@ public:
 	void    CommSetSerialPort(HWND hWindow, DWORD dwNewSerialPortItem);
 	void    CommUpdate(DWORD);
 	void    SetSnapshot_v1(const DWORD baudrate, const BYTE bytesize, const BYTE commandbyte, const DWORD comminactivity, const BYTE controlbyte, const BYTE parity, const BYTE stopbits);
-	int     GetSnapshot(const HANDLE hFile);
-	int     SetSnapshot(const HANDLE hFile);
+	void    GetSnapshot(const HANDLE hFile);
+	void    SetSnapshot(const HANDLE hFile);
 
 	char*	GetSerialPortChoices();
 	DWORD	GetSerialPort() { return m_dwSerialPortItem; }	// Drop-down list item

--- a/source/Speaker.cpp
+++ b/source/Speaker.cpp
@@ -1080,14 +1080,19 @@ void Spkr_DSUninit()
 
 //=============================================================================
 
-DWORD SpkrGetSnapshot(SS_IO_Speaker* pSS)
+void SpkrSetSnapshot_v1(const unsigned __int64 SpkrLastCycle)
 {
-	pSS->g_nSpkrLastCycle = g_nSpkrLastCycle;
-	return 0;
+	g_nSpkrLastCycle = SpkrLastCycle;
 }
 
-DWORD SpkrSetSnapshot(SS_IO_Speaker* pSS)
+//
+
+void SpkrGetSnapshot(unsigned __int64& rSpkrLastCycle)
 {
-	g_nSpkrLastCycle = pSS->g_nSpkrLastCycle;
-	return 0;
+	rSpkrLastCycle = g_nSpkrLastCycle;
+}
+
+void SpkrSetSnapshot(const unsigned __int64 SpkrLastCycle)
+{
+	g_nSpkrLastCycle = SpkrLastCycle;
 }

--- a/source/Speaker.h
+++ b/source/Speaker.h
@@ -19,7 +19,8 @@ void    Spkr_Demute();
 bool    Spkr_IsActive();
 bool    Spkr_DSInit();
 void    Spkr_DSUninit();
-DWORD   SpkrGetSnapshot(SS_IO_Speaker* pSS);
-DWORD   SpkrSetSnapshot(SS_IO_Speaker* pSS);
+void    SpkrSetSnapshot_v1(const unsigned __int64 SpkrLastCycle);
+void    SpkrGetSnapshot(unsigned __int64& rSpkrLastCycle);
+void    SpkrSetSnapshot(const unsigned __int64 SpkrLastCycle);
 
 BYTE __stdcall SpkrToggle (WORD pc, WORD addr, BYTE bWrite, BYTE d, ULONG nCyclesLeft);

--- a/source/StdAfx.h
+++ b/source/StdAfx.h
@@ -23,7 +23,6 @@
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <time.h>
 
 #include <windows.h>
@@ -36,6 +35,7 @@
 #include <algorithm>
 #include <map>
 #include <queue>
+#include <string>
 #include <vector>
 
 // SM_CXPADDEDBORDER is not supported on 2000 & XP:

--- a/source/Tape.cpp
+++ b/source/Tape.cpp
@@ -33,6 +33,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "AppleWin.h"
 #include "Keyboard.h"
 #include "Memory.h"
+#include "Pravets.h"
 
 static bool g_CapsLockAllowed = false;
 

--- a/source/Video.cpp
+++ b/source/Video.cpp
@@ -39,6 +39,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "..\resource\resource.h"
 #include "Configuration\PropertySheet.h"
 #include "Debugger\Debugger_Color.h"	// For NUM_DEBUG_COLORS
+#include "SaveState_Structs_v2.h"
 
 #define HALF_PIXEL_SOLID 1
 #define HALF_PIXEL_BLEED 0
@@ -2941,20 +2942,26 @@ void VideoSetForceFullRedraw(void)
 
 //===========================================================================
 
-DWORD VideoGetSnapshot(SS_IO_Video* pSS)
+void VideoSetSnapshot_v1(const UINT AltCharSet, const UINT VideoMode)
 {
-	pSS->bAltCharSet = !(g_nAltCharSetOffset == 0);
-	pSS->dwVidMode = g_uVideoMode;
-	return 0;
+	g_nAltCharSetOffset = !AltCharSet ? 0 : 256;
+	g_uVideoMode = VideoMode;
 }
 
-//===========================================================================
+//
 
-DWORD VideoSetSnapshot(SS_IO_Video* pSS)
+void VideoGetSnapshot(SS_IO_Video_v2& Video)
 {
-	g_nAltCharSetOffset = !pSS->bAltCharSet ? 0 : 256;
-	g_uVideoMode = pSS->dwVidMode;
-	return 0;
+	Video.AltCharSet = !(g_nAltCharSetOffset == 0);
+	Video.VideoMode = g_uVideoMode;
+	Video.CyclesThisVideoFrame = g_dwCyclesThisFrame;
+}
+
+void VideoSetSnapshot(const SS_IO_Video_v2& Video)
+{
+	g_nAltCharSetOffset = !Video.AltCharSet ? 0 : 256;
+	g_uVideoMode = Video.VideoMode;
+	g_dwCyclesThisFrame = Video.CyclesThisVideoFrame;
 }
 
 //===========================================================================

--- a/source/Video.h
+++ b/source/Video.h
@@ -85,8 +85,9 @@ bool    VideoGetSWAltCharSet(void);
 
 void    VideoSetForceFullRedraw(void);
 
-DWORD   VideoGetSnapshot(SS_IO_Video* pSS);
-DWORD   VideoSetSnapshot(SS_IO_Video* pSS);
+void    VideoSetSnapshot_v1(const UINT AltCharSet, const UINT VideoMode);
+void    VideoGetSnapshot(struct SS_IO_Video_v2& Video);
+void    VideoSetSnapshot(const struct SS_IO_Video_v2& Video);
 
 void _Video_Dirty();
 void _Video_RedrawScreen( VideoUpdateFuncPtr_t update, bool bMixed = false );

--- a/source/Z80VICE/z80.cpp
+++ b/source/Z80VICE/z80.cpp
@@ -86,16 +86,20 @@ static BYTE reg_f2 = 0;
 static BYTE reg_h2 = 0;
 static BYTE reg_l2 = 0;
 
+#if 0	// [AppleWin-TC] Not used
 static int dma_request = 0;
+#endif
 
 static BYTE *z80_bank_base;
 static int z80_bank_limit;
 
 
+#if 0	// [AppleWin-TC] Not used
 void z80_trigger_dma(void)
 {
     dma_request = 1;
 }
+#endif
 
 void z80_reset(void)
 {
@@ -162,11 +166,11 @@ void z80_reset(void)
 
 /* ------------------------------------------------------------------------- */
 
+#if 0	// [AppleWin-TC]
 static unsigned int z80_last_opcode_info;
 
 #define LAST_OPCODE_INFO z80_last_opcode_info
 
-#if 0	// [AppleWin-TC]
 /* Remember the number of the last opcode.  By default, the opcode does not
    delay interrupt and does not change the I flag.  */
 #define SET_LAST_OPCODE(x) \
@@ -463,6 +467,9 @@ static void export_registers(void)
 
 /* ------------------------------------------------------------------------- */
 
+// [AppleWin-TC] Z80 IRQs not supported
+
+#if 0
 /* Interrupt handling.  */
 
 #define DO_INTERRUPT(int_kind)                                       \
@@ -533,6 +540,7 @@ static void export_registers(void)
             }                                                        \
         }                                                            \
     } while (0)
+#endif
 
 /* ------------------------------------------------------------------------- */
 
@@ -6421,4 +6429,182 @@ void z80_WRMEM(WORD Addr, BYTE Value)
 		case 0xF000: addr = laddr+0x0000; break;
 	}
 	CpuWrite( addr, Value, ConvertZ80TStatesTo6502Cycles(maincpu_clk) );
+}
+
+//===========================================================================
+
+struct Z80_Unit
+{
+	BYTE reg_a;
+	BYTE reg_b;
+	BYTE reg_c;
+	BYTE reg_d;
+	BYTE reg_e;
+	BYTE reg_f;
+	BYTE reg_h;
+	BYTE reg_l;
+	BYTE reg_ixh;
+	BYTE reg_ixl;
+	BYTE reg_iyh;
+	BYTE reg_iyl;
+	WORD reg_sp;
+	DWORD z80_reg_pc;
+	BYTE reg_i;
+	BYTE reg_r;
+
+	BYTE iff1;
+	BYTE iff2;
+	BYTE im_mode;
+
+	BYTE reg_a2;
+	BYTE reg_b2;
+	BYTE reg_c2;
+	BYTE reg_d2;
+	BYTE reg_e2;
+	BYTE reg_f2;
+	BYTE reg_h2;
+	BYTE reg_l2;
+};
+
+struct SS_CARD_Z80
+{
+	SS_CARD_HDR	Hdr;
+	Z80_Unit	Unit;
+	UINT		Active;
+};
+
+void Z80_GetSnapshot(const HANDLE hFile, const UINT uZ80Slot)
+{
+	SS_CARD_Z80 Card;
+
+	SS_CARD_Z80* const pSS = &Card;
+
+	pSS->Hdr.UnitHdr.hdr.v2.Length = sizeof(SS_CARD_Z80);
+	pSS->Hdr.UnitHdr.hdr.v2.Type = UT_Card;
+	pSS->Hdr.UnitHdr.hdr.v2.Version = 1;
+
+	pSS->Hdr.Slot = uZ80Slot;	// fixme: object should know its slot
+	pSS->Hdr.Type = CT_Z80;
+
+	pSS->Unit.reg_a = reg_a;
+	pSS->Unit.reg_b = reg_b;
+	pSS->Unit.reg_c = reg_c;
+	pSS->Unit.reg_d = reg_d;
+	pSS->Unit.reg_e = reg_e;
+	pSS->Unit.reg_f = reg_f;
+	pSS->Unit.reg_h = reg_h;
+	pSS->Unit.reg_l = reg_l;
+	pSS->Unit.reg_ixh = reg_ixh;
+	pSS->Unit.reg_ixl = reg_ixl;
+	pSS->Unit.reg_iyh = reg_iyh;
+	pSS->Unit.reg_iyl = reg_iyl;
+	pSS->Unit.reg_sp = reg_sp;
+	pSS->Unit.z80_reg_pc = z80_reg_pc;
+	pSS->Unit.reg_i = reg_i;
+	pSS->Unit.reg_r = reg_r;
+
+	pSS->Unit.iff1 = iff1;
+	pSS->Unit.iff2 = iff2;
+	pSS->Unit.im_mode = im_mode;
+
+	pSS->Unit.reg_a2 = reg_a2;
+	pSS->Unit.reg_b2 = reg_b2;
+	pSS->Unit.reg_c2 = reg_c2;
+	pSS->Unit.reg_d2 = reg_d2;
+	pSS->Unit.reg_e2 = reg_e2;
+	pSS->Unit.reg_f2 = reg_f2;
+	pSS->Unit.reg_h2 = reg_h2;
+	pSS->Unit.reg_l2 = reg_l2;
+
+	// SoftCard SW & HW details: http://apple2info.net/images/f/f0/SC-SWHW.pdf
+	// . SoftCard uses the Apple II's DMA circuit to pause the 6502 (no CLK to 6502)
+	// . But: "In Apple II DMA, the 6502 CPU will die after approximately 15 clocks because it depends on the clock to refresh its internal registers."
+	//		ref: Apple Tech Note: https://archive.org/stream/IIe_2523004_RDY_Line/IIe_2523004_RDY_Line_djvu.txt
+	//      NB. Not for 65C02 which is a static processor.
+	// . SoftCard controls the 6502's RDY line to periodically allow only 1 memory fetch by 6502 (ie. the opcode fetch)
+	//
+	// So save /g_ActiveCPU/ to SS_CARD_Z80 (so RDY is like IRQ & NMI signals, ie. saved struct of the producer's card)
+	//
+	// NB. Save-state only occurs when message pump runs:
+	//		. ie. at end of 1ms emulation burst
+	// Either 6502 or Z80 could be active.
+	//
+
+	pSS->Active = g_ActiveCPU == CPU_Z80 ? 1 : 0;
+
+	//
+
+	DWORD dwBytesWritten;
+	BOOL bRes = WriteFile(	hFile,
+							&Card,
+							Card.Hdr.UnitHdr.hdr.v2.Length,
+							&dwBytesWritten,
+							NULL);
+
+	if(!bRes || (dwBytesWritten != Card.Hdr.UnitHdr.hdr.v2.Length))
+	{
+		//dwError = GetLastError();
+		throw std::string("Save error: Z80");
+	}
+}
+
+void Z80_SetSnapshot(const HANDLE hFile)
+{
+	SS_CARD_Z80 Card;
+
+	DWORD dwBytesRead;
+	BOOL bRes = ReadFile(	hFile,
+							&Card,
+							sizeof(Card),
+							&dwBytesRead,
+							NULL);
+
+	if (dwBytesRead != sizeof(Card))
+		throw std::string("Card: file corrupt");
+
+	if (Card.Hdr.Slot != 4 && Card.Hdr.Slot != 5)	// fixme
+		throw std::string("Card: wrong slot");
+
+	if (Card.Hdr.UnitHdr.hdr.v2.Version > 1)
+		throw std::string("Card: wrong version");
+
+	if (Card.Hdr.UnitHdr.hdr.v2.Length != sizeof(SS_CARD_Z80))
+		throw std::string("Card: unit size mismatch");
+
+	SS_CARD_Z80* pSS = &Card;
+
+	reg_a = pSS->Unit.reg_a;
+	reg_b = pSS->Unit.reg_b;
+	reg_c = pSS->Unit.reg_c;
+	reg_d = pSS->Unit.reg_d;
+	reg_e = pSS->Unit.reg_e;
+	reg_f = pSS->Unit.reg_f;
+	reg_h = pSS->Unit.reg_h;
+	reg_l = pSS->Unit.reg_l;
+	reg_ixh = pSS->Unit.reg_ixh;
+	reg_ixl = pSS->Unit.reg_ixl;
+	reg_iyh = pSS->Unit.reg_iyh;
+	reg_iyl = pSS->Unit.reg_iyl;
+	reg_sp = pSS->Unit.reg_sp;
+	z80_reg_pc = pSS->Unit.z80_reg_pc;
+	reg_i = pSS->Unit.reg_i;
+	reg_r = pSS->Unit.reg_r;
+
+	iff1 = pSS->Unit.iff1;
+	iff2 = pSS->Unit.iff2;
+	im_mode = pSS->Unit.im_mode;
+
+	reg_a2 = pSS->Unit.reg_a2;
+	reg_b2 = pSS->Unit.reg_b2;
+	reg_c2 = pSS->Unit.reg_c2;
+	reg_d2 = pSS->Unit.reg_d2;
+	reg_e2 = pSS->Unit.reg_e2;
+	reg_f2 = pSS->Unit.reg_f2;
+	reg_h2 = pSS->Unit.reg_h2;
+	reg_l2 = pSS->Unit.reg_l2;
+
+	export_registers();
+
+	if (pSS->Active)
+		g_ActiveCPU = CPU_Z80;	// Support MS SoftCard in multiple slots (only one Z80 can be active at any one time)
 }

--- a/source/Z80VICE/z80regs.h
+++ b/source/Z80VICE/z80regs.h
@@ -46,6 +46,7 @@ typedef struct z80_regs_s {
     WORD reg_hl2;
 } z80_regs_t;
 
+#if 0	// [AppleWin-TC]: unused, so comment out
 #define Z80_REGS_GET_AF(reg_ptr) ((reg_ptr)->reg_af)
 #define Z80_REGS_GET_BC(reg_ptr) ((reg_ptr)->reg_bc)
 #define Z80_REGS_GET_DE(reg_ptr) ((reg_ptr)->reg_de)
@@ -75,6 +76,7 @@ typedef struct z80_regs_s {
 #define Z80_REGS_SET_BC2(reg_ptr, val) ((reg_ptr)->reg_bc2 = (val))
 #define Z80_REGS_SET_DE2(reg_ptr, val) ((reg_ptr)->reg_de2 = (val))
 #define Z80_REGS_SET_HL2(reg_ptr, val) ((reg_ptr)->reg_hl2 = (val))
+#endif
 
 #endif
 

--- a/source/z80emu.h
+++ b/source/z80emu.h
@@ -14,3 +14,7 @@
 
 // Protótipos
 void ConfigureSoftcard(LPBYTE pCxRomPeripheral, UINT uSlot);
+
+// NB. These are in z80.cpp:
+void Z80_GetSnapshot(const HANDLE hFile, const UINT uZ80Slot);
+void Z80_SetSnapshot(const HANDLE hFile);


### PR DESCRIPTION
Hi - a mega pull-request, I'm afraid!

The short summary is that it addresses #260, with this new format being extensible and supporting all the AppleWin cards (except Uthernet). Additionally the old v1 format is still supported (for loading).

I don't think it's worth anyone actually reviewing this pull-request. Maybe just give an opinion on the restoring of the configuration (see below).

This v2 format also saves/restores the configuration state. I'm in two minds about restoring the config though:
. On the one hand, you can save a game's state: eg. where you want to use cursor keys (or auto-fire) etc. for joystick emulation.
. But on the other hand, you don't know what state you'll be loading in. So it'll overwrite your current setup (eg. Apple II type, video mode, ConfirmReboot, ScrollLock toggle mode, volume settings, etc)
  - arguably you don't know what h/w state you are loading in anyway, so your current card setup will switch to the newly loaded state's

So a quick solution is to just disable the restore config state routine for now.
What do you think?

In terms of testing, I've got save-state files that test all cards. My plan is to put these into a separate git repo (eg. AppleWin-test). The reason for this is that they are binary files and if they get updated then all versions will accrue in the repo. OK, the size is only ~140K (or bigger for RAMworks saved state files), so perhaps having lots of these to download when you sync with a repo isn't such a big deal.

OTOH, the advantage of putting them directly into the AppleWin repo is that they'll be in sync with the commits to that repo (making testing specific versions easier).

Anyway, I think if it doesn't work having them in a separate git repo, then I can just move them across.

