### PR TITLE
Needed in VS2017.

### DIFF
--- a/source/StdAfx.h
+++ b/source/StdAfx.h
@@ -46,6 +46,7 @@ typedef UINT32 uint32_t;
 #include <stack>
 #include <string>
 #include <vector>
+#include <memory>
 
 // SM_CXPADDEDBORDER is not supported on 2000 & XP:
 // http://msdn.microsoft.com/en-nz/library/windows/desktop/ms724385(v=vs.85).aspx


### PR DESCRIPTION
So I have regenerated the VS2017 solution and come to a different conclusion.

`#include <memory>`

is always needed.

Now, for auto_ptr<>, this actually depends on a compiler switch /std:c++14 vs /std:c++latest.
With the former (the default as well), auto_ptr still exists, which means that with the default conversion there is no need to change anything else.

So in this patch I do the bare minimum and include only `<memory>`.

I can only imagine that when I converted the solution a few week ago, I must have changed that switch, hence the need to replace auto_ptr.
Or VS2017 updated itself and changed behaviour, I remember installing it before it was fully released...
