### PR TITLE
Apple II original: default to 48K (ie. no Language Card)

### DIFF
--- a/source/Applewin.cpp
+++ b/source/Applewin.cpp
@@ -1142,6 +1142,7 @@ int APIENTRY WinMain(HINSTANCE passinstance, HINSTANCE, LPSTR lpCmdLine, int)
 	bool bSetFullScreen = false;
 	bool bBoot = false;
 	bool bChangedDisplayResolution = false;
+	bool bSlot0LanguageCard = false;
 	bool bSlot7Empty = false;
 	UINT bestWidth = 0, bestHeight = 0;
 	LPSTR szImageName_drive[NUM_DRIVES] = {NULL,NULL};
@@ -1269,11 +1270,12 @@ int APIENTRY WinMain(HINSTANCE passinstance, HINSTANCE, LPSTR lpCmdLine, int)
 			lpCmdLine = GetCurrArg(lpNextArg);
 			lpNextArg = GetNextArg(lpNextArg);
 
-			// "The boards consist of 16K banks of memory (4 banks for the 64K board, 8 banks for the 128K), accessed one at a time" - Ref: "64K/128K RAM BOARD", Saturn Systems, Ch.1 Introduction(pg-5)
 			if (strcmp(lpCmdLine, "saturn") == 0 || strcmp(lpCmdLine, "saturn128") == 0)
 				uSaturnBanks = Saturn128K::kMaxSaturnBanks;
 			else if (strcmp(lpCmdLine, "saturn64") == 0)
 				uSaturnBanks = Saturn128K::kMaxSaturnBanks/2;
+			else if (strcmp(lpCmdLine, "languagecard") == 0 || strcmp(lpCmdLine, "lc") == 0)
+				bSlot0LanguageCard = true;
 		}
 		else if (strcmp(lpCmdLine, "-f8rom") == 0)		// Use custom 2K ROM at [$F800..$FFFF]
 		{
@@ -1468,6 +1470,12 @@ int APIENTRY WinMain(HINSTANCE passinstance, HINSTANCE, LPSTR lpCmdLine, int)
 			SetSaturnMemorySize(uSaturnBanks);	// Set number of banks before constructing Saturn card
 			SetExpansionMemType(CT_Saturn128K);
 			uSaturnBanks = 0;		// Don't reapply after a restart
+		}
+
+		if (bSlot0LanguageCard)
+		{
+			SetExpansionMemType(CT_LanguageCard);
+			bSlot0LanguageCard = false;	// Don't reapply after a restart
 		}
 
 		DebugInitialize();

--- a/source/Common.h
+++ b/source/Common.h
@@ -193,6 +193,11 @@ enum eApple2Type {
 					A2TYPE_MAX
 				};
 
+inline bool IsApple2Original(eApple2Type type)		// Apple ][
+{
+	return type == A2TYPE_APPLE2;
+}
+
 inline bool IsApple2Plus(eApple2Type type)			// Apple ][,][+
 {
 	return (type & (APPLE2E_MASK|APPLE2C_MASK)) == 0;

--- a/source/LanguageCard.cpp
+++ b/source/LanguageCard.cpp
@@ -44,6 +44,11 @@ LanguageCardUnit::LanguageCardUnit(void) :
 	SetMemMainLanguageCard(NULL, true);
 }
 
+LanguageCardUnit::~LanguageCardUnit(void)
+{
+	SetMemMainLanguageCard(NULL);
+}
+
 DWORD LanguageCardUnit::SetPaging(WORD address, DWORD memmode, BOOL& modechanging, bool write)
 {
 	memmode &= ~(MF_BANK2 | MF_HIGHRAM);

--- a/source/LanguageCard.h
+++ b/source/LanguageCard.h
@@ -8,7 +8,7 @@ class LanguageCardUnit
 {
 public:
 	LanguageCardUnit(void);
-	virtual ~LanguageCardUnit(void) {}
+	virtual ~LanguageCardUnit(void);
 
 	virtual DWORD SetPaging(WORD address, DWORD memmode, BOOL& modechanging, bool write);
 	virtual void SetMemorySize(UINT banks) {}		// No-op for //e and slot-0 16K LC

--- a/source/LanguageCard.h
+++ b/source/LanguageCard.h
@@ -71,6 +71,7 @@ public:
 	virtual void SaveSnapshot(class YamlSaveHelper& yamlSaveHelper);
 	virtual bool LoadSnapshot(class YamlLoadHelper& yamlLoadHelper, UINT slot, UINT version);
 
+	// "The boards consist of 16K banks of memory (4 banks for the 64K board, 8 banks for the 128K), accessed one at a time" - Ref: "64K/128K RAM BOARD", Saturn Systems, Ch.1 Introduction(pg-5)
 	static const UINT kMaxSaturnBanks = 8;		// 8 * 16K = 128K
 	static std::string GetSnapshotCardName(void);
 

--- a/source/Memory.cpp
+++ b/source/Memory.cpp
@@ -262,12 +262,12 @@ void SetExpansionMemType(const SS_CARDTYPE type)
 		newSlotAuxCard = CT_Extended80Col;
 	}
 
-	if (type == CT_Saturn128K)
+	if (type == CT_LanguageCard || type == CT_Saturn128K)
 	{
 		g_MemTypeAppleII = type;
 		g_MemTypeAppleIIPlus = type;
 		if (IsApple2PlusOrClone(GetApple2Type()))
-			newSlot0Card = CT_Saturn128K;
+			newSlot0Card = type;
 		else
 			newSlot0Card = CT_Empty;	// NB. No slot0 for //e
 	}
@@ -277,7 +277,7 @@ void SetExpansionMemType(const SS_CARDTYPE type)
 		if (IsApple2PlusOrClone(GetApple2Type()))
 			newSlotAuxCard = CT_Empty;	// NB. No aux slot for ][ or ][+
 		else
-			newSlotAuxCard = CT_RamWorksIII;
+			newSlotAuxCard = type;
 	}
 
 	if (IsApple2PlusOrClone(GetApple2Type()))

--- a/source/Memory.cpp
+++ b/source/Memory.cpp
@@ -283,7 +283,6 @@ void SetExpansionMemType(const SS_CARDTYPE type)
 	if (IsApple2PlusOrClone(GetApple2Type()))
 	{
 		delete g_pLanguageCard;
-		_ASSERT(g_pMemMainLanguageCard == NULL);	// TODO: should be set NULL by dtor
 
 		if (newSlot0Card == CT_Saturn128K)
 			g_pLanguageCard = new Saturn128K(g_uSaturnBanksFromCmdLine);
@@ -1188,7 +1187,6 @@ void MemDestroy()
 
 	delete g_pLanguageCard;
 	g_pLanguageCard = NULL;
-	g_pMemMainLanguageCard = NULL;
 
 	memaux   = NULL;
 	memmain  = NULL;

--- a/source/SaveState.cpp
+++ b/source/SaveState.cpp
@@ -605,7 +605,7 @@ void Snapshot_SaveState(void)
 			yamlSaveHelper.UnitHdr(GetSnapshotUnitSlotsName(), UNIT_SLOTS_VER);
 			YamlSaveHelper::Label state(yamlSaveHelper, "%s:\n", SS_YAML_KEY_STATE);
 
-			if (IsApple2PlusOrClone(GetApple2Type()))
+			if (g_Slot0 != CT_Empty && IsApple2PlusOrClone(GetApple2Type()))
 				GetLanguageCard()->SaveSnapshot(yamlSaveHelper);	// Language Card or Saturn 128K
 
 			Printer_SaveSnapshot(yamlSaveHelper);


### PR DESCRIPTION
PR for #590.

Apple II original defaults to no LC in slot-0.

Adds new cmd-line switches: `-s0 <languagecard|lc>` to enable LC in slot-0.
When LC is enabled, it replaces the Apple II's F8 ROM with the II+'s F8 auto-start ROM.