### PR TITLE
Allow compilation with VS2017

### DIFF
--- a/source/Disk.cpp
+++ b/source/Disk.cpp
@@ -1292,7 +1292,7 @@ static void DiskLoadSnapshotDriveUnit(YamlLoadHelper& yamlLoadHelper, UINT unit)
 	g_aFloppyDisk[unit].trackimagedata	= yamlLoadHelper.LoadUint(SS_YAML_KEY_TRACK_IMAGE_DATA);
 	g_aFloppyDisk[unit].trackimagedirty	= yamlLoadHelper.LoadUint(SS_YAML_KEY_TRACK_IMAGE_DIRTY);
 
-	std::auto_ptr<BYTE> pTrack( new BYTE [NIBBLES_PER_TRACK] );
+	std::shared_ptr<BYTE> pTrack( new BYTE [NIBBLES_PER_TRACK] );
 	memset(pTrack.get(), 0, NIBBLES_PER_TRACK);
 	if (yamlLoadHelper.GetSubMap(SS_YAML_KEY_TRACK_IMAGE))
 	{

--- a/source/StdAfx.h
+++ b/source/StdAfx.h
@@ -46,6 +46,7 @@ typedef UINT32 uint32_t;
 #include <stack>
 #include <string>
 #include <vector>
+#include <memory>
 
 // SM_CXPADDEDBORDER is not supported on 2000 & XP:
 // http://msdn.microsoft.com/en-nz/library/windows/desktop/ms724385(v=vs.85).aspx


### PR DESCRIPTION
1) neet to include memory explicitly.
2) auto_ptr has gone. replace with shared_ptr as it works everywhere


Signed-off-by: Andrea Odetti <mariofutire@gmail.com>