### PR TITLE
Update DiskImageHelper.cpp support 40 tracks of .nib files Issues #387

### DIFF
--- a/source/DiskImageHelper.cpp
+++ b/source/DiskImageHelper.cpp
@@ -714,10 +714,10 @@ public:
 
 	virtual eDetectResult Detect(const LPBYTE pImage, const DWORD dwImageSize, const TCHAR* pszExt)
 	{
-		if (dwImageSize != NIB1_TRACK_SIZE*TRACKS_STANDARD)
+		if (dwImageSize < NIB1_TRACK_SIZETRACKS_STANDARD || dwImageSize % NIB1_TRACK_SIZE != 0 || dwImageSize > NIB1_TRACK_SIZE*TRACKS_MAX)
 			return eMismatch;
 
-		m_uNumTracksInImage = TRACKS_STANDARD;
+		m_uNumTracksInImage = dwImageSize / NIB1_TRACK_SIZE;
 		return eMatch;
 	}
 

--- a/source/DiskImageHelper.cpp
+++ b/source/DiskImageHelper.cpp
@@ -714,7 +714,7 @@ public:
 
 	virtual eDetectResult Detect(const LPBYTE pImage, const DWORD dwImageSize, const TCHAR* pszExt)
 	{
-		if (dwImageSize < NIB1_TRACK_SIZETRACKS_STANDARD || dwImageSize % NIB1_TRACK_SIZE != 0 || dwImageSize > NIB1_TRACK_SIZE*TRACKS_MAX)
+		if (dwImageSize < NIB1_TRACK_SIZE*TRACKS_STANDARD || dwImageSize % NIB1_TRACK_SIZE != 0 || dwImageSize > NIB1_TRACK_SIZE*TRACKS_MAX)
 			return eMismatch;
 
 		m_uNumTracksInImage = dwImageSize / NIB1_TRACK_SIZE;


### PR DESCRIPTION
support 40 tracks of .nib files #387