### PR TITLE
Fix for Issue #(368)

### DIFF
--- a/source/DiskImage.h
+++ b/source/DiskImage.h
@@ -25,6 +25,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include "DiskDefs.h"
 
+
 	#define TRACK_DENIBBLIZED_SIZE (16 * 256)	// #Sectors x Sector-size
 
 	#define	TRACKS_STANDARD	35
@@ -61,9 +62,10 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 	const int MAX_DISK_IMAGE_NAME = 15;
 	const int MAX_DISK_FULL_NAME  = 127;
 
+#include "DiskImageHelper.h"
 
-ImageError_e ImageOpen(LPCTSTR pszImageFilename, HIMAGE* hDiskImage, bool* pWriteProtected, const bool bCreateIfNecessary, std::string& strFilenameInZip, const bool bExpectFloppy=true);
-void ImageClose(const HIMAGE hDiskImage, const bool bOpenError=false);
+ImageError_e ImageOpen(CDiskImageHelper* diskImageHelper, LPCTSTR pszImageFilename, HIMAGE* hDiskImage, bool* pWriteProtected, const bool bCreateIfNecessary, std::string& strFilenameInZip, const bool bExpectFloppy=true);
+void ImageClose(CDiskImageHelper* diskImageHelper, const HIMAGE hDiskImage, const bool bOpenError=false);
 BOOL ImageBoot(const HIMAGE hDiskImage);
 void ImageDestroy(void);
 void ImageInitialize(void);

--- a/source/Harddisk.cpp
+++ b/source/Harddisk.cpp
@@ -158,7 +158,7 @@ static void HD_CleanupDrive(const int iDrive)
 {
 	if (g_HardDisk[iDrive].imagehandle)
 	{
-		ImageClose(g_HardDisk[iDrive].imagehandle);
+		ImageClose((CDiskImageHelper *) &sg_HardDiskImageHelper, g_HardDisk[iDrive].imagehandle);
 		g_HardDisk[iDrive].imagehandle = (HIMAGE)0;
 	}
 
@@ -359,7 +359,8 @@ static BOOL HD_Insert(const int iDrive, LPCTSTR pszImageFilename)
 
 	const bool bCreateIfNecessary = false;		// NB. Don't allow creation of HDV files
 	const bool bExpectFloppy = false;
-	ImageError_e Error = ImageOpen(pszImageFilename,
+	ImageError_e Error = ImageOpen((CDiskImageHelper *)&sg_HardDiskImageHelper,
+		pszImageFilename,
 		&g_HardDisk[iDrive].imagehandle,
 		&g_HardDisk[iDrive].bWriteProtected,
 		bCreateIfNecessary,


### PR DESCRIPTION
Passing in a pointer to the CDiskImageHelper to ImageOpen, ImageClose.  Moved disk oriented setup of the DiskImageHelper workspace to disk.cpp

Verified that CHardDiskImageHelper::GetMaxImageSize() is called.