### PR TITLE
Add support for PAL/bilingual or custom 8K video ROMs

### DIFF
--- a/resource/Applewin.rc
+++ b/resource/Applewin.rc
@@ -252,8 +252,8 @@ DISK_ICON               ICON                    "DISK.ICO"
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 1,27,10,0
- PRODUCTVERSION 1,27,10,0
+ FILEVERSION 1,27,11,0
+ PRODUCTVERSION 1,27,11,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -271,12 +271,12 @@ BEGIN
             VALUE "Comments", "https://github.com/AppleWin"
             VALUE "CompanyName", "AppleWin"
             VALUE "FileDescription", "Apple //e Emulator for Windows"
-            VALUE "FileVersion", "1, 27, 10, 0"
+            VALUE "FileVersion", "1, 27, 11, 0"
             VALUE "InternalName", "APPLEWIN"
             VALUE "LegalCopyright", " 1994-2018 Michael O'Brien, Oliver Schmidt, Tom Charlesworth, Michael Pohoreski, Nick Westgate, Linards Ticmanis"
             VALUE "OriginalFilename", "APPLEWIN.EXE"
             VALUE "ProductName", "Apple //e Emulator"
-            VALUE "ProductVersion", "1, 27, 10, 0"
+            VALUE "ProductVersion", "1, 27, 11, 0"
         END
     END
     BLOCK "VarFileInfo"

--- a/source/Applewin.cpp
+++ b/source/Applewin.cpp
@@ -1294,11 +1294,15 @@ int APIENTRY WinMain(HINSTANCE passinstance, HINSTANCE, LPSTR lpCmdLine, int)
 			lpCmdLine = GetCurrArg(lpNextArg);
 			lpNextArg = GetNextArg(lpNextArg);
 
-			if (!Video_ReadVideoRomFile(lpCmdLine))
+			if (!ReadVideoRomFile(lpCmdLine))
 			{
 				std::string msg = "Failed to load video rom (not found or not exactly 4/8/16KiB)";
 				LogFileOutput("%s", msg.c_str());
 				MessageBox(g_hFrameWindow, msg.c_str(), TEXT("AppleWin Error"), MB_OK);
+			}
+			else
+			{
+				SetVideoRomRockerSwitch(true);	// Use PAL char set
 			}
 		}
 		else if (strcmp(lpCmdLine, "-printscreen") == 0)		// Turn on display of the last filename print screen was saved to

--- a/source/Applewin.cpp
+++ b/source/Applewin.cpp
@@ -1289,6 +1289,18 @@ int APIENTRY WinMain(HINSTANCE passinstance, HINSTANCE, LPSTR lpCmdLine, int)
 			if ((g_hCustomRomF8 == INVALID_HANDLE_VALUE) || (GetFileSize(g_hCustomRomF8, NULL) != 0x800))
 				g_bCustomRomF8Failed = true;
 		}
+		else if (strcmp(lpCmdLine, "-videorom") == 0)			// Use 4K,8K or 16K video ROM for Enhanced //e
+		{
+			lpCmdLine = GetCurrArg(lpNextArg);
+			lpNextArg = GetNextArg(lpNextArg);
+
+			if (!Video_ReadVideoRomFile(lpCmdLine))
+			{
+				std::string msg = "Failed to load video rom (not found or not exactly 4/8/16KiB)";
+				LogFileOutput("%s", msg.c_str());
+				MessageBox(g_hFrameWindow, msg.c_str(), TEXT("AppleWin Error"), MB_OK);
+			}
+		}
 		else if (strcmp(lpCmdLine, "-printscreen") == 0)		// Turn on display of the last filename print screen was saved to
 		{
 			g_bDisplayPrintScreenFileName = true;
@@ -1553,7 +1565,9 @@ int APIENTRY WinMain(HINSTANCE passinstance, HINSTANCE, LPSTR lpCmdLine, int)
 
 		if (g_bCustomRomF8Failed)
 		{
-			MessageBox(g_hFrameWindow, "Failed to load custom F8 rom (not found or not exactly 2KB)", TEXT("AppleWin Error"), MB_OK);
+			std::string msg = "Failed to load custom F8 rom (not found or not exactly 2KiB)";
+			LogFileOutput("%s", msg.c_str());
+			MessageBox(g_hFrameWindow, msg.c_str(), TEXT("AppleWin Error"), MB_OK);
 			bShutdown = true;
 		}
 

--- a/source/Debugger/Debugger_Display.cpp
+++ b/source/Debugger/Debugger_Display.cpp
@@ -3089,7 +3089,7 @@ void DrawSoftSwitches( int iSoftSwitch )
 		_DrawSoftSwitch( rect, 0xC00C, bSet, "Col", "40", "80", NULL, bgMemory );
 
 		// C00E = off, C00F = on
-		bSet = VideoGetSWAltCharSet();
+		bSet = !VideoGetSWAltCharSet();
 		_DrawSoftSwitch( rect, 0xC00E, bSet, NULL, "ASC", "MOUS", NULL, bgMemory ); // ASCII/MouseText
 
 #if SOFTSWITCH_LANGCARD

--- a/source/Frame.cpp
+++ b/source/Frame.cpp
@@ -1316,13 +1316,18 @@ LRESULT CALLBACK FrameWndProc (
 		}
 		else if (wparam == VK_F10)
 		{
-			if (g_Apple2Type == A2TYPE_PRAVETS8A && !KeybGetCtrlStatus())
-			{
-				KeybToggleP8ACapsLock ();	// F10: Toggles P8 Capslock
-			}
-			else
+			if (KeybGetCtrlStatus())
 			{
 				SetUsingCursor(FALSE);		// Ctrl+F10
+			}
+			else if (g_Apple2Type == A2TYPE_APPLE2E || g_Apple2Type == A2TYPE_APPLE2EENHANCED)
+			{
+				SetVideoRomRockerSwitch( !GetVideoRomRockerSwitch() );	// F10: toggle rocker switch
+				NTSC_VideoInitAppleType();
+			}
+			else if (g_Apple2Type == A2TYPE_PRAVETS8A)
+			{
+				KeybToggleP8ACapsLock ();	// F10: Toggles Pravets8A Capslock
 			}
 		}
 		else if (wparam == VK_F11 && !KeybGetCtrlStatus())	// Save state (F11)
@@ -1758,7 +1763,6 @@ LRESULT CALLBACK FrameWndProc (
 		KeybUpdateCtrlShiftStatus();
 
 		// http://msdn.microsoft.com/en-us/library/windows/desktop/gg153546(v=vs.85).aspx
-		// v1.25.0: Alt-Return Alt-Enter toggle fullscreen
 		if (g_bAltEnter_ToggleFullScreen && KeybGetAltStatus() && (wparam == VK_RETURN)) // NB. VK_RETURN = 0x0D; Normally WM_CHAR will be 0x0A but ALT key triggers as WM_SYSKEYDOWN and VK_MENU
 			return 0; // NOP -- eat key
 
@@ -1772,7 +1776,10 @@ LRESULT CALLBACK FrameWndProc (
 	case WM_SYSKEYUP:
 		KeybUpdateCtrlShiftStatus();
 
-		// v1.25.0: Alt-Return Alt-Enter toggle fullscreen
+		// F10: no WM_KEYUP handler for VK_F10. Don't allow WM_KEYUP to pass to default handler which will show the app window's "menu" (and lose focus)
+		if (wparam == VK_F10)
+			return 0;
+
 		if (g_bAltEnter_ToggleFullScreen && KeybGetAltStatus() && (wparam == VK_RETURN)) // NB. VK_RETURN = 0x0D; Normally WM_CHAR will be 0x0A but ALT key triggers as WM_SYSKEYDOWN and VK_MENU
 			ScreenWindowResize(false);
 		else

--- a/source/NTSC.cpp
+++ b/source/NTSC.cpp
@@ -471,7 +471,7 @@ static void set_csbits()
 	case A2TYPE_APPLE2:			csbits = &csbits_a2[0];         g_nVideoCharSet = 0; break;
 	case A2TYPE_APPLE2PLUS:		csbits = &csbits_a2[0];         g_nVideoCharSet = 0; break;
 	case A2TYPE_APPLE2E:		csbits = &csbits_2e[0];			break;
-	case A2TYPE_APPLE2EENHANCED:csbits = &csbits_enhanced2e[0]; break;
+	case A2TYPE_APPLE2EENHANCED:csbits = GetEnhanced2e_csbits(); break;
 	case A2TYPE_PRAVETS82:	    csbits = &csbits_pravets82[0];  g_nVideoCharSet = 0; break;	// Apple ][ clone
 	case A2TYPE_PRAVETS8M:	    csbits = &csbits_pravets8M[0];  g_nVideoCharSet = 0; break;	// Apple ][ clone
 	case A2TYPE_PRAVETS8A:	    csbits = &csbits_pravets8C[0];  break;	// Apple //e clone

--- a/source/NTSC_CharSet.cpp
+++ b/source/NTSC_CharSet.cpp
@@ -163,7 +163,6 @@ void userVideoRom(void)
 
 	if (size == 4*1024)
 	{
-		// TODO: test
 		userVideoRom4K(&csbits_enhanced2e[0], pVideoRom);
 		return;
 	}

--- a/source/NTSC_CharSet.cpp
+++ b/source/NTSC_CharSet.cpp
@@ -161,7 +161,7 @@ void userVideoRom(void)
 	if (!size)
 		return;
 
-	if (size == 4*1024)
+	if (size == kVideoRomSize4K)
 	{
 		userVideoRom4K(&csbits_enhanced2e[0], pVideoRom);
 		return;

--- a/source/NTSC_CharSet.h
+++ b/source/NTSC_CharSet.h
@@ -2,7 +2,7 @@
 
 typedef unsigned char (*csbits_t)[256][8];
 
-extern unsigned char csbits_enhanced2e[2][256][8];	// Enhanced //e
+extern unsigned char csbits_enhanced2e[2][256][8];	// Enhanced //e (2732 4K video ROM)
 extern unsigned char csbits_2e[2][256][8];			// Original //e (no mousetext)
 extern unsigned char csbits_a2[1][256][8];			// ][ and ][+
 extern unsigned char csbits_pravets82[1][256][8];	// Pravets 82
@@ -10,3 +10,4 @@ extern unsigned char csbits_pravets8M[1][256][8];	// Pravets 8M
 extern unsigned char csbits_pravets8C[2][256][8];	// Pravets 8A & 8C
 
 void make_csbits(void);
+csbits_t GetEnhanced2e_csbits(void);

--- a/source/Video.cpp
+++ b/source/Video.cpp
@@ -647,7 +647,7 @@ void VideoResetState ()
 
 //===========================================================================
 
-BYTE VideoSetMode (WORD, WORD address, BYTE write, BYTE, ULONG uExecutedCycles)
+BYTE VideoSetMode(WORD, WORD address, BYTE write, BYTE, ULONG uExecutedCycles)
 {
 	address &= 0xFF;
 
@@ -1150,8 +1150,9 @@ static const UINT kVideoRomSize16K = kVideoRomSize8K*2;
 static const UINT kVideoRomSizeMax = kVideoRomSize16K;
 static BYTE g_videoRom[kVideoRomSizeMax];
 static UINT g_videoRomSize = 0;
+static bool g_videoRomRockerSwitch = false;
 
-bool Video_ReadVideoRomFile(const char* pRomFile)
+bool ReadVideoRomFile(const char* pRomFile)
 {
 	g_videoRomSize = 0;
 
@@ -1179,10 +1180,25 @@ bool Video_ReadVideoRomFile(const char* pRomFile)
 	return g_videoRomSize != 0;
 }
 
-UINT Video_GetVideoRom(const BYTE*& pVideoRom)
+UINT GetVideoRom(const BYTE*& pVideoRom)
 {
 	pVideoRom = &g_videoRom[0];
 	return g_videoRomSize;
+}
+
+bool GetVideoRomRockerSwitch(void)
+{
+	return g_videoRomRockerSwitch;
+}
+
+void SetVideoRomRockerSwitch(bool state)
+{
+	g_videoRomRockerSwitch = state;
+}
+
+bool IsVideoRom4K(void)
+{
+	return g_videoRomSize == 0 || g_videoRomSize == kVideoRomSize4K;
 }
 
 //===========================================================================

--- a/source/Video.cpp
+++ b/source/Video.cpp
@@ -1144,7 +1144,6 @@ static void Video_SaveScreenShot( const char *pScreenShotFileName, const VideoSc
 
 //===========================================================================
 
-static const UINT kVideoRomSize4K = 4*1024;
 static const UINT kVideoRomSize8K = kVideoRomSize4K*2;
 static const UINT kVideoRomSize16K = kVideoRomSize8K*2;
 static const UINT kVideoRomSizeMax = kVideoRomSize16K;

--- a/source/Video.cpp
+++ b/source/Video.cpp
@@ -1141,6 +1141,36 @@ static void Video_SaveScreenShot( const char *pScreenShotFileName, const VideoSc
 	}
 }
 
+
+//===========================================================================
+
+static const UINT kVideoRomSize4K = 4*1024;
+static const UINT kVideoRomSize8K = kVideoRomSize4K*2;
+static const UINT kVideoRomSize16K = kVideoRomSize8K*2;
+static const UINT kVideoRomSizeMax = kVideoRomSize16K;
+static BYTE g_videoRom[kVideoRomSizeMax];
+
+bool Video_ReadVideoRomFile(const char* pRomFile)
+{
+	HANDLE h = CreateFile(pRomFile, GENERIC_READ, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_READONLY, NULL);
+	if (h == INVALID_HANDLE_VALUE)
+		return false;
+
+	bool res = false;
+
+	const ULONG size = GetFileSize(h, NULL);
+	if (size == kVideoRomSize4K || size == kVideoRomSize8K || size == kVideoRomSize16K)
+	{
+		DWORD bytesRead;
+		if (ReadFile(h, g_videoRom, size, &bytesRead, NULL) && bytesRead == size)
+			res = true;
+	}
+
+	CloseHandle(h);
+
+	return res;
+}
+
 //===========================================================================
 
 void Config_Load_Video()
@@ -1159,8 +1189,6 @@ void Config_Save_Video()
 	REGSAVE(TEXT(REGVALUE_VIDEO_HALF_SCAN_LINES),g_uHalfScanLines);
 	REGSAVE(TEXT(REGVALUE_VIDEO_MONO_COLOR     ),g_nMonochromeRGB);
 }
-
-// ____________________________________________________________________
 
 //===========================================================================
 static void videoCreateDIBSection()

--- a/source/Video.h
+++ b/source/Video.h
@@ -198,10 +198,13 @@ enum VideoScreenShot_e
 void Video_TakeScreenShot( VideoScreenShot_e iScreenShotType );
 void Video_SetBitmapHeader( WinBmpHeader_t *pBmp, int nWidth, int nHeight, int nBitsPerPixel );
 
-BYTE VideoSetMode (WORD pc, WORD addr, BYTE bWrite, BYTE d, ULONG uExecutedCycles);
-UINT Video_GetVideoRom(const BYTE*& pVideoRom);
+BYTE VideoSetMode(WORD pc, WORD addr, BYTE bWrite, BYTE d, ULONG uExecutedCycles);
 
-bool Video_ReadVideoRomFile(const char* pRomFile);
+bool ReadVideoRomFile(const char* pRomFile);
+UINT GetVideoRom(const BYTE*& pVideoRom);
+bool GetVideoRomRockerSwitch(void);
+void SetVideoRomRockerSwitch(bool state);
+bool IsVideoRom4K(void);
 
 void Config_Load_Video(void);
 void Config_Save_Video(void);

--- a/source/Video.h
+++ b/source/Video.h
@@ -200,5 +200,7 @@ void Video_SetBitmapHeader( WinBmpHeader_t *pBmp, int nWidth, int nHeight, int n
 
 BYTE VideoSetMode (WORD pc, WORD addr, BYTE bWrite, BYTE d, ULONG uExecutedCycles);
 
+bool Video_ReadVideoRomFile(const char* pRomFile);
+
 void Config_Load_Video(void);
 void Config_Save_Video(void);

--- a/source/Video.h
+++ b/source/Video.h
@@ -199,6 +199,7 @@ void Video_TakeScreenShot( VideoScreenShot_e iScreenShotType );
 void Video_SetBitmapHeader( WinBmpHeader_t *pBmp, int nWidth, int nHeight, int nBitsPerPixel );
 
 BYTE VideoSetMode (WORD pc, WORD addr, BYTE bWrite, BYTE d, ULONG uExecutedCycles);
+UINT Video_GetVideoRom(const BYTE*& pVideoRom);
 
 bool Video_ReadVideoRomFile(const char* pRomFile);
 

--- a/source/Video.h
+++ b/source/Video.h
@@ -200,6 +200,7 @@ void Video_SetBitmapHeader( WinBmpHeader_t *pBmp, int nWidth, int nHeight, int n
 
 BYTE VideoSetMode(WORD pc, WORD addr, BYTE bWrite, BYTE d, ULONG uExecutedCycles);
 
+const UINT kVideoRomSize4K = 4*1024;
 bool ReadVideoRomFile(const char* pRomFile);
 UINT GetVideoRom(const BYTE*& pVideoRom);
 bool GetVideoRomRockerSwitch(void);


### PR DESCRIPTION
PR for #574.

Adds new cmd-line switches: -videorom <filename> to replace the video ROM for the Enhanced //e.
ROM sizes of 4K, 8K and 16K (top 8K only) are supported.
NB. The rocker switch is set to European video ROM.

F10 (for //e or Enhanced //e models) emulates the PAL //e's rocker switch (under the keyboard) to toggle between European or US video ROM.

Other:
. Fixed debugger's view of the AltCharSet soft-switch (it was showing the opposite state).