### PR TITLE
Apple II: Language Card and Saturn support for slot-0

### DIFF
--- a/AppleWinExpress2008.vcproj
+++ b/AppleWinExpress2008.vcproj
@@ -626,6 +626,14 @@
 					>
 				</File>
 				<File
+					RelativePath=".\source\LanguageCard.cpp"
+					>
+				</File>
+				<File
+					RelativePath=".\source\LanguageCard.h"
+					>
+				</File>
+				<File
 					RelativePath=".\source\Log.cpp"
 					>
 				</File>

--- a/AppleWinExpress2013.vcxproj
+++ b/AppleWinExpress2013.vcxproj
@@ -71,6 +71,7 @@
     <ClInclude Include="source\Harddisk.h" />
     <ClInclude Include="source\Joystick.h" />
     <ClInclude Include="source\Keyboard.h" />
+    <ClInclude Include="source\LanguageCard.h" />
     <ClInclude Include="source\Log.h" />
     <ClInclude Include="source\Memory.h" />
     <ClInclude Include="source\Mockingboard.h" />
@@ -154,6 +155,7 @@
     <ClCompile Include="source\Harddisk.cpp" />
     <ClCompile Include="source\Joystick.cpp" />
     <ClCompile Include="source\Keyboard.cpp" />
+    <ClCompile Include="source\LanguageCard.cpp" />
     <ClCompile Include="source\Log.cpp" />
     <ClCompile Include="source\Memory.cpp" />
     <ClCompile Include="source\Mockingboard.cpp" />

--- a/AppleWinExpress2013.vcxproj.filters
+++ b/AppleWinExpress2013.vcxproj.filters
@@ -76,6 +76,9 @@
     <ClCompile Include="source\Keyboard.cpp">
       <Filter>Source Files\Emulator</Filter>
     </ClCompile>
+    <ClCompile Include="source\LanguageCard.cpp">
+      <Filter>Source Files\Emulator</Filter>
+    </ClCompile>
     <ClCompile Include="source\Log.cpp">
       <Filter>Source Files\Emulator</Filter>
     </ClCompile>
@@ -310,6 +313,9 @@
       <Filter>Source Files\Emulator</Filter>
     </ClInclude>
     <ClInclude Include="source\Keyboard.h">
+      <Filter>Source Files\Emulator</Filter>
+    </ClInclude>
+    <ClInclude Include="source\LanguageCard.h">
       <Filter>Source Files\Emulator</Filter>
     </ClInclude>
     <ClInclude Include="source\Log.h">

--- a/AppleWinExpress2015.vcxproj
+++ b/AppleWinExpress2015.vcxproj
@@ -71,6 +71,7 @@
     <ClInclude Include="source\Harddisk.h" />
     <ClInclude Include="source\Joystick.h" />
     <ClInclude Include="source\Keyboard.h" />
+    <ClInclude Include="source\LanguageCard.h" />
     <ClInclude Include="source\Log.h" />
     <ClInclude Include="source\Memory.h" />
     <ClInclude Include="source\Mockingboard.h" />
@@ -154,6 +155,7 @@
     <ClCompile Include="source\Harddisk.cpp" />
     <ClCompile Include="source\Joystick.cpp" />
     <ClCompile Include="source\Keyboard.cpp" />
+    <ClCompile Include="source\LanguageCard.cpp" />
     <ClCompile Include="source\Log.cpp" />
     <ClCompile Include="source\Memory.cpp" />
     <ClCompile Include="source\Mockingboard.cpp" />

--- a/AppleWinExpress2015.vcxproj.filters
+++ b/AppleWinExpress2015.vcxproj.filters
@@ -76,6 +76,9 @@
     <ClCompile Include="source\Keyboard.cpp">
       <Filter>Source Files\Emulator</Filter>
     </ClCompile>
+    <ClCompile Include="source\LanguageCard.cpp">
+      <Filter>Source Files\Emulator</Filter>
+    </ClCompile>
     <ClCompile Include="source\Log.cpp">
       <Filter>Source Files\Emulator</Filter>
     </ClCompile>
@@ -310,6 +313,9 @@
       <Filter>Source Files\Emulator</Filter>
     </ClInclude>
     <ClInclude Include="source\Keyboard.h">
+      <Filter>Source Files\Emulator</Filter>
+    </ClInclude>
+    <ClInclude Include="source\LanguageCard.h">
       <Filter>Source Files\Emulator</Filter>
     </ClInclude>
     <ClInclude Include="source\Log.h">

--- a/AppleWinExpress2017.vcxproj
+++ b/AppleWinExpress2017.vcxproj
@@ -71,6 +71,7 @@
     <ClInclude Include="source\Harddisk.h" />
     <ClInclude Include="source\Joystick.h" />
     <ClInclude Include="source\Keyboard.h" />
+    <ClInclude Include="source\LanguageCard.h" />
     <ClInclude Include="source\Log.h" />
     <ClInclude Include="source\Memory.h" />
     <ClInclude Include="source\Mockingboard.h" />
@@ -154,6 +155,7 @@
     <ClCompile Include="source\Harddisk.cpp" />
     <ClCompile Include="source\Joystick.cpp" />
     <ClCompile Include="source\Keyboard.cpp" />
+    <ClCompile Include="source\LanguageCard.cpp" />
     <ClCompile Include="source\Log.cpp" />
     <ClCompile Include="source\Memory.cpp" />
     <ClCompile Include="source\Mockingboard.cpp" />

--- a/AppleWinExpress2017.vcxproj.filters
+++ b/AppleWinExpress2017.vcxproj.filters
@@ -76,6 +76,9 @@
     <ClCompile Include="source\Keyboard.cpp">
       <Filter>Source Files\Emulator</Filter>
     </ClCompile>
+    <ClCompile Include="source\LanguageCard.cpp">
+      <Filter>Source Files\Emulator</Filter>
+    </ClCompile>
     <ClCompile Include="source\Log.cpp">
       <Filter>Source Files\Emulator</Filter>
     </ClCompile>
@@ -310,6 +313,9 @@
       <Filter>Source Files\Emulator</Filter>
     </ClInclude>
     <ClInclude Include="source\Keyboard.h">
+      <Filter>Source Files\Emulator</Filter>
+    </ClInclude>
+    <ClInclude Include="source\LanguageCard.h">
       <Filter>Source Files\Emulator</Filter>
     </ClInclude>
     <ClInclude Include="source\Log.h">

--- a/source/Applewin.cpp
+++ b/source/Applewin.cpp
@@ -1249,8 +1249,6 @@ int APIENTRY WinMain(HINSTANCE passinstance, HINSTANCE, LPSTR lpCmdLine, int)
 #ifdef RAMWORKS
 		else if (strcmp(lpCmdLine, "-r") == 0)		// RamWorks size [1..127]
 		{
-			g_eMemType = MEM_TYPE_RAMWORKS;
-
 			lpCmdLine = GetCurrArg(lpNextArg);
 			lpNextArg = GetNextArg(lpNextArg);
 			    g_uMaxExPages = atoi(lpCmdLine);
@@ -1259,25 +1257,26 @@ int APIENTRY WinMain(HINSTANCE passinstance, HINSTANCE, LPSTR lpCmdLine, int)
 			else
 			if (g_uMaxExPages < 1)
 				g_uMaxExPages = 1;
+
+			SetExpansionMemType(MEM_TYPE_RAMWORKS);
 		}
 #endif
 #ifdef SATURN
 		else if (strcmp(lpCmdLine, "-saturn") == 0)		// 64 = Saturn 64K (4 banks), 128 = Saturn 128K (8 banks)
 		{
-			g_eMemType = MEM_TYPE_SATURN;
-
 			lpCmdLine = GetCurrArg(lpNextArg);
 			lpNextArg = GetNextArg(lpNextArg);
 
-			// " The  boards  consist  of 16K  banks  of  memory
-			//  (4  banks  for  the  64K  board,
-			//  8  banks  for  the  128K),  accessed  one  at  a  time"
-			    g_uSaturnTotalBanks = atoi(lpCmdLine) / 16; // number of 16K Banks [1..8]
-			if (g_uSaturnTotalBanks > 8)
-				g_uSaturnTotalBanks = 8;
+			// "The boards consist of 16K banks of memory (4 banks for the 64K board, 8 banks for the 128K), accessed one at a time" - Ref: ?
+			UINT banks = atoi(lpCmdLine) / 16;			// number of 16K Banks [1..8]
+			if (banks > kMaxSaturnBanks)
+				banks = kMaxSaturnBanks;
 			else
-			if (g_uSaturnTotalBanks < 1)
-				g_uSaturnTotalBanks = 1;
+			if (banks < 1)
+				banks = 1;
+
+			SetSaturnMemorySize(banks);
+			SetExpansionMemType(MEM_TYPE_SATURN);
 		}
 #endif
 		else if (strcmp(lpCmdLine, "-f8rom") == 0)		// Use custom 2K ROM at [$F800..$FFFF]

--- a/source/Applewin.cpp
+++ b/source/Applewin.cpp
@@ -36,6 +36,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "Frame.h"
 #include "Harddisk.h"
 #include "Joystick.h"
+#include "LanguageCard.h"
 #include "Log.h"
 #include "Memory.h"
 #include "Mockingboard.h"
@@ -1263,7 +1264,6 @@ int APIENTRY WinMain(HINSTANCE passinstance, HINSTANCE, LPSTR lpCmdLine, int)
 				uRamWorksExPages = 1;
 		}
 #endif
-#ifdef SATURN
 		else if (strcmp(lpCmdLine, "-saturn") == 0)		// 64 = Saturn 64K (4 banks), 128 = Saturn 128K (8 banks)
 		{
 			lpCmdLine = GetCurrArg(lpNextArg);
@@ -1278,7 +1278,6 @@ int APIENTRY WinMain(HINSTANCE passinstance, HINSTANCE, LPSTR lpCmdLine, int)
 				uSaturnBanks = 1;
 
 		}
-#endif
 		else if (strcmp(lpCmdLine, "-f8rom") == 0)		// Use custom 2K ROM at [$F800..$FFFF]
 		{
 			lpCmdLine = GetCurrArg(lpNextArg);
@@ -1467,14 +1466,12 @@ int APIENTRY WinMain(HINSTANCE passinstance, HINSTANCE, LPSTR lpCmdLine, int)
 			uRamWorksExPages = 0;	// Don't reapply after a restart
 		}
 #endif
-#ifdef SATURN
 		if (uSaturnBanks)
 		{
 			SetSaturnMemorySize(uSaturnBanks);
 			SetExpansionMemType(MEM_TYPE_SATURN);
 			uSaturnBanks = 0;		// Don't reapply after a restart
 		}
-#endif
 
 		DebugInitialize();
 		LogFileOutput("Main: DebugInitialize()\n");

--- a/source/Applewin.cpp
+++ b/source/Applewin.cpp
@@ -103,8 +103,8 @@ CSuperSerialCard	sg_SSC;
 CMouseInterface		sg_Mouse;
 
 SS_CARDTYPE g_Slot0 = CT_LanguageCard;	// Just for Apple II or II+ or similar clones
-SS_CARDTYPE	g_Slot4 = CT_Empty;
-SS_CARDTYPE	g_Slot5 = CT_Empty;
+SS_CARDTYPE g_Slot4 = CT_Empty;
+SS_CARDTYPE g_Slot5 = CT_Empty;
 SS_CARDTYPE g_SlotAux = CT_Extended80Col;	// For Apple //e and above
 
 HANDLE		g_hCustomRomF8 = INVALID_HANDLE_VALUE;	// Cmd-line specified custom ROM at $F800..$FFFF

--- a/source/Applewin.cpp
+++ b/source/Applewin.cpp
@@ -1271,8 +1271,8 @@ int APIENTRY WinMain(HINSTANCE passinstance, HINSTANCE, LPSTR lpCmdLine, int)
 
 			// "The boards consist of 16K banks of memory (4 banks for the 64K board, 8 banks for the 128K), accessed one at a time" - Ref: "64K/128K RAM BOARD", Saturn Systems, Ch.1 Introduction(pg-5)
 			uSaturnBanks = atoi(lpCmdLine) / 16;			// number of 16K Banks [1..8]
-			if (uSaturnBanks > kMaxSaturnBanks)
-				uSaturnBanks = kMaxSaturnBanks;
+			if (uSaturnBanks > Saturn128K::kMaxSaturnBanks)
+				uSaturnBanks = Saturn128K::kMaxSaturnBanks;
 			else
 			if (uSaturnBanks < 1)
 				uSaturnBanks = 1;
@@ -1461,15 +1461,15 @@ int APIENTRY WinMain(HINSTANCE passinstance, HINSTANCE, LPSTR lpCmdLine, int)
 #ifdef RAMWORKS
 		if (uRamWorksExPages)
 		{
-			SetRamWorksMemorySize(uRamWorksExPages);
 			SetExpansionMemType(MEM_TYPE_RAMWORKS);
+			SetRamWorksMemorySize(uRamWorksExPages);
 			uRamWorksExPages = 0;	// Don't reapply after a restart
 		}
 #endif
 		if (uSaturnBanks)
 		{
-			SetSaturnMemorySize(uSaturnBanks);
 			SetExpansionMemType(MEM_TYPE_SATURN);
+			GetLanguageCard()->SetMemorySize(uSaturnBanks);
 			uSaturnBanks = 0;		// Don't reapply after a restart
 		}
 

--- a/source/Applewin.h
+++ b/source/Applewin.h
@@ -49,8 +49,10 @@ extern bool       g_bDisableDirectSound;				// Cmd line switch: don't init DS (s
 extern bool       g_bDisableDirectSoundMockingboard;	// Cmd line switch: don't init MB support
 extern int        g_nMemoryClearType;					// Cmd line switch: use specific MIP (Memory Initialization Pattern)
 
+extern SS_CARDTYPE g_Slot0;	// LC or Saturn in slot0
 extern SS_CARDTYPE g_Slot4;	// Mockingboard, Z80, Mouse in slot4
 extern SS_CARDTYPE g_Slot5;	// Mockingboard, Z80,       in slot5
+extern SS_CARDTYPE g_SlotAux;
 
 extern HANDLE	g_hCustomRomF8;		// NULL if no custom rom
 

--- a/source/Common.h
+++ b/source/Common.h
@@ -20,7 +20,6 @@ const DWORD dwClksPerFrame			= uCyclesPerLine * uLinesPerFrame;	// 17030
 #define  MIN(a,b)          (((a) < (b)) ? (a) : (b))
 
 #define  RAMWORKS			// 8MB RamWorks III support
-#define  SATURN				// SATURN 128K
 
 // Use a base freq so that DirectX (or sound h/w) doesn't have to up/down-sample
 // Assume base freqs are 44.1KHz & 48KHz

--- a/source/Common.h
+++ b/source/Common.h
@@ -112,6 +112,7 @@ enum AppMode_e
 #define  REGVALUE_CUSTOM_SPEED       "Custom Speed"
 #define  REGVALUE_EMULATION_SPEED    "Emulation Speed"
 #define  REGVALUE_WINDOW_SCALE       "Window Scale"
+#define  REGVALUE_SLOT0					"Slot 0"
 #define  REGVALUE_SLOT1					"Slot 1"
 #define  REGVALUE_SLOT2					"Slot 2"
 #define  REGVALUE_SLOT3					"Slot 3"
@@ -193,7 +194,7 @@ enum eApple2Type {
 					A2TYPE_MAX
 				};
 
-inline bool IsApple2(eApple2Type type)
+inline bool IsApple2Plus(eApple2Type type)			// Apple ][,][+
 {
 	return (type & (APPLE2E_MASK|APPLE2C_MASK)) == 0;
 }

--- a/source/Common.h
+++ b/source/Common.h
@@ -20,7 +20,7 @@ const DWORD dwClksPerFrame			= uCyclesPerLine * uLinesPerFrame;	// 17030
 #define  MIN(a,b)          (((a) < (b)) ? (a) : (b))
 
 #define  RAMWORKS			// 8MB RamWorks III support
-//#define  SATURN				// SATURN 128K
+#define  SATURN				// SATURN 128K
 
 // Use a base freq so that DirectX (or sound h/w) doesn't have to up/down-sample
 // Assume base freqs are 44.1KHz & 48KHz
@@ -201,6 +201,12 @@ inline bool IsApple2(eApple2Type type)
 inline bool IsClone(eApple2Type type)
 {
 	return (type & APPLECLONE_MASK) != 0;
+}
+
+inline bool IsApple2PlusOrClone(eApple2Type type)	// Apple ][,][+ or clone ][,][+
+{
+	return ((type & (APPLE2E_MASK|APPLE2C_MASK)) == 0)
+		||	(type & APPLECLONE_MASK) && !(type & A2TYPE_CLONE_A2E);
 }
 
 extern eApple2Type g_Apple2Type;

--- a/source/Configuration/PageAdvanced.cpp
+++ b/source/Configuration/PageAdvanced.cpp
@@ -259,8 +259,8 @@ int CPageAdvanced::GetCloneMenuItem(void)
 
 void CPageAdvanced::InitFreezeDlgButton(HWND hWnd)
 {
-	const bool bIsApple2 = IsApple2( m_PropertySheetHelper.GetConfigNew().m_Apple2Type );
-	EnableWindow(GetDlgItem(hWnd, IDC_THE_FREEZES_F8_ROM_FW), bIsApple2 ? TRUE : FALSE);
+	const bool bIsApple2Plus = IsApple2Plus( m_PropertySheetHelper.GetConfigNew().m_Apple2Type );
+	EnableWindow(GetDlgItem(hWnd, IDC_THE_FREEZES_F8_ROM_FW), bIsApple2Plus ? TRUE : FALSE);
 
 	const UINT CheckTheFreezesRom = m_PropertySheetHelper.GetConfigNew().m_bEnableTheFreezesF8Rom ? BST_CHECKED : BST_UNCHECKED;
 	CheckDlgButton(hWnd, IDC_THE_FREEZES_F8_ROM_FW, CheckTheFreezesRom);

--- a/source/Debugger/Debugger_Display.cpp
+++ b/source/Debugger/Debugger_Display.cpp
@@ -2891,10 +2891,10 @@ void _DrawSoftSwitchLanguageCardBank( RECT & rect, int iBankDisplay, int bg_defa
 		int iActiveBank = -1;
 		char sText[ 4 ] = "?"; // Default to RAMWORKS
 #ifdef RAMWORKS
-		if (g_eMemType == MEM_TYPE_RAMWORKS) { sText[0] = 'r'; iActiveBank = g_uActiveBank; } // RAMWORKS
+		if (GetCurrentExpansionMemType() == MEM_TYPE_RAMWORKS) { sText[0] = 'r'; iActiveBank = g_uActiveBank; } // RAMWORKS
 #endif
 #ifdef SATURN
-		if (g_eMemType == MEM_TYPE_SATURN  ) { sText[0] = 's'; iActiveBank = g_uSaturnActiveBank; } // SATURN 64K 128K
+		if (GetCurrentExpansionMemType() == MEM_TYPE_SATURN  ) { sText[0] = 's'; iActiveBank = GetSaturnActiveBank(); } // SATURN 64K 128K
 #endif // SATURN
 
 		if (iActiveBank >= 0)

--- a/source/Debugger/Debugger_Display.cpp
+++ b/source/Debugger/Debugger_Display.cpp
@@ -2894,7 +2894,7 @@ void _DrawSoftSwitchLanguageCardBank( RECT & rect, int iBankDisplay, int bg_defa
 #ifdef RAMWORKS
 		if (GetCurrentExpansionMemType() == MEM_TYPE_RAMWORKS) { sText[0] = 'r'; iActiveBank = GetRamWorksActiveBank(); } // RAMWORKS
 #endif
-		if (GetCurrentExpansionMemType() == MEM_TYPE_SATURN  ) { sText[0] = 's'; iActiveBank = GetSaturnActiveBank(); } // SATURN 64K 128K
+		if (GetCurrentExpansionMemType() == MEM_TYPE_SATURN  ) { sText[0] = 's'; iActiveBank = GetLanguageCard()->GetActiveBank(); } // SATURN 64K 128K
 
 		if (iActiveBank >= 0)
 		{

--- a/source/Debugger/Debugger_Display.cpp
+++ b/source/Debugger/Debugger_Display.cpp
@@ -34,6 +34,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "../Applewin.h"
 #include "../CPU.h"
 #include "../Frame.h"
+#include "../LanguageCard.h"
 #include "../Memory.h"
 #include "../Mockingboard.h"
 #include "../Video.h"
@@ -2893,9 +2894,7 @@ void _DrawSoftSwitchLanguageCardBank( RECT & rect, int iBankDisplay, int bg_defa
 #ifdef RAMWORKS
 		if (GetCurrentExpansionMemType() == MEM_TYPE_RAMWORKS) { sText[0] = 'r'; iActiveBank = GetRamWorksActiveBank(); } // RAMWORKS
 #endif
-#ifdef SATURN
 		if (GetCurrentExpansionMemType() == MEM_TYPE_SATURN  ) { sText[0] = 's'; iActiveBank = GetSaturnActiveBank(); } // SATURN 64K 128K
-#endif // SATURN
 
 		if (iActiveBank >= 0)
 		{

--- a/source/Debugger/Debugger_Display.cpp
+++ b/source/Debugger/Debugger_Display.cpp
@@ -2891,7 +2891,7 @@ void _DrawSoftSwitchLanguageCardBank( RECT & rect, int iBankDisplay, int bg_defa
 		int iActiveBank = -1;
 		char sText[ 4 ] = "?"; // Default to RAMWORKS
 #ifdef RAMWORKS
-		if (GetCurrentExpansionMemType() == MEM_TYPE_RAMWORKS) { sText[0] = 'r'; iActiveBank = g_uActiveBank; } // RAMWORKS
+		if (GetCurrentExpansionMemType() == MEM_TYPE_RAMWORKS) { sText[0] = 'r'; iActiveBank = GetRamWorksActiveBank(); } // RAMWORKS
 #endif
 #ifdef SATURN
 		if (GetCurrentExpansionMemType() == MEM_TYPE_SATURN  ) { sText[0] = 's'; iActiveBank = GetSaturnActiveBank(); } // SATURN 64K 128K

--- a/source/LanguageCard.cpp
+++ b/source/LanguageCard.cpp
@@ -1,0 +1,264 @@
+/*
+AppleWin : An Apple //e emulator for Windows
+
+Copyright (C) 1994-1996, Michael O'Brien
+Copyright (C) 1999-2001, Oliver Schmidt
+Copyright (C) 2002-2005, Tom Charlesworth
+Copyright (C) 2006-2018, Tom Charlesworth, Michael Pohoreski, Nick Westgate
+
+AppleWin is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+AppleWin is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with AppleWin; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+/* Description: Language Card and Saturn 128K emulation
+ *
+ * Author: various
+ */
+
+#include "StdAfx.h"
+
+#include "Applewin.h"
+#include "LanguageCard.h"
+#include "Log.h"
+#include "Memory.h"
+#include "YamlHelper.h"
+
+LanguageCard::LanguageCard(void)
+{
+	type = MEM_TYPE_LANGUAGECARD;
+}
+
+//
+
+Saturn128K::Saturn128K(void)
+{
+	type = MEM_TYPE_SATURN;
+
+	m_uSaturnTotalBanks = 0;
+	m_uSaturnActiveBank = 0;
+	for (UINT i=0; i<kMaxSaturnBanks; i++)
+		m_aSaturnBanks[i] = NULL;
+}
+
+void Saturn128K::SetMemorySize(UINT banks)
+{
+	m_uSaturnTotalBanks = banks;
+}
+
+UINT Saturn128K::GetActiveBank(void)
+{
+	return m_uSaturnActiveBank;
+}
+
+void Saturn128K::Initialize(void)
+{
+	if (GetCurrentExpansionMemType() == MEM_TYPE_SATURN)
+	{
+		_ASSERT(IsApple2PlusOrClone(GetApple2Type()));
+
+		m_uSaturnActiveBank = 0;
+
+		for(UINT i = 0; i < m_uSaturnTotalBanks; i++)
+			m_aSaturnBanks[i] = (LPBYTE) VirtualAlloc( NULL, 1024 * 16, MEM_COMMIT, PAGE_READWRITE); // Saturn banks are 16K, max 8 banks/card
+
+		SetMemMainLanguageCard( m_aSaturnBanks[ m_uSaturnActiveBank ] );
+	}
+}
+
+void Saturn128K::Destroy(void)
+{
+	for (UINT i = 0; i < m_uSaturnTotalBanks; i++)
+	{
+		if (m_aSaturnBanks[i])
+		{
+			VirtualFree(m_aSaturnBanks[i], 0, MEM_RELEASE);
+			m_aSaturnBanks[i] = NULL;
+		}
+	}
+}
+
+DWORD Saturn128K::SetPaging(WORD address, DWORD memmode)
+{
+/*
+	Bin   Addr.
+	      $C0N0 4K Bank A, RAM read, Write protect
+	      $C0N1 4K Bank A, ROM read, Write enabled
+	      $C0N2 4K Bank A, ROM read, Write protect
+	      $C0N3 4K Bank A, RAM read, Write enabled
+	0100  $C0N4 select 16K Bank 1
+	0101  $C0N5 select 16K Bank 2
+	0110  $C0N6 select 16K Bank 3
+	0111  $C0N7 select 16K Bank 4
+	      $C0N8 4K Bank B, RAM read, Write protect
+	      $C0N9 4K Bank B, ROM read, Write enabled
+	      $C0NA 4K Bank B, ROM read, Write protect
+	      $C0NB 4K Bank B, RAM read, Write enabled
+	1100  $C0NC select 16K Bank 5
+	1101  $C0ND select 16K Bank 6
+	1110  $C0NE select 16K Bank 7
+	1111  $C0NF select 16K Bank 8
+*/
+	_ASSERT(m_uSaturnTotalBanks);
+	if (!m_uSaturnTotalBanks)
+		return memmode;
+
+	if (address & (1<<2))
+	{
+		m_uSaturnActiveBank = 0 // Saturn 128K Language Card Bank 0 .. 7
+			| (address >> 1) & 4
+			| (address >> 0) & 3;
+
+		if (m_uSaturnActiveBank >= m_uSaturnTotalBanks)
+		{
+			// EG. Run RAMTEST128K tests on a Saturn 64K card
+			// TODO: Saturn::UpdatePaging() should deal with this case:
+			// . Technically read floating-bus, write to nothing
+			// . But the mem cache doesn't support floating-bus reads from non-I/O space
+			m_uSaturnActiveBank = m_uSaturnTotalBanks-1;	// FIXME: just prevent crash for now!
+		}
+
+		SetMemMainLanguageCard( m_aSaturnBanks[ m_uSaturnActiveBank ] );
+	}
+	else
+	{
+		memmode &= ~(MF_BANK2 | MF_HIGHRAM);
+
+		if (!(address & 8))
+			memmode |= MF_BANK2;
+
+		if (((address & 2) >> 1) == (address & 1))
+			memmode |= MF_HIGHRAM;
+
+		if (address & 1 && GetLastRamWrite())	// Saturn differs from Apple's 16K LC: any access (LC is read-only)
+			memmode |= MF_WRITERAM;
+		else
+			memmode &= ~MF_WRITERAM;
+
+		SetLastRamWrite(address & 1);	// Saturn differs from Apple's 16K LC: any access (LC is read-only)
+	}
+
+	return memmode;
+}
+
+//
+
+static const UINT kUNIT_SATURN_VER = 1;
+static const UINT kSLOT_SATURN = 0;
+
+#define SS_YAML_VALUE_CARD_SATURN128 "Saturn 128"
+
+#define SS_YAML_KEY_MEMORYMODE "Memory Mode"
+#define SS_YAML_KEY_LASTRAMWRITE "Last RAM Write"
+#define SS_YAML_KEY_NUM_SATURN_BANKS "Num Saturn Banks"
+#define SS_YAML_KEY_ACTIVE_SATURN_BANK "Active Saturn Bank"
+
+std::string Saturn128K::GetSnapshotMemStructName(void)
+{
+	static const std::string name("Memory Bank");
+	return name;
+}
+
+std::string Saturn128K::GetSnapshotCardNameSaturn128(void)
+{
+	static const std::string name(SS_YAML_VALUE_CARD_SATURN128);
+	return name;
+}
+
+std::string Saturn128K::GetSnapshotCardName(void)
+{
+	return GetSnapshotCardNameSaturn128();
+}
+
+void Saturn128K::SaveSnapshot(YamlSaveHelper& yamlSaveHelper)
+{
+	if (!IsApple2PlusOrClone(GetApple2Type()))
+	{
+		_ASSERT(0);
+		LogFileOutput("Warning: Save-state attempted to save Saturn card for //e or above\n");
+		return;	// No Saturn support for //e and above
+	}
+
+	YamlSaveHelper::Slot slot(yamlSaveHelper, GetSnapshotCardName(), kSLOT_SATURN, kUNIT_SATURN_VER);
+	YamlSaveHelper::Label state(yamlSaveHelper, "%s:\n", SS_YAML_KEY_STATE);
+
+	yamlSaveHelper.Save("%s: 0x%02X   # [1..8] 4=64K, 8=128K card\n", SS_YAML_KEY_NUM_SATURN_BANKS, m_uSaturnTotalBanks);
+	yamlSaveHelper.Save("%s: 0x%02X # [0..7]\n", SS_YAML_KEY_ACTIVE_SATURN_BANK, m_uSaturnActiveBank);
+
+	// Technically the Saturn card has it's own state (independent of the Apple //e's internal MMU):
+	// . memmode: WRITERAM, HIGHRAM, BANK2
+	// . g_bLastWriteRam counter
+	// Just duplicate MMU state for now:
+	yamlSaveHelper.SaveHexUint32(SS_YAML_KEY_MEMORYMODE, GetMemMode() & (MF_WRITERAM|MF_HIGHRAM|MF_BANK2));
+	yamlSaveHelper.SaveUint(SS_YAML_KEY_LASTRAMWRITE, GetLastRamWrite() ? 1 : 0);
+
+	for(UINT uBank = 0; uBank < m_uSaturnTotalBanks; uBank++)
+	{
+		LPBYTE pMemBase = m_aSaturnBanks[uBank];
+		YamlSaveHelper::Label state(yamlSaveHelper, "%s%02X:\n", GetSnapshotMemStructName().c_str(), uBank);
+		yamlSaveHelper.SaveMemory(pMemBase, 16*1024);
+	}
+}
+
+bool Saturn128K::LoadSnapshot(YamlLoadHelper& yamlLoadHelper, UINT slot, UINT version)
+{
+	if (slot != kSLOT_SATURN)	// fixme
+		throw std::string("Card: wrong slot");
+
+	if (version != kUNIT_SATURN_VER)
+		throw std::string("Card: wrong version");
+
+	// "State"
+	UINT numBanks   = yamlLoadHelper.LoadUint(SS_YAML_KEY_NUM_SATURN_BANKS);
+	UINT activeBank = yamlLoadHelper.LoadUint(SS_YAML_KEY_ACTIVE_SATURN_BANK);
+	(void) yamlLoadHelper.LoadUint(SS_YAML_KEY_MEMORYMODE);		// Ignore & just use Apple //e MMU's value
+	(void) yamlLoadHelper.LoadUint(SS_YAML_KEY_LASTRAMWRITE);	// Ignore & just use Apple //e MMU's value
+
+	if (numBanks < 1 || numBanks > kMaxSaturnBanks || activeBank >= numBanks)
+		throw std::string(SS_YAML_KEY_UNIT ": Bad Saturn card state");
+
+	m_uSaturnTotalBanks = numBanks;
+	m_uSaturnActiveBank = activeBank;
+
+	//
+
+	for(UINT uBank = 0; uBank < m_uSaturnTotalBanks; uBank++)
+	{
+		LPBYTE pBank = m_aSaturnBanks[uBank];
+		if (!pBank)
+		{
+			pBank = m_aSaturnBanks[uBank] = (LPBYTE) VirtualAlloc(NULL, 16*1024, MEM_COMMIT, PAGE_READWRITE);
+			if (!pBank)
+				throw std::string("Card: mem alloc failed");
+		}
+
+		// "Memory Bankxx"
+		char szBank[3];
+		sprintf(szBank, "%02X", uBank);
+		std::string memName = GetSnapshotMemStructName() + szBank;
+
+		if (!yamlLoadHelper.GetSubMap(memName))
+			throw std::string("Memory: Missing map name: " + memName);
+
+		yamlLoadHelper.LoadMemory(pBank, 16*1024);
+
+		yamlLoadHelper.PopMap();
+	}
+
+	SetExpansionMemType(MEM_TYPE_SATURN);
+	SetMemMainLanguageCard( m_aSaturnBanks[ m_uSaturnActiveBank ] );
+
+	// NB. MemUpdatePaging(TRUE) called at end of Snapshot_LoadState_v2()
+
+	return true;
+}

--- a/source/LanguageCard.h
+++ b/source/LanguageCard.h
@@ -1,0 +1,74 @@
+#pragma once
+
+//
+// Language Card
+//
+
+enum MemoryType_e;
+
+class LanguageCard
+{
+public:
+	LanguageCard(void);
+	virtual ~LanguageCard(void){}
+
+	virtual void Initialize(void){}
+	virtual void Destroy(void){}
+	virtual DWORD SetPaging(WORD address, DWORD memmode)
+	{
+		return 0;	// TODO
+	}
+
+	virtual void SetMemorySize(UINT banks)
+	{
+	}
+	virtual UINT GetActiveBank(void)
+	{
+		return 0;	// Always 0 as only 1x 16K bank
+	}
+
+	virtual std::string GetSnapshotCardName(void)
+	{
+		static const std::string name("Language Card");
+		return name;
+	}
+	virtual void SaveSnapshot(class YamlSaveHelper& yamlSaveHelper) {}
+	virtual bool LoadSnapshot(class YamlLoadHelper& yamlLoadHelper, UINT slot, UINT version)
+	{
+		return false;	// TODO
+	}
+
+	MemoryType_e type;
+};
+
+//
+// Saturn 128K
+//
+
+class Saturn128K : public LanguageCard
+{
+public:
+	Saturn128K(void);
+	virtual ~Saturn128K(void){}
+
+	virtual void Initialize(void);
+	virtual void Destroy(void);
+	virtual DWORD SetPaging(WORD address, DWORD memmode);
+
+	virtual void SetMemorySize(UINT banks);
+	virtual UINT GetActiveBank(void);
+
+	virtual std::string GetSnapshotCardName(void);
+	virtual void SaveSnapshot(class YamlSaveHelper& yamlSaveHelper);
+	virtual bool LoadSnapshot(class YamlLoadHelper& yamlLoadHelper, UINT slot, UINT version);
+
+	static const UINT kMaxSaturnBanks = 8;		// 8 * 16K = 128K
+	static std::string Saturn128K::GetSnapshotCardNameSaturn128(void);
+
+private:
+	std::string Saturn128K::GetSnapshotMemStructName(void);
+
+	UINT m_uSaturnTotalBanks;	// Will be > 0 if Saturn card is installed
+	UINT m_uSaturnActiveBank;	// Saturn 128K Language Card Bank 0 .. 7
+	LPBYTE m_aSaturnBanks[kMaxSaturnBanks];
+};

--- a/source/LanguageCard.h
+++ b/source/LanguageCard.h
@@ -32,7 +32,10 @@ public:
 
 	MemoryType_e type;
 	static const UINT kMemBankSize = 16*1024;
-	static std::string LanguageCard::GetSnapshotCardName(void);
+	static std::string GetSnapshotCardName(void);
+
+protected:
+	void SaveLCState(class YamlSaveHelper& yamlSaveHelper);
 
 private:
 	std::string GetSnapshotMemStructName(void);

--- a/source/LanguageCard.h
+++ b/source/LanguageCard.h
@@ -12,8 +12,8 @@ public:
 	LanguageCard(void);
 	virtual ~LanguageCard(void){}
 
-	virtual void Initialize(void){}
-	virtual void Destroy(void){}
+	virtual void Initialize(void);
+	virtual void Destroy(void);
 	virtual DWORD SetPaging(WORD address, DWORD memmode)
 	{
 		return 0;	// TODO
@@ -27,18 +27,17 @@ public:
 		return 0;	// Always 0 as only 1x 16K bank
 	}
 
-	virtual std::string GetSnapshotCardName(void)
-	{
-		static const std::string name("Language Card");
-		return name;
-	}
-	virtual void SaveSnapshot(class YamlSaveHelper& yamlSaveHelper) {}
-	virtual bool LoadSnapshot(class YamlLoadHelper& yamlLoadHelper, UINT slot, UINT version)
-	{
-		return false;	// TODO
-	}
+	virtual void SaveSnapshot(class YamlSaveHelper& yamlSaveHelper);
+	virtual bool LoadSnapshot(class YamlLoadHelper& yamlLoadHelper, UINT slot, UINT version);
 
 	MemoryType_e type;
+	static const UINT kMemBankSize = 16*1024;
+	static std::string LanguageCard::GetSnapshotCardName(void);
+
+private:
+	std::string GetSnapshotMemStructName(void);
+
+	LPBYTE m_pMemory;
 };
 
 //
@@ -58,15 +57,14 @@ public:
 	virtual void SetMemorySize(UINT banks);
 	virtual UINT GetActiveBank(void);
 
-	virtual std::string GetSnapshotCardName(void);
 	virtual void SaveSnapshot(class YamlSaveHelper& yamlSaveHelper);
 	virtual bool LoadSnapshot(class YamlLoadHelper& yamlLoadHelper, UINT slot, UINT version);
 
 	static const UINT kMaxSaturnBanks = 8;		// 8 * 16K = 128K
-	static std::string Saturn128K::GetSnapshotCardNameSaturn128(void);
+	static std::string GetSnapshotCardName(void);
 
 private:
-	std::string Saturn128K::GetSnapshotMemStructName(void);
+	std::string GetSnapshotMemStructName(void);
 
 	UINT m_uSaturnTotalBanks;	// Will be > 0 if Saturn card is installed
 	UINT m_uSaturnActiveBank;	// Saturn 128K Language Card Bank 0 .. 7

--- a/source/Memory.cpp
+++ b/source/Memory.cpp
@@ -1062,15 +1062,11 @@ static void UpdatePaging(BOOL initialize)
 	{
 		int bankoffset = (SW_BANK2 ? 0 : 0x1000);
 		memshadow[loop] = SW_HIGHRAM ? SW_ALTZP	? memaux+(loop << 8)-bankoffset
-												// memmain+(loop << 8)-bankoffset
-												//: g_aSaturnBanks[g_uSaturnActiveBank]+((loop-0xC0)<<8)-bankoffset
 												: g_pMemMainLanguageCard+((loop-0xC0)<<8)-bankoffset
 									 : memrom+((loop-0xD0) * 0x100);
 
 		memwrite[loop]  = SW_WRITERAM	? SW_HIGHRAM	? mem+(loop << 8)
 														: SW_ALTZP	? memaux+(loop << 8)-bankoffset
-																	// memmain+(loop << 8)-bankoffset
-																	//: g_aSaturnBanks[g_uSaturnActiveBank]+((loop-0xC0)<<8)-bankoffset
 																	: g_pMemMainLanguageCard+((loop-0xC0)<<8)-bankoffset
 										: NULL;
 	}
@@ -1078,15 +1074,11 @@ static void UpdatePaging(BOOL initialize)
 	for (loop = 0xE0; loop < 0x100; loop++)
 	{
 		memshadow[loop] = SW_HIGHRAM	? SW_ALTZP	? memaux+(loop << 8)
-													// memmain+(loop << 8)
-													//: g_aSaturnBanks[g_uSaturnActiveBank]+((loop-0xC0)<<8)
 													: g_pMemMainLanguageCard+((loop-0xC0)<<8)
 										: memrom+((loop-0xD0) * 0x100);
 
 		memwrite[loop]  = SW_WRITERAM	? SW_HIGHRAM	? mem+(loop << 8)
 														: SW_ALTZP	? memaux+(loop << 8)
-																	// memmain+(loop << 8)
-																	//: g_aSaturnBanks[g_uSaturnActiveBank]+((loop-0xC0)<<8)
 																	: g_pMemMainLanguageCard+((loop-0xC0)<<8)
 										: NULL;
 	}

--- a/source/Memory.cpp
+++ b/source/Memory.cpp
@@ -1400,6 +1400,9 @@ void MemInitialize()
 
 	//
 
+	RWpages[0] = memaux;
+	g_pMemMainLanguageCard = memmain+0xC000;
+
 	if (IsApple2PlusOrClone(GetApple2Type()))
 		SetExpansionMemType(g_MemTypeAppleIIPlus);
 	else
@@ -1408,19 +1411,16 @@ void MemInitialize()
 #ifdef RAMWORKS
 	if (GetCurrentExpansionMemType() == MEM_TYPE_RAMWORKS)
 	{
+		// allocate memory for RAMWorks III - up to 8MB
 		_ASSERT(!IsApple2PlusOrClone(GetApple2Type()));
 
-		// allocate memory for RAMWorks III - up to 8MB
 		g_uActiveBank = 0;
-		RWpages[g_uActiveBank] = memaux;
 
 		UINT i = 1;
 		while ((i < g_uMaxExPages) && (RWpages[i] = (LPBYTE) VirtualAlloc(NULL, _6502_MEM_END+1, MEM_COMMIT, PAGE_READWRITE)))
 			i++;
 	}
 #endif
-
-	g_pMemMainLanguageCard = memmain+0xC000;
 
 #ifdef SATURN
 	if (GetCurrentExpansionMemType() == MEM_TYPE_SATURN)
@@ -2193,6 +2193,7 @@ bool MemLoadSnapshot(YamlLoadHelper& yamlLoadHelper)
 
 	ResetDefaultMachineMemTypes();
 	SetExpansionMemType(MEM_TYPE_NATIVE);
+	g_pMemMainLanguageCard = memmain+0xC000;
 
 	modechanging = 0;
 	// NB. MemUpdatePaging(TRUE) called at end of Snapshot_LoadState_v2()
@@ -2396,6 +2397,7 @@ bool Saturn_LoadSnapshot(YamlLoadHelper& yamlLoadHelper, UINT slot, UINT version
 	}
 
 	SetExpansionMemType(MEM_TYPE_SATURN);
+	g_pMemMainLanguageCard = g_aSaturnBanks[ g_uSaturnActiveBank ];
 
 	// NB. MemUpdatePaging(TRUE) called at end of Snapshot_LoadState_v2()
 

--- a/source/Memory.cpp
+++ b/source/Memory.cpp
@@ -1417,6 +1417,9 @@ void MemInitialize()
 	RWpages[0] = memaux;
 	g_pMemMainLanguageCard = memmain+0xC000;
 
+	if (!g_pLanguageCard)
+		g_pLanguageCard = new LanguageCard;		// NB. deleted after a VM restart
+
 	if (IsApple2PlusOrClone(GetApple2Type()))
 		SetExpansionMemType(g_MemTypeAppleIIPlus);
 	else
@@ -1436,8 +1439,6 @@ void MemInitialize()
 	}
 #endif
 
-	if (!g_pLanguageCard)
-		g_pLanguageCard = new LanguageCard;		// NB. deleted after a VM restart
 	g_pLanguageCard->Initialize();
 
 	//
@@ -2097,8 +2098,8 @@ void MemSaveSnapshot(YamlSaveHelper& yamlSaveHelper)
 		yamlSaveHelper.SaveUint(SS_YAML_KEY_PERIPHERALROMSLOT, g_uPeripheralRomSlot);
 	}
 
-	if (g_Slot0 == CT_Saturn128K)
-		MemSaveSnapshotMemory(yamlSaveHelper, true, 0, 48*1024);
+	if (IsApple2PlusOrClone(GetApple2Type()))
+		MemSaveSnapshotMemory(yamlSaveHelper, true, 0, 48*1024);	// NB. Language Card/Saturn provides the remaining 16K (or multiple) bank(s)
 	else
 		MemSaveSnapshotMemory(yamlSaveHelper, true);
 }

--- a/source/Memory.h
+++ b/source/Memory.h
@@ -49,8 +49,6 @@ enum MemoryType_e
 
 typedef BYTE (__stdcall *iofunction)(WORD nPC, WORD nAddr, BYTE nWriteFlag, BYTE nWriteValue, ULONG nExecutedCycles);
 
-extern MemoryType_e	g_eMemType;
-
 extern iofunction IORead[256];
 extern iofunction IOWrite[256];
 extern LPBYTE     memwrite[0x100];
@@ -63,10 +61,7 @@ extern UINT       g_uMaxExPages;	// user requested ram pages (from cmd line)
 extern UINT       g_uActiveBank;
 #endif
 
-#ifdef SATURN
-extern UINT g_uSaturnTotalBanks;
-extern UINT g_uSaturnActiveBank;		// Saturn 128K Language Card Bank 0 .. 7
-#endif // SATURN
+const UINT kMaxSaturnBanks = 8;		// 8 * 16K = 128K
 
 void	RegisterIoHandler(UINT uSlot, iofunction IOReadC0, iofunction IOWriteC0, iofunction IOReadCx, iofunction IOWriteCx, LPVOID lpSlotParameter, BYTE* pExpansionRom);
 
@@ -96,6 +91,11 @@ void    MemSaveSnapshot(class YamlSaveHelper& yamlSaveHelper);
 bool    MemLoadSnapshot(class YamlLoadHelper& yamlLoadHelper);
 void    MemSaveSnapshotAux(class YamlSaveHelper& yamlSaveHelper);
 bool    MemLoadSnapshotAux(class YamlLoadHelper& yamlLoadHelper, UINT version);
+
+void	SetExpansionMemType(MemoryType_e type);
+MemoryType_e GetCurrentExpansionMemType(void);
+void	SetSaturnMemorySize(UINT banks);
+UINT	GetSaturnActiveBank(void);
 
 BYTE __stdcall IO_Null(WORD programcounter, WORD address, BYTE write, BYTE value, ULONG nCycles);
 

--- a/source/Memory.h
+++ b/source/Memory.h
@@ -61,8 +61,6 @@ extern UINT       g_uMaxExPages;	// user requested ram pages (from cmd line)
 extern UINT       g_uActiveBank;
 #endif
 
-const UINT kMaxSaturnBanks = 8;		// 8 * 16K = 128K
-
 void	RegisterIoHandler(UINT uSlot, iofunction IOReadC0, iofunction IOWriteC0, iofunction IOReadCx, iofunction IOWriteCx, LPVOID lpSlotParameter, BYTE* pExpansionRom);
 
 void    MemDestroy ();
@@ -98,10 +96,9 @@ BYTE __stdcall MemSetPaging(WORD pc, WORD addr, BYTE bWrite, BYTE d, ULONG nExec
 
 void	SetExpansionMemType(MemoryType_e type);
 MemoryType_e GetCurrentExpansionMemType(void);
+
 void	SetRamWorksMemorySize(UINT pages);
 UINT	GetRamWorksActiveBank(void);
-void	SetSaturnMemorySize(UINT banks);
-UINT	GetSaturnActiveBank(void);
-std::string Saturn_GetSnapshotCardName(void);
-void Saturn_SaveSnapshot(YamlSaveHelper& yamlSaveHelper);
-bool Saturn_LoadSnapshot(YamlLoadHelper& yamlLoadHelper, UINT slot, UINT version);
+BOOL	GetLastRamWrite(void);
+void	SetLastRamWrite(BOOL count);
+void	SetMemMainLanguageCard(LPBYTE ptr);

--- a/source/Memory.h
+++ b/source/Memory.h
@@ -41,10 +41,11 @@ enum MemoryInitPattern_e
 
 enum MemoryType_e
 {
-	MEM_TYPE_NATIVE   = 0,
-	MEM_TYPE_RAMWORKS = 1,
-	MEM_TYPE_SATURN   = 2,
-	NUM_MEM_TYPE      = 3
+	MEM_TYPE_NATIVE,
+	MEM_TYPE_RAMWORKS,
+	MEM_TYPE_LANGUAGECARD,
+	MEM_TYPE_SATURN,
+	NUM_MEM_TYPE
 };
 
 typedef BYTE (__stdcall *iofunction)(WORD nPC, WORD nAddr, BYTE nWriteFlag, BYTE nWriteValue, ULONG nExecutedCycles);
@@ -102,3 +103,4 @@ UINT	GetRamWorksActiveBank(void);
 BOOL	GetLastRamWrite(void);
 void	SetLastRamWrite(BOOL count);
 void	SetMemMainLanguageCard(LPBYTE ptr);
+class LanguageCard* GetLanguageCard(void);

--- a/source/Memory.h
+++ b/source/Memory.h
@@ -92,11 +92,16 @@ bool    MemLoadSnapshot(class YamlLoadHelper& yamlLoadHelper);
 void    MemSaveSnapshotAux(class YamlSaveHelper& yamlSaveHelper);
 bool    MemLoadSnapshotAux(class YamlLoadHelper& yamlLoadHelper, UINT version);
 
-void	SetExpansionMemType(MemoryType_e type);
-MemoryType_e GetCurrentExpansionMemType(void);
-void	SetSaturnMemorySize(UINT banks);
-UINT	GetSaturnActiveBank(void);
-
 BYTE __stdcall IO_Null(WORD programcounter, WORD address, BYTE write, BYTE value, ULONG nCycles);
 
 BYTE __stdcall MemSetPaging(WORD pc, WORD addr, BYTE bWrite, BYTE d, ULONG nExecutedCycles);
+
+void	SetExpansionMemType(MemoryType_e type);
+MemoryType_e GetCurrentExpansionMemType(void);
+void	SetRamWorksMemorySize(UINT pages);
+UINT	GetRamWorksActiveBank(void);
+void	SetSaturnMemorySize(UINT banks);
+UINT	GetSaturnActiveBank(void);
+std::string Saturn_GetSnapshotCardName(void);
+void Saturn_SaveSnapshot(YamlSaveHelper& yamlSaveHelper);
+bool Saturn_LoadSnapshot(YamlLoadHelper& yamlLoadHelper, UINT slot, UINT version);

--- a/source/SaveState.cpp
+++ b/source/SaveState.cpp
@@ -416,7 +416,13 @@ static void ParseSlots(YamlLoadHelper& yamlLoadHelper, UINT version)
 			m_ConfigNew.m_bEnableHDD = true;
 			type = CT_GenericHDD;
 		}
-		else if (card == Saturn128K::GetSnapshotCardNameSaturn128())
+		else if (card == LanguageCard::GetSnapshotCardName())
+		{
+			SetExpansionMemType(MEM_TYPE_LANGUAGECARD);
+			bRes = GetLanguageCard()->LoadSnapshot(yamlLoadHelper, slot, version);
+			type = CT_LanguageCard;
+		}
+		else if (card == Saturn128K::GetSnapshotCardName())
 		{
 			SetExpansionMemType(MEM_TYPE_SATURN);
 			bRes = GetLanguageCard()->LoadSnapshot(yamlLoadHelper, slot, version);
@@ -599,8 +605,8 @@ void Snapshot_SaveState(void)
 			yamlSaveHelper.UnitHdr(GetSnapshotUnitSlotsName(), UNIT_SLOTS_VER);
 			YamlSaveHelper::Label state(yamlSaveHelper, "%s:\n", SS_YAML_KEY_STATE);
 
-			if (g_Slot0 == CT_Saturn128K)	// TODO: Replace with AppleII/II+ check - but need to implement base LC save/load
-				GetLanguageCard()->SaveSnapshot(yamlSaveHelper);
+			if (IsApple2PlusOrClone(GetApple2Type()))
+				GetLanguageCard()->SaveSnapshot(yamlSaveHelper);	// Language Card or Saturn 128K
 
 			Printer_SaveSnapshot(yamlSaveHelper);
 

--- a/source/SaveState.cpp
+++ b/source/SaveState.cpp
@@ -37,6 +37,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "Frame.h"
 #include "Joystick.h"
 #include "Keyboard.h"
+#include "LanguageCard.h"
 #include "Memory.h"
 #include "Mockingboard.h"
 #include "MouseInterface.h"

--- a/source/SaveState.cpp
+++ b/source/SaveState.cpp
@@ -416,9 +416,10 @@ static void ParseSlots(YamlLoadHelper& yamlLoadHelper, UINT version)
 			m_ConfigNew.m_bEnableHDD = true;
 			type = CT_GenericHDD;
 		}
-		else if (card == Saturn_GetSnapshotCardName())
+		else if (card == Saturn128K::GetSnapshotCardNameSaturn128())
 		{
-			bRes = Saturn_LoadSnapshot(yamlLoadHelper, slot, version);
+			SetExpansionMemType(MEM_TYPE_SATURN);
+			bRes = GetLanguageCard()->LoadSnapshot(yamlLoadHelper, slot, version);
 			type = CT_Saturn128K;
 		}
 		else
@@ -484,7 +485,7 @@ static void Snapshot_LoadState_v2(void)
 		//
 
 		CConfigNeedingRestart ConfigOld;
-		//ConfigOld.m_Slot[0] = CT_LanguageCard;	// fixme
+		//ConfigOld.m_Slot[0] = CT_LanguageCard;	// fixme: II/II+=LC, //e=empty
 		ConfigOld.m_Slot[1] = CT_GenericPrinter;	// fixme
 		ConfigOld.m_Slot[2] = CT_SSC;				// fixme
 		//ConfigOld.m_Slot[3] = CT_Uthernet;		// todo
@@ -598,8 +599,8 @@ void Snapshot_SaveState(void)
 			yamlSaveHelper.UnitHdr(GetSnapshotUnitSlotsName(), UNIT_SLOTS_VER);
 			YamlSaveHelper::Label state(yamlSaveHelper, "%s:\n", SS_YAML_KEY_STATE);
 
-			if (g_Slot0 == CT_Saturn128K)
-				Saturn_SaveSnapshot(yamlSaveHelper);
+			if (g_Slot0 == CT_Saturn128K)	// TODO: Replace with AppleII/II+ check - but need to implement base LC save/load
+				GetLanguageCard()->SaveSnapshot(yamlSaveHelper);
 
 			Printer_SaveSnapshot(yamlSaveHelper);
 

--- a/source/SaveState_Structs_common.h
+++ b/source/SaveState_Structs_common.h
@@ -46,9 +46,6 @@ enum SS_UNIT_TYPE
 const UINT nMemMainSize = 64*1024;
 const UINT nMemAuxSize = 64*1024;
 
-const UINT kSLOT_LANG = 0;
-const UINT kSLOT_AUX = 8;
-
 struct SS_CARD_HDR
 {
 	SS_UNIT_HDR UnitHdr;
@@ -70,10 +67,12 @@ enum SS_CARDTYPE
 	CT_Phasor,			// Soundcard
 	CT_Echo,			// Soundcard
 	CT_SAM,				// Soundcard: Software Automated Mouth
-	CT_80Col,			// 80 column card (no memory)
+	CT_80Col,			// 80 column card (1K)
 	CT_Extended80Col,	// Extended 80-col card (64K)
 	CT_RamWorksIII,		// RamWorksIII (up to 8MB)
 	CT_Uthernet,
+	CT_LanguageCard,	// Apple][ or ][+ in slot-0
+	CT_Saturn128K,		// Saturn 128K (but may be populated with less RAM, in multiples of 16K)
 };
 
 /////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
PR for #408.

Apple II and Apple II+ support for a Language Card or Saturn 128K in slot-0.
NB. Not for Apple //e and above.

Includes full save-state support.
Implementation has been moved to new classes in a new LanguageCard.cpp.