### PR TITLE
Ignore VS2017 database/IntelliSense folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,6 +159,7 @@ ClientBin/
 *.pfx
 *.publishsettings
 node_modules/
+.vs/
 
 # RIA/Silverlight projects
 Generated_Code/


### PR DESCRIPTION
Just a cache directory missing from `.gitignore`.