### PR TITLE
Convert files with special characters to UTF-8

### DIFF
--- a/AppleWinExpress2017.vcxproj
+++ b/AppleWinExpress2017.vcxproj
@@ -369,6 +369,7 @@
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>source\cpu;source\emulator;source\debugger;zlib;zip_lib;libyaml\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -393,6 +394,7 @@
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>source\cpu;source\emulator;source\debugger;zlib;zip_lib;libyaml\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -420,6 +422,7 @@
       <AdditionalIncludeDirectories>source\cpu;source\emulator;source\debugger;zlib;zip_lib;libyaml\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -450,6 +453,7 @@
       <AdditionalIncludeDirectories>source\cpu;source\emulator;source\debugger;zlib;zip_lib;libyaml\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/bin/History.txt
+++ b/bin/History.txt
@@ -707,8 +707,8 @@ Beta builds for specific testers
 . Support for Pravets 82. Caps Lock serves as Lat/Cyr lock. The charset still needs a little fix (all characters have to be one row down).
 . Some partial support for Pravets 8A. Caps Lock serves as Lat/Cyr lock, and F10 serves as Caps Lock.
 In Pravets 8A mode the former behaviour of the F10 key is preserved as Ctrl+F10 (see Help/Keyboard for details).
-Extended Basic and Miniassembler work, but there are still problems with the 8 bit charset (œ‡ËÒ [Parris] does not switch to latin characters).
-Some keys have to be remapped, because currently they are not available (i.e. ›). There is still the problem that there is not enough space for this key on the keyboard.
+Extended Basic and Miniassembler work, but there are still problems with the 8 bit charset (√è√†√∞√®√± [Parris] does not switch to latin characters).
+Some keys have to be remapped, because currently they are not available (i.e. √ù). There is still the problem that there is not enough space for this key on the keyboard.
 . Added Send to CiderPress function via the popup menu of the drive buttons.
 
 1.14.1.2 - 2 Dec 2007 (beta)

--- a/docs/ToDo.txt
+++ b/docs/ToDo.txt
@@ -36,10 +36,10 @@ To support Bob Bishop's intros, tight-loop page-flipping, etc
 Plans for (1st pass) cleaning up are:
 . Ditch the x86 code to access the PC speaker + ditch PC speaker support
 . [DONE] The arrays ioread[] & iowrite[] in Memory.cpp should be switched from units of 1 byte to 16 bytes.
-  This will yield 256 entries spanning [$C000…$CFFF] – currently it’s only [$C000…$C0FF]. This will mean that:
-	a) cards with I/O mapped above $C0FF (eg Mockingboard, Mouse?) don’t have to be kludged as in the READ/WRITE macros in CPU.cpp
+  This will yield 256 entries spanning [$C000â€¦$CFFF] â€“ currently itâ€™s only [$C000â€¦$C0FF]. This will mean that:
+	a) cards with I/O mapped above $C0FF (eg Mockingboard, Mouse?) donâ€™t have to be kludged as in the READ/WRITE macros in CPU.cpp
 	b) $CFFF (ROMs out) can be emulated
-. Talking of CPU.cpp & those macros: I’d prefer to replace them with inline funcs. Maintenance of these
-  macros is a bitch & they can’t be single-stepped. Inline funs should yield the same code (in release build)
+. Talking of CPU.cpp & those macros: Iâ€™d prefer to replace them with inline funcs. Maintenance of these
+  macros is a bitch & they canâ€™t be single-stepped. Inline funs should yield the same code (in release build)
   as the macros.
 

--- a/source/CommonVICE/interrupt.h
+++ b/source/CommonVICE/interrupt.h
@@ -3,7 +3,7 @@
  *
  * Written by
  *  Ettore Perazzoli <ettore@comm2000.it>
- *  André Fachat <fachat@physik.tu-chemnitz.de>
+ *  AndrÃ© Fachat <fachat@physik.tu-chemnitz.de>
  *  Andreas Boose <viceteam@t-online.de>
  *
  * This file is part of VICE, the Versatile Commodore Emulator.

--- a/source/CommonVICE/mem.h
+++ b/source/CommonVICE/mem.h
@@ -2,7 +2,7 @@
  * mem.h - Memory interface.
  *
  * Written by
- *  André Fachat <fachat@physik.tu-chemnitz.de>
+ *  AndrÃ© Fachat <fachat@physik.tu-chemnitz.de>
  *  Ettore Perazzoli <ettore@comm2000.it>
  *  Andreas Boose <viceteam@t-online.de>
  *

--- a/source/CommonVICE/types.h
+++ b/source/CommonVICE/types.h
@@ -3,7 +3,7 @@
  *
  * Written by
  *  Ettore Perazzoli <ettore@comm2000.it>
- *  André Fachat <a.fachat@physik.tu-chemnitz.de>
+ *  AndrÃ© Fachat <a.fachat@physik.tu-chemnitz.de>
  *  Teemu Rantanen <tvr@cs.hut.fi>
  *  Andreas Boose <viceteam@t-online.de>
  *

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -9361,7 +9361,7 @@ void DebuggerProcessKey( int keycode )
 		}		
 	}
 	else if (( keycode == VK_OEM_3 ) ||	// US: Tilde ~ (key to the immediate left of numeral 1)
-			 ( keycode == VK_OEM_8 ))	// UK: Logical NOT ¬ (key to the immediate left of numeral 1)
+			 ( keycode == VK_OEM_8 ))	// UK: Logical NOT Â¬ (key to the immediate left of numeral 1)
 	{
 		if (KeybGetCtrlStatus())
 		{

--- a/source/Keyboard.cpp
+++ b/source/Keyboard.cpp
@@ -195,7 +195,7 @@ void KeybQueueKeypress (WPARAM key, Keystroke_e bASCII)
 					if (key == 92) keycode = 96;
 					if (GetCapsLockAllowed() == true)
 					{
-						if ((key == 92) || (key == 124)) keycode = 96; //İ to Ş
+						if ((key == 92) || (key == 124)) keycode = 96; //Ã to Ã
 						//This shall be rewriten, so that enabling CAPS_LOCK (i.e. F10) will not invert these keys values)
 						//The same for latin letters.
 						if ((key == '{') || (key == '}') || (key == '~') || (key == 124) || (key == '^') ||  (key == 95))
@@ -231,24 +231,24 @@ void KeybQueueKeypress (WPARAM key, Keystroke_e bASCII)
 				}
 			}
 			// Remap for the TK3000 //e, which had a special |Mode| key for displaying accented chars on screen
-			// Borrowed from Fábio Belavenuto's TK3000e emulator (Copyright (C) 2004) - http://code.google.com/p/tk3000e/
+			// Borrowed from FÃ¡bio Belavenuto's TK3000e emulator (Copyright (C) 2004) - http://code.google.com/p/tk3000e/
 			if (g_bTK3KModeKey)	// We already switch this on only if the the TK3000 is currently being emulated
 			{
 				if ((key >= 0xC0) && (key <= 0xDA)) key += 0x20; // Convert uppercase to lowercase
 				switch (key)
 				{
-					case 0xE0: key = '_';  break; // à
-					case 0xE1: key = '@';  break; // á
-					case 0xE2: key = '\\'; break; // â
-					case 0xE3: key = '[';  break; // ã
-					case 0xE7: key = ']';  break; // ç
-					case 0xE9: key = '`';  break; // é
-					case 0xEA: key = '&';  break; // ê
-					case 0xED: key = '{';  break; // í
-					case 0xF3: key = '~';  break; // ó
-					case 0xF4: key = '}';  break; // ô
-					case 0xF5: key = '#';  break; // õ
-					case 0xFA: key = '|';  break; // ú
+					case 0xE0: key = '_';  break; // Ã 
+					case 0xE1: key = '@';  break; // Ã¡
+					case 0xE2: key = '\\'; break; // Ã¢
+					case 0xE3: key = '[';  break; // Ã£
+					case 0xE7: key = ']';  break; // Ã§
+					case 0xE9: key = '`';  break; // Ã©
+					case 0xEA: key = '&';  break; // Ãª
+					case 0xED: key = '{';  break; // Ã­
+					case 0xF3: key = '~';  break; // Ã³
+					case 0xF4: key = '}';  break; // Ã´
+					case 0xF5: key = '#';  break; // Ãµ
+					case 0xFA: key = '|';  break; // Ãº
 				}
 				if (key > 0x7F) return;	// Get out
 				if ((key >= 'a') && (key <= 'z') && (g_bCapsLock))

--- a/source/ParallelPrinter.cpp
+++ b/source/ParallelPrinter.cpp
@@ -161,9 +161,9 @@ static BYTE __stdcall PrintTransmit(WORD, WORD, BYTE, BYTE value, ULONG)
 {
 	         char Lat8A[]= "abwgdevzijklmnoprstufhc~{}yx`q|]";
              char Lat82[]= "abwgdevzijklmnoprstufhc^[]yx@q{}~`"; 
-			 char Kir82[]= "ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏĞÑÒÓÔÕÖ×ØÙÚÜŞß[]^@";
-	  char Kir8ACapital[]= "ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏĞÑÒÓÔÕÖ×ØÙÚÜŞßİ";
-	char Kir8ALowerCase[]= "àáâãäåæçèéêëìíîïğñòóôõö÷øùúüşÿı";
+			 char Kir82[]= "Ã€ÃÃ‚ÃƒÃ„Ã…Ã†Ã‡ÃˆÃ‰ÃŠÃ‹ÃŒÃÃÃÃÃ‘Ã’Ã“Ã”Ã•Ã–Ã—Ã˜Ã™ÃšÃœÃÃŸ[]^@";
+	  char Kir8ACapital[]= "Ã€ÃÃ‚ÃƒÃ„Ã…Ã†Ã‡ÃˆÃ‰ÃŠÃ‹ÃŒÃÃÃÃÃ‘Ã’Ã“Ã”Ã•Ã–Ã—Ã˜Ã™ÃšÃœÃÃŸÃ";
+	char Kir8ALowerCase[]= "Ã Ã¡Ã¢Ã£Ã¤Ã¥Ã¦Ã§Ã¨Ã©ÃªÃ«Ã¬Ã­Ã®Ã¯Ã°Ã±Ã²Ã³Ã´ÃµÃ¶Ã·Ã¸Ã¹ÃºÃ¼Ã¾Ã¿Ã½";
 	bool Pres = false;
     if (!CheckPrint())
     {

--- a/source/z80emu.cpp
+++ b/source/z80emu.cpp
@@ -1,13 +1,13 @@
 /*  Emulador do computador TK3000 //e (Microdigital)
- *  por Fábio Belavenuto - Copyright (C) 2004
+ *  por FÃ¡bio Belavenuto - Copyright (C) 2004
  *
  *  Adaptado do emulador Applewin por Michael O'Brien
  *  Part of code is Copyright (C) 2003-2004 Tom Charlesworth
  *
- *  Este arquivo é distribuido pela Licença Pública Geral GNU.
+ *  Este arquivo Ã© distribuido pela LicenÃ§a PÃºblica Geral GNU.
  *  Veja o arquivo Licenca.txt distribuido com este software.
  *
- *  ESTE SOFTWARE NÃO OFERECE NENHUMA GARANTIA
+ *  ESTE SOFTWARE NÃƒO OFERECE NENHUMA GARANTIA
  *
  */
 

--- a/source/z80emu.h
+++ b/source/z80emu.h
@@ -1,18 +1,18 @@
 /*  Emulador do computador TK3000 //e (Microdigital)
- *  por Fábio Belavenuto - Copyright (C) 2004
+ *  por FÃ¡bio Belavenuto - Copyright (C) 2004
  *
  *  Adaptado do emulador Applewin por Michael O'Brien
  *
- *  Este arquivo é distribuido pela Licença Pública Geral GNU.
+ *  Este arquivo Ã© distribuido pela LicenÃ§a PÃºblica Geral GNU.
  *  Veja o arquivo Licenca.txt distribuido com este software.
  *
- *  ESTE SOFTWARE NÃO OFERECE NENHUMA GARANTIA
+ *  ESTE SOFTWARE NÃƒO OFERECE NENHUMA GARANTIA
  *
  */
 
 // Emula a CPU Z80
 
-// Protótipos
+// ProtÃ³tipos
 void ConfigureSoftcard(LPBYTE pCxRomPeripheral, UINT uSlot);
 
 // NB. These are in z80.cpp:


### PR DESCRIPTION
Compilation fails on some of these files on computers with certain locales (e.g. CJK) otherwise.