### PR TITLE
Fix the following errors reported by VS2017 Code Analysis.

### DIFF
--- a/source/Applewin.cpp
+++ b/source/Applewin.cpp
@@ -746,25 +746,25 @@ void RegisterExtensions(void)
 //	sprintf(command, "\"%s\" \"-d1 %%1\"", szCommandTmp);	// Wrap	path & filename	in quotes &	null terminate
 
 	// NB. Reflect extensions in DELREG.INF
-//	RegSetValue(HKEY_CLASSES_ROOT,".bin",REG_SZ,"DiskImage",10);	// Removed as .bin is too generic
+//	RegSetValue(HKEY_CLASSES_ROOT,".bin",REG_SZ,"DiskImage",0);	// Removed as .bin is too generic
 	long Res = RegDeleteValue(HKEY_CLASSES_ROOT, ".bin");			// TODO: This isn't working :-/
 
-	RegSetValue(HKEY_CLASSES_ROOT,".do"	,REG_SZ,"DiskImage",10);
-	RegSetValue(HKEY_CLASSES_ROOT,".dsk",REG_SZ,"DiskImage",10);
-	RegSetValue(HKEY_CLASSES_ROOT,".nib",REG_SZ,"DiskImage",10);
-	RegSetValue(HKEY_CLASSES_ROOT,".po"	,REG_SZ,"DiskImage",10);
-//	RegSetValue(HKEY_CLASSES_ROOT,".2mg",REG_SZ,"DiskImage",10);	// Don't grab this, as not all .2mg images are supported (so defer to CiderPress)
-//	RegSetValue(HKEY_CLASSES_ROOT,".2img",REG_SZ,"DiskImage",10);	// Don't grab this, as not all .2mg images are supported (so defer to CiderPress)
-//	RegSetValue(HKEY_CLASSES_ROOT,".aws",REG_SZ,"DiskImage",10);	// TO DO
-//	RegSetValue(HKEY_CLASSES_ROOT,".hdv",REG_SZ,"DiskImage",10);	// TO DO
+	RegSetValue(HKEY_CLASSES_ROOT,".do"	,REG_SZ,"DiskImage",0);
+	RegSetValue(HKEY_CLASSES_ROOT,".dsk",REG_SZ,"DiskImage",0);
+	RegSetValue(HKEY_CLASSES_ROOT,".nib",REG_SZ,"DiskImage",0);
+	RegSetValue(HKEY_CLASSES_ROOT,".po"	,REG_SZ,"DiskImage",0);
+//	RegSetValue(HKEY_CLASSES_ROOT,".2mg",REG_SZ,"DiskImage",0);	// Don't grab this, as not all .2mg images are supported (so defer to CiderPress)
+//	RegSetValue(HKEY_CLASSES_ROOT,".2img",REG_SZ,"DiskImage",0);	// Don't grab this, as not all .2mg images are supported (so defer to CiderPress)
+//	RegSetValue(HKEY_CLASSES_ROOT,".aws",REG_SZ,"DiskImage",0);	// TO DO
+//	RegSetValue(HKEY_CLASSES_ROOT,".hdv",REG_SZ,"DiskImage",0);	// TO DO
 
 	RegSetValue(HKEY_CLASSES_ROOT,
 				"DiskImage",
-				REG_SZ,"Disk Image",21);
+				REG_SZ,"Disk Image",0);
 
 	RegSetValue(HKEY_CLASSES_ROOT,
 				"DiskImage\\DefaultIcon",
-				REG_SZ,icon,_tcslen(icon)+1);
+				REG_SZ,icon,0);
 
 // This key can interfere....
 // HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\FileExt\.dsk

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -2727,6 +2727,8 @@ bool _CmdConfigFont ( int iFont, LPCSTR pFontName, int iPitchFamily, int nFontHe
 
 	if (iFont < NUM_FONTS)
 		pFont = & g_aFontConfig[ iFont ];
+	else
+		return bStatus;
 
 	if (pFontName)
 	{	
@@ -6621,7 +6623,7 @@ bool ParseAssemblyListing( bool bBytesToMemory, bool bAddSymbols )
 					int nLen = pLabelEnd - pLabelStart;
 					nLen = MIN( nLen, MAX_SYMBOLS_LEN );
 					strncpy( sName, pLabelStart, nLen );
-					sName[ nLen ] = 0;
+					sName[ nLen - 1 ] = 0;
 
 					char *pAddressEQU = strstr( pLabel, "$" );
 					char *pAddressDFB = strstr( sLine, ":" ); // Get address from start of line

--- a/source/Debugger/Debugger_Display.cpp
+++ b/source/Debugger/Debugger_Display.cpp
@@ -3711,7 +3711,9 @@ void DrawSubWindow_Source2 (Update_t bUpdate)
 	char sTitle[ CONSOLE_WIDTH ];
 	char sText [ CONSOLE_WIDTH ];
 	strcpy ( sTitle, "   Source: " );
-	strncpy( sText , g_aSourceFileName, g_nConsoleDisplayWidth - strlen( sTitle ) - 1 );
+	int maxSizeToCopy = g_nConsoleDisplayWidth - strlen(sTitle) - 1;
+	strncpy( sText , g_aSourceFileName, maxSizeToCopy );
+	sText[ maxSizeToCopy - 1 ] = 0;
 	strcat ( sTitle, sText );
 
 	DebuggerSetColorBG( DebuggerGetColor( BG_SOURCE_TITLE ));

--- a/source/Debugger/Debugger_Symbols.cpp
+++ b/source/Debugger/Debugger_Symbols.cpp
@@ -228,6 +228,7 @@ bool String2Address( LPCTSTR pText, WORD & nAddress_ )
 
 		_tcscpy( sHexApple, "0x" );
 		_tcsncpy( sHexApple+2, pText+1, MAX_SYMBOLS_LEN - 3 );
+		sHexApple[2 + (MAX_SYMBOLS_LEN - 3) - 1] = 0;
 		pText = sHexApple;
 	}
 

--- a/source/DiskImageHelper.cpp
+++ b/source/DiskImageHelper.cpp
@@ -1127,6 +1127,7 @@ void GetCharLowerExt(TCHAR* pszExt, LPCTSTR pszImageFilename, const UINT uExtSiz
 		pImageFileExt = _tcsrchr(pImageFileExt, TEXT('.'));
 
 	_tcsncpy(pszExt, pImageFileExt, uExtSize);
+	pszExt[uExtSize - 1] = 0;
 
 	CharLowerBuff(pszExt, _tcslen(pszExt));
 }
@@ -1135,6 +1136,7 @@ void GetCharLowerExt2(TCHAR* pszExt, LPCTSTR pszImageFilename, const UINT uExtSi
 {
 	TCHAR szFilename[MAX_PATH];
 	_tcsncpy(szFilename, pszImageFilename, MAX_PATH);
+	szFilename[MAX_PATH - 1] = 0;
 
 	TCHAR* pLastDot = _tcsrchr(szFilename, TEXT('.'));
 	if (pLastDot)

--- a/source/Log.cpp
+++ b/source/Log.cpp
@@ -39,7 +39,7 @@ void LogOutput(LPCTSTR format, ...)
 	va_start(args, format);
 
 	_vsntprintf(output, sizeof(output) - 1, format, args);
-	output[255] = 0;
+	output[sizeof(output) - 1] = 0;
 	OutputDebugString(output);
 }
 
@@ -58,5 +58,6 @@ void LogFileOutput(LPCTSTR format, ...)
 	va_start(args, format);
 
 	_vsntprintf(output, sizeof(output) - 1, format, args);
+	output[sizeof(output) - 1] = 0;
 	fprintf(g_fh, "%s", output);
 }

--- a/source/Log.cpp
+++ b/source/Log.cpp
@@ -39,6 +39,7 @@ void LogOutput(LPCTSTR format, ...)
 	va_start(args, format);
 
 	_vsntprintf(output, sizeof(output) - 1, format, args);
+	output[255] = 0;
 	OutputDebugString(output);
 }
 

--- a/source/ParallelPrinter.cpp
+++ b/source/ParallelPrinter.cpp
@@ -239,6 +239,7 @@ void Printer_SetFilename(char* prtFilename)
 	else  //No registry entry is available
 	{
 		_tcsncpy(g_szPrintFilename, g_sProgramDir, MAX_PATH);
+		g_szPrintFilename[MAX_PATH - 1] = 0;
         _tcsncat(g_szPrintFilename, _T(DEFAULT_PRINT_FILENAME), MAX_PATH);		
 		RegSaveString(TEXT("Configuration"),REGVALUE_PRINTER_FILENAME,1,g_szPrintFilename);
 	}


### PR DESCRIPTION
applewin\source\applewin.cpp(761): warning C6385: Reading invalid data from '"Disk Image"':  the readable size is '11' bytes, but '21' bytes may be read.
applewin\source\debugger\debug.cpp(6624): warning C6386: Buffer overrun while writing to 'sName':  the writable size is '31' bytes, but '32' bytes might be written.
applewin\source\debugger\debugger_display.cpp(3715): warning C6053: The prior call to 'strncpy' might not zero-terminate string 'sText'.
applewin\source\log.cpp(42): warning C6053: The prior call to '_vsnprintf' might not zero-terminate string 'output'.
applewin\source\debugger\debug.cpp(2759): warning C6011: Dereferencing NULL pointer 'pFont'.
applewin\source\debugger\debugger_symbols.cpp(243): warning C6053: The prior call to '_tcsncpy' might not zero-terminate string 'pText'.
applewin\source\diskimagehelper.cpp(1132): warning C6053: The prior call to '_tcsncpy' might not zero-terminate string 'pszExt'.
applewin\source\diskimagehelper.cpp(1141): warning C6053: The prior call to '_tcsncpy' might not zero-terminate string 'szFilename'.
applewin\source\parallelprinter.cpp(242): warning C6053: The prior call to '_tcsncpy' might not zero-terminate string 'g_szPrintFilename'.

The one about RegSetValue(), according to Microsoft

https://msdn.microsoft.com/en-us/library/windows/desktop/ms724922(v=vs.85).aspx

the last argument cbData is ignored, so I set it to 0, as in some cases was anyway wrong (see "DiskImage").


Signed-off-by: Andrea Odetti <mariofutire@gmail.com>