### PR TITLE
Support old AppleWin 1.25 "Color (Standard)" video mode

### DIFF
--- a/AppleWinExpress2008.vcproj
+++ b/AppleWinExpress2008.vcproj
@@ -913,6 +913,14 @@
 					RelativePath=".\source\Video.h"
 					>
 				</File>
+				<File
+					RelativePath=".\source\Video_OriginalColorTVMode.cpp"
+					>
+				</File>
+				<File
+					RelativePath=".\source\Video_OriginalColorTVMode.h"
+					>
+				</File>
 			</Filter>
 			<Filter
 				Name="Configuration"

--- a/resource/Applewin.rc
+++ b/resource/Applewin.rc
@@ -252,8 +252,8 @@ DISK_ICON               ICON                    "DISK.ICO"
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 1,27,12,0
- PRODUCTVERSION 1,27,12,0
+ FILEVERSION 1,27,14,0
+ PRODUCTVERSION 1,27,14,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -271,12 +271,12 @@ BEGIN
             VALUE "Comments", "https://github.com/AppleWin"
             VALUE "CompanyName", "AppleWin"
             VALUE "FileDescription", "Apple //e Emulator for Windows"
-            VALUE "FileVersion", "1, 27, 12, 0"
+            VALUE "FileVersion", "1, 27, 14, 0"
             VALUE "InternalName", "APPLEWIN"
             VALUE "LegalCopyright", " 1994-2018 Michael O'Brien, Oliver Schmidt, Tom Charlesworth, Michael Pohoreski, Nick Westgate, Linards Ticmanis"
             VALUE "OriginalFilename", "APPLEWIN.EXE"
             VALUE "ProductName", "Apple //e Emulator"
-            VALUE "ProductVersion", "1, 27, 12, 0"
+            VALUE "ProductVersion", "1, 27, 14, 0"
         END
     END
     BLOCK "VarFileInfo"

--- a/source/Applewin.cpp
+++ b/source/Applewin.cpp
@@ -60,6 +60,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 static UINT16 g_AppleWinVersion[4] = {0};
 char VERSIONSTRING[16] = "xx.yy.zz.ww";
+static UINT16 g_OldAppleWinVersion[4] = {0};
 
 const TCHAR *g_pAppTitle = NULL;
 
@@ -164,9 +165,9 @@ void SetApple2Type(eApple2Type type)
 	SetMainCpuDefault(type);
 }
 
-const UINT16* GetAppleWinVersion(void)
+const UINT16* GetOldAppleWinVersion(void)
 {
-	return &g_AppleWinVersion[0];
+	return g_OldAppleWinVersion;
 }
 
 bool GetLoadedSaveStateFlag(void)
@@ -1477,6 +1478,38 @@ int APIENTRY WinMain(HINSTANCE passinstance, HINSTANCE, LPSTR lpCmdLine, int)
 		g_bRestart = false;
 		ResetToLogoMode();
 
+		//
+
+		char szOldAppleWinVersion[sizeof(VERSIONSTRING)] = {0};
+		RegLoadString(TEXT(REG_CONFIG), TEXT(REGVALUE_VERSION), 1, szOldAppleWinVersion, sizeof(szOldAppleWinVersion));
+
+		const bool bShowAboutDlg = strcmp(szOldAppleWinVersion, VERSIONSTRING) != 0;
+
+		if (bShowAboutDlg)
+		{
+			if (!AboutDlg())
+				bShutdown = true;															// Close everything down
+			else
+				RegSaveString(TEXT(REG_CONFIG), TEXT(REGVALUE_VERSION), 1, VERSIONSTRING);	// Only save version after user accepts license
+		}
+
+		// NB. g_OldAppleWinVersion needed by LoadConfiguration() -> Config_Load_Video()
+		// version: xx.yy.zz.ww
+		// offset : 0123456789
+		char* p0 = szOldAppleWinVersion;
+		szOldAppleWinVersion[strlen(szOldAppleWinVersion)] = '.';	// Overwrite null terminator with '.'
+		for (UINT i=0; i<4; i++)
+		{
+			char* p1 = strstr(p0, ".");
+			if (!p1)
+				break;
+			*p1 = 0;
+			g_OldAppleWinVersion[i] = atoi(p0);
+			p0 = p1+1;
+		}
+
+		//
+
 		LoadConfiguration();
 		LogFileOutput("Main: LoadConfiguration()\n");
 
@@ -1530,18 +1563,6 @@ int APIENTRY WinMain(HINSTANCE passinstance, HINSTANCE, LPSTR lpCmdLine, int)
 
 		MemInitialize();
 		LogFileOutput("Main: MemInitialize()\n");
-
-		char szOldAppleWinVersion[sizeof(VERSIONSTRING)] = {0};
-		RegLoadString(TEXT(REG_CONFIG), TEXT(REGVALUE_VERSION), 1, szOldAppleWinVersion, sizeof(szOldAppleWinVersion));
-
-		const bool bShowAboutDlg = strcmp(szOldAppleWinVersion, VERSIONSTRING) != 0;
-		if (bShowAboutDlg)
-		{
-			if (!AboutDlg())
-				bShutdown = true;															// Close everything down
-			else
-				RegSaveString(TEXT(REG_CONFIG), TEXT(REGVALUE_VERSION), 1, VERSIONSTRING);	// Only save version after user accepts license
-		}
 
 		if (g_bCapturePrintScreenKey)
 		{

--- a/source/Applewin.h
+++ b/source/Applewin.h
@@ -9,7 +9,7 @@ void LogFileTimeUntilFirstKeyRead(void);
 void SetCurrentCLK6502();
 bool SetCurrentImageDir(const char* pszImageDir);
 
-extern const UINT16* GetAppleWinVersion(void);
+extern const UINT16* GetOldAppleWinVersion(void);
 extern char VERSIONSTRING[];	// Constructed in WinMain()
 
 extern const TCHAR     *g_pAppTitle;

--- a/source/NTSC.cpp
+++ b/source/NTSC.cpp
@@ -1946,7 +1946,6 @@ void NTSC_SetVideoStyle() // (int v, int s)
 			}
 			break;
 
-//		case VT_MONO_WHITE: //VT_MONO_MONITOR: //3:
 		case VT_MONO_AMBER:
 			r = 0xFF;
 			g = 0x80;
@@ -1959,6 +1958,7 @@ void NTSC_SetVideoStyle() // (int v, int s)
 			b = 0x00;
 			goto _mono;
 
+		case VT_COLOR_STANDARD:
 		case VT_MONO_WHITE:
 			r = 0xFF;
 			g = 0xFF;

--- a/source/NTSC.cpp
+++ b/source/NTSC.cpp
@@ -1823,32 +1823,40 @@ void NTSC_SetVideoMode( uint32_t uVideoModeFlags )
 
 	g_nTextPage  = 1;
 	g_nHiresPage = 1;
-	if (uVideoModeFlags & VF_PAGE2) {
+	if (uVideoModeFlags & VF_PAGE2)
+	{
 		// Apple IIe, Technical Notes, #3: Double High-Resolution Graphics
 		// 80STORE must be OFF to display page 2
-		if (0 == (uVideoModeFlags & VF_80STORE)) {
+		if (0 == (uVideoModeFlags & VF_80STORE))
+		{
 			g_nTextPage  = 2;
 			g_nHiresPage = 2;
 		}
 	}
 
-	if (uVideoModeFlags & VF_TEXT) {
+	if (uVideoModeFlags & VF_TEXT)
+	{
 		if (uVideoModeFlags & VF_80COL)
 			g_pFuncUpdateGraphicsScreen = updateScreenText80;
 		else
 			g_pFuncUpdateGraphicsScreen = updateScreenText40;
 	}
-	else if (uVideoModeFlags & VF_HIRES) {
+	else if (uVideoModeFlags & VF_HIRES)
+	{
 		if (uVideoModeFlags & VF_DHIRES)
+		{
 			if (uVideoModeFlags & VF_80COL)
 			{
-			if (g_eVideoType == VT_COLOR_STANDARD)
-				g_pFuncUpdateGraphicsScreen = updateScreenDoubleHires80Simple;
-			else
-				g_pFuncUpdateGraphicsScreen = updateScreenDoubleHires80;
+				if (g_eVideoType == VT_COLOR_STANDARD)
+					g_pFuncUpdateGraphicsScreen = updateScreenDoubleHires80Simple;
+				else
+					g_pFuncUpdateGraphicsScreen = updateScreenDoubleHires80;
 			}
 			else
+			{
 				g_pFuncUpdateGraphicsScreen = updateScreenDoubleHires40;
+			}
+		}
 		else
 		{
 			if (g_eVideoType == VT_COLOR_STANDARD)
@@ -1857,8 +1865,10 @@ void NTSC_SetVideoMode( uint32_t uVideoModeFlags )
 				g_pFuncUpdateGraphicsScreen = updateScreenSingleHires40;
 		}
 	}
-	else {
+	else
+	{
 		if (uVideoModeFlags & VF_DHIRES)
+		{
 			if (uVideoModeFlags & VF_80COL)
 			{
 				if (g_eVideoType == VT_COLOR_STANDARD)
@@ -1867,7 +1877,10 @@ void NTSC_SetVideoMode( uint32_t uVideoModeFlags )
 					g_pFuncUpdateGraphicsScreen = updateScreenDoubleLores80;
 			}
 			else
+			{
 				g_pFuncUpdateGraphicsScreen = updateScreenDoubleLores40;
+			}
+		}
 		else
 		{
 			if (g_eVideoType == VT_COLOR_STANDARD)

--- a/source/NTSC.cpp
+++ b/source/NTSC.cpp
@@ -1339,6 +1339,36 @@ void updateScreenDoubleHires40 (long cycles6502) // wsUpdateVideoHires0
 }
 
 //===========================================================================
+
+void updateScreenDoubleHires80Simple (long cycles6502 ) // wsUpdateVideoDblHires
+{
+	if (g_nVideoMixed && g_nVideoClockVert >= VIDEO_SCANNER_Y_MIXED)
+	{
+		g_pFuncUpdateTextScreen( cycles6502 );
+		return;
+	}
+
+	for (; cycles6502 > 0; --cycles6502)
+	{
+		uint16_t addr = getVideoScannerAddressHGR();
+
+		if (g_nVideoClockVert < VIDEO_SCANNER_Y_DISPLAY)
+		{
+			if ((g_nVideoClockHorz < VIDEO_SCANNER_HORZ_COLORBURST_END) && (g_nVideoClockHorz >= VIDEO_SCANNER_HORZ_COLORBURST_BEG))
+			{
+				g_nColorBurstPixels = 1024;
+			}
+			else if (g_nVideoClockHorz >= VIDEO_SCANNER_HORZ_START)
+			{
+				uint16_t addr = getVideoScannerAddressHGR();
+				UpdateDHiResCell(g_nVideoClockHorz-VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress);
+				g_pVideoAddress += 14;
+			}
+		}
+		updateVideoScannerHorzEOLSimple();
+	}
+}
+
 void updateScreenDoubleHires80 (long cycles6502 ) // wsUpdateVideoDblHires
 {
 	if (g_nVideoMixed && g_nVideoClockVert >= VIDEO_SCANNER_Y_MIXED)
@@ -1417,6 +1447,36 @@ void updateScreenDoubleLores40 (long cycles6502) // wsUpdateVideo7MLores
 }
 
 //===========================================================================
+
+static void updateScreenDoubleLores80Simple (long cycles6502) // wsUpdateVideoDblLores
+{
+	if (g_nVideoMixed && g_nVideoClockVert >= VIDEO_SCANNER_Y_MIXED)
+	{
+		g_pFuncUpdateTextScreen( cycles6502 );
+		return;
+	}
+
+	for (; cycles6502 > 0; --cycles6502)
+	{
+		uint16_t addr = getVideoScannerAddressTXT();
+
+		if (g_nVideoClockVert < VIDEO_SCANNER_Y_DISPLAY)
+		{
+			if ((g_nVideoClockHorz < VIDEO_SCANNER_HORZ_COLORBURST_END) && (g_nVideoClockHorz >= VIDEO_SCANNER_HORZ_COLORBURST_BEG))
+			{
+				g_nColorBurstPixels = 1024;
+			}
+			else if (g_nVideoClockHorz >= VIDEO_SCANNER_HORZ_START)
+			{
+				uint16_t addr = getVideoScannerAddressTXT();
+				UpdateDLoResCell(g_nVideoClockHorz-VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress);
+				g_pVideoAddress += 14;
+			}
+		}
+		updateVideoScannerHorzEOLSimple();
+	}
+}
+
 void updateScreenDoubleLores80 (long cycles6502) // wsUpdateVideoDblLores
 {
 	if (g_nVideoMixed && g_nVideoClockVert >= VIDEO_SCANNER_Y_MIXED)
@@ -1467,7 +1527,7 @@ void updateScreenDoubleLores80 (long cycles6502) // wsUpdateVideoDblLores
 }
 
 //===========================================================================
-void updateScreenSingleHires40Simple (long cycles6502)
+static void updateScreenSingleHires40Simple (long cycles6502)
 {
 	if (g_nVideoMixed && g_nVideoClockVert >= VIDEO_SCANNER_Y_MIXED)
 	{
@@ -1535,6 +1595,35 @@ void updateScreenSingleHires40 (long cycles6502)
 }
 
 //===========================================================================
+static void updateScreenSingleLores40Simple (long cycles6502)
+{
+	if (g_nVideoMixed && g_nVideoClockVert >= VIDEO_SCANNER_Y_MIXED)
+	{
+		g_pFuncUpdateTextScreen( cycles6502 );
+		return;
+	}
+
+	for (; cycles6502 > 0; --cycles6502)
+	{
+		uint16_t addr = getVideoScannerAddressTXT();
+
+		if (g_nVideoClockVert < VIDEO_SCANNER_Y_DISPLAY)
+		{
+			if ((g_nVideoClockHorz < VIDEO_SCANNER_HORZ_COLORBURST_END) && (g_nVideoClockHorz >= VIDEO_SCANNER_HORZ_COLORBURST_BEG))
+			{
+				g_nColorBurstPixels = 1024;
+			}
+			else if (g_nVideoClockHorz >= VIDEO_SCANNER_HORZ_START)
+			{
+				uint16_t addr = getVideoScannerAddressTXT();
+				UpdateLoResCell(g_nVideoClockHorz-VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress);
+				g_pVideoAddress += 14;
+			}
+		}
+		updateVideoScannerHorzEOLSimple();
+	}
+}
+
 void updateScreenSingleLores40 (long cycles6502)
 {
 	if (g_nVideoMixed && g_nVideoClockVert >= VIDEO_SCANNER_Y_MIXED)
@@ -1752,7 +1841,12 @@ void NTSC_SetVideoMode( uint32_t uVideoModeFlags )
 	else if (uVideoModeFlags & VF_HIRES) {
 		if (uVideoModeFlags & VF_DHIRES)
 			if (uVideoModeFlags & VF_80COL)
-				g_pFuncUpdateGraphicsScreen = updateScreenDoubleHires80;
+			{
+//			if (g_eVideoType == VT_COLOR_TV_ORIGINAL)
+				g_pFuncUpdateGraphicsScreen = updateScreenDoubleHires80Simple;
+//			else
+//				g_pFuncUpdateGraphicsScreen = updateScreenDoubleHires80;
+			}
 			else
 				g_pFuncUpdateGraphicsScreen = updateScreenDoubleHires40;
 		else
@@ -1766,11 +1860,21 @@ void NTSC_SetVideoMode( uint32_t uVideoModeFlags )
 	else {
 		if (uVideoModeFlags & VF_DHIRES)
 			if (uVideoModeFlags & VF_80COL)
-				g_pFuncUpdateGraphicsScreen = updateScreenDoubleLores80;
+			{
+//				if (g_eVideoType == VT_COLOR_TV_ORIGINAL)
+					g_pFuncUpdateGraphicsScreen = updateScreenDoubleLores80Simple;
+//				else
+//					g_pFuncUpdateGraphicsScreen = updateScreenDoubleLores80;
+			}
 			else
 				g_pFuncUpdateGraphicsScreen = updateScreenDoubleLores40;
 		else
-			g_pFuncUpdateGraphicsScreen = updateScreenSingleLores40;
+		{
+//			if (g_eVideoType == VT_COLOR_TV_ORIGINAL)
+				g_pFuncUpdateGraphicsScreen = updateScreenSingleLores40Simple;
+//			else
+//				g_pFuncUpdateGraphicsScreen = updateScreenSingleLores40;
+		}
 	}
 }
 

--- a/source/NTSC.cpp
+++ b/source/NTSC.cpp
@@ -915,7 +915,7 @@ inline void updateVideoScannerAddress()
 		(g_pFuncUpdateGraphicsScreen == updateScreenDoubleLores80) ||
 		(g_pFuncUpdateGraphicsScreen == updateScreenText80) ||
 		(g_nVideoMixed && g_nVideoClockVert >= VIDEO_SCANNER_Y_MIXED && g_pFuncUpdateTextScreen == updateScreenText80))
-		&& (g_eVideoType != VT_COLOR_STANDARD))	// Fix for "Ansi Story" (Turn the disk over) - Top row of TEXT80 is shifted by 1 pixel
+		&& (g_eVideoType != VT_COLOR_SIMPLIFIED))	// Fix for "Ansi Story" (Turn the disk over) - Top row of TEXT80 is shifted by 1 pixel
 	{
 		g_pVideoAddress -= 1;
 	}
@@ -1341,7 +1341,7 @@ void updateScreenDoubleHires40 (long cycles6502) // wsUpdateVideoHires0
 
 //===========================================================================
 
-void updateScreenDoubleHires80Simple (long cycles6502 ) // wsUpdateVideoDblHires
+void updateScreenDoubleHires80Simplified (long cycles6502 ) // wsUpdateVideoDblHires
 {
 	if (g_nVideoMixed && g_nVideoClockVert >= VIDEO_SCANNER_Y_MIXED)
 	{
@@ -1449,7 +1449,7 @@ void updateScreenDoubleLores40 (long cycles6502) // wsUpdateVideo7MLores
 
 //===========================================================================
 
-static void updateScreenDoubleLores80Simple (long cycles6502) // wsUpdateVideoDblLores
+static void updateScreenDoubleLores80Simplified (long cycles6502) // wsUpdateVideoDblLores
 {
 	if (g_nVideoMixed && g_nVideoClockVert >= VIDEO_SCANNER_Y_MIXED)
 	{
@@ -1528,7 +1528,7 @@ void updateScreenDoubleLores80 (long cycles6502) // wsUpdateVideoDblLores
 }
 
 //===========================================================================
-static void updateScreenSingleHires40Simple (long cycles6502)
+static void updateScreenSingleHires40Simplified (long cycles6502)
 {
 	if (g_nVideoMixed && g_nVideoClockVert >= VIDEO_SCANNER_Y_MIXED)
 	{
@@ -1596,7 +1596,7 @@ void updateScreenSingleHires40 (long cycles6502)
 }
 
 //===========================================================================
-static void updateScreenSingleLores40Simple (long cycles6502)
+static void updateScreenSingleLores40Simplified (long cycles6502)
 {
 	if (g_nVideoMixed && g_nVideoClockVert >= VIDEO_SCANNER_Y_MIXED)
 	{
@@ -1720,7 +1720,7 @@ void updateScreenText80 (long cycles6502)
 					aux ^= g_nTextFlashMask;
 
 				uint16_t bits = (main << 7) | (aux & 0x7f);
-				if (g_eVideoType != VT_COLOR_STANDARD)				// No extra 14M bit needed for VT_COLOR_STANDARD
+				if (g_eVideoType != VT_COLOR_SIMPLIFIED)				// No extra 14M bit needed for VT_COLOR_SIMPLIFIED
 					bits = (bits << 1) | g_nLastColumnPixelNTSC;	// GH#555: Align TEXT80 chars with DHGR
 				updatePixels( bits );
 				g_nLastColumnPixelNTSC = (bits >> 14) & 1;
@@ -1849,8 +1849,8 @@ void NTSC_SetVideoMode( uint32_t uVideoModeFlags )
 		{
 			if (uVideoModeFlags & VF_80COL)
 			{
-				if (g_eVideoType == VT_COLOR_STANDARD)
-					g_pFuncUpdateGraphicsScreen = updateScreenDoubleHires80Simple;
+				if (g_eVideoType == VT_COLOR_SIMPLIFIED)
+					g_pFuncUpdateGraphicsScreen = updateScreenDoubleHires80Simplified;
 				else
 					g_pFuncUpdateGraphicsScreen = updateScreenDoubleHires80;
 			}
@@ -1861,8 +1861,8 @@ void NTSC_SetVideoMode( uint32_t uVideoModeFlags )
 		}
 		else
 		{
-			if (g_eVideoType == VT_COLOR_STANDARD)
-				g_pFuncUpdateGraphicsScreen = updateScreenSingleHires40Simple;
+			if (g_eVideoType == VT_COLOR_SIMPLIFIED)
+				g_pFuncUpdateGraphicsScreen = updateScreenSingleHires40Simplified;
 			else
 				g_pFuncUpdateGraphicsScreen = updateScreenSingleHires40;
 		}
@@ -1873,8 +1873,8 @@ void NTSC_SetVideoMode( uint32_t uVideoModeFlags )
 		{
 			if (uVideoModeFlags & VF_80COL)
 			{
-				if (g_eVideoType == VT_COLOR_STANDARD)
-					g_pFuncUpdateGraphicsScreen = updateScreenDoubleLores80Simple;
+				if (g_eVideoType == VT_COLOR_SIMPLIFIED)
+					g_pFuncUpdateGraphicsScreen = updateScreenDoubleLores80Simplified;
 				else
 					g_pFuncUpdateGraphicsScreen = updateScreenDoubleLores80;
 			}
@@ -1885,8 +1885,8 @@ void NTSC_SetVideoMode( uint32_t uVideoModeFlags )
 		}
 		else
 		{
-			if (g_eVideoType == VT_COLOR_STANDARD)
-				g_pFuncUpdateGraphicsScreen = updateScreenSingleLores40Simple;
+			if (g_eVideoType == VT_COLOR_SIMPLIFIED)
+				g_pFuncUpdateGraphicsScreen = updateScreenSingleLores40Simplified;
 			else
 				g_pFuncUpdateGraphicsScreen = updateScreenSingleLores40;
 		}
@@ -1960,7 +1960,7 @@ void NTSC_SetVideoStyle() // (int v, int s)
 			b = 0x00;
 			goto _mono;
 
-		case VT_COLOR_STANDARD:
+		case VT_COLOR_SIMPLIFIED:
 		case VT_MONO_WHITE:
 			r = 0xFF;
 			g = 0xFF;

--- a/source/NTSC.cpp
+++ b/source/NTSC.cpp
@@ -1842,38 +1842,38 @@ void NTSC_SetVideoMode( uint32_t uVideoModeFlags )
 		if (uVideoModeFlags & VF_DHIRES)
 			if (uVideoModeFlags & VF_80COL)
 			{
-//			if (g_eVideoType == VT_COLOR_TV_ORIGINAL)
+			if (g_eVideoType == VT_COLOR_STANDARD)
 				g_pFuncUpdateGraphicsScreen = updateScreenDoubleHires80Simple;
-//			else
-//				g_pFuncUpdateGraphicsScreen = updateScreenDoubleHires80;
+			else
+				g_pFuncUpdateGraphicsScreen = updateScreenDoubleHires80;
 			}
 			else
 				g_pFuncUpdateGraphicsScreen = updateScreenDoubleHires40;
 		else
 		{
-//			if (g_eVideoType == VT_COLOR_TV_ORIGINAL)
+			if (g_eVideoType == VT_COLOR_STANDARD)
 				g_pFuncUpdateGraphicsScreen = updateScreenSingleHires40Simple;
-//			else
-//				g_pFuncUpdateGraphicsScreen = updateScreenSingleHires40;
+			else
+				g_pFuncUpdateGraphicsScreen = updateScreenSingleHires40;
 		}
 	}
 	else {
 		if (uVideoModeFlags & VF_DHIRES)
 			if (uVideoModeFlags & VF_80COL)
 			{
-//				if (g_eVideoType == VT_COLOR_TV_ORIGINAL)
+				if (g_eVideoType == VT_COLOR_STANDARD)
 					g_pFuncUpdateGraphicsScreen = updateScreenDoubleLores80Simple;
-//				else
-//					g_pFuncUpdateGraphicsScreen = updateScreenDoubleLores80;
+				else
+					g_pFuncUpdateGraphicsScreen = updateScreenDoubleLores80;
 			}
 			else
 				g_pFuncUpdateGraphicsScreen = updateScreenDoubleLores40;
 		else
 		{
-//			if (g_eVideoType == VT_COLOR_TV_ORIGINAL)
+			if (g_eVideoType == VT_COLOR_STANDARD)
 				g_pFuncUpdateGraphicsScreen = updateScreenSingleLores40Simple;
-//			else
-//				g_pFuncUpdateGraphicsScreen = updateScreenSingleLores40;
+			else
+				g_pFuncUpdateGraphicsScreen = updateScreenSingleLores40;
 		}
 	}
 }

--- a/source/NTSC.cpp
+++ b/source/NTSC.cpp
@@ -902,8 +902,8 @@ inline void updateVideoScannerAddress()
 	g_pVideoAddress = g_nVideoClockVert < VIDEO_SCANNER_Y_DISPLAY ? g_pScanLines[2*g_nVideoClockVert] : g_pScanLines[0];
 
 	// Adjust, as these video styles have 2x 14M pixels of pre-render
-	// NB. For VT_COLOR_MONITOR, also check color-burst so that TEXT and MIXED(HGR+TEXT) render the TEXT at the same offset (GH#341)
-	if (g_eVideoType == VT_MONO_TV || g_eVideoType == VT_COLOR_TV || (g_eVideoType == VT_COLOR_MONITOR && GetColorBurst()))
+	// NB. For VT_COLOR_MONITOR_NTSC, also check color-burst so that TEXT and MIXED(HGR+TEXT) render the TEXT at the same offset (GH#341)
+	if (g_eVideoType == VT_MONO_TV || g_eVideoType == VT_COLOR_TV || (g_eVideoType == VT_COLOR_MONITOR_NTSC && GetColorBurst()))
 		g_pVideoAddress -= 2;
 
 	// GH#555: For the 14M video modes (DHGR,DGR,80COL), start rendering 1x 14M pixel early to account for these video modes being shifted right by 1 pixel
@@ -915,7 +915,7 @@ inline void updateVideoScannerAddress()
 		(g_pFuncUpdateGraphicsScreen == updateScreenDoubleLores80) ||
 		(g_pFuncUpdateGraphicsScreen == updateScreenText80) ||
 		(g_nVideoMixed && g_nVideoClockVert >= VIDEO_SCANNER_Y_MIXED && g_pFuncUpdateTextScreen == updateScreenText80))
-		&& (g_eVideoType != VT_COLOR_SIMPLIFIED))	// Fix for "Ansi Story" (Turn the disk over) - Top row of TEXT80 is shifted by 1 pixel
+		&& (g_eVideoType != VT_COLOR_MONITOR_RGB))	// Fix for "Ansi Story" (Turn the disk over) - Top row of TEXT80 is shifted by 1 pixel
 	{
 		g_pVideoAddress -= 1;
 	}
@@ -1292,8 +1292,8 @@ inline void zeroPixel0_14M(void)	// GH#555
 	if (g_nVideoClockHorz == VIDEO_SCANNER_HORZ_START)
 	{
 		UINT32* p = ((UINT32*)g_pVideoAddress) - 14;	// Point back to pixel-0
-		// NB. For VT_COLOR_MONITOR, also check color-burst so that TEXT and MIXED(HGR+TEXT) render the TEXT at the same offset (GH#341)
-		if (g_eVideoType == VT_MONO_TV || g_eVideoType == VT_COLOR_TV || (g_eVideoType == VT_COLOR_MONITOR && GetColorBurst()))
+		// NB. For VT_COLOR_MONITOR_NTSC, also check color-burst so that TEXT and MIXED(HGR+TEXT) render the TEXT at the same offset (GH#341)
+		if (g_eVideoType == VT_MONO_TV || g_eVideoType == VT_COLOR_TV || (g_eVideoType == VT_COLOR_MONITOR_NTSC && GetColorBurst()))
 		{
 			p[2] = 0;
 			p[g_kFrameBufferWidth+2] = 0;	// Next line (there are 2 lines per Apple II scanline)
@@ -1720,7 +1720,7 @@ void updateScreenText80 (long cycles6502)
 					aux ^= g_nTextFlashMask;
 
 				uint16_t bits = (main << 7) | (aux & 0x7f);
-				if (g_eVideoType != VT_COLOR_SIMPLIFIED)				// No extra 14M bit needed for VT_COLOR_SIMPLIFIED
+				if (g_eVideoType != VT_COLOR_MONITOR_RGB)			// No extra 14M bit needed for VT_COLOR_MONITOR_RGB
 					bits = (bits << 1) | g_nLastColumnPixelNTSC;	// GH#555: Align TEXT80 chars with DHGR
 				updatePixels( bits );
 				g_nLastColumnPixelNTSC = (bits >> 14) & 1;
@@ -1849,7 +1849,7 @@ void NTSC_SetVideoMode( uint32_t uVideoModeFlags )
 		{
 			if (uVideoModeFlags & VF_80COL)
 			{
-				if (g_eVideoType == VT_COLOR_SIMPLIFIED)
+				if (g_eVideoType == VT_COLOR_MONITOR_RGB)
 					g_pFuncUpdateGraphicsScreen = updateScreenDoubleHires80Simplified;
 				else
 					g_pFuncUpdateGraphicsScreen = updateScreenDoubleHires80;
@@ -1861,7 +1861,7 @@ void NTSC_SetVideoMode( uint32_t uVideoModeFlags )
 		}
 		else
 		{
-			if (g_eVideoType == VT_COLOR_SIMPLIFIED)
+			if (g_eVideoType == VT_COLOR_MONITOR_RGB)
 				g_pFuncUpdateGraphicsScreen = updateScreenSingleHires40Simplified;
 			else
 				g_pFuncUpdateGraphicsScreen = updateScreenSingleHires40;
@@ -1873,7 +1873,7 @@ void NTSC_SetVideoMode( uint32_t uVideoModeFlags )
 		{
 			if (uVideoModeFlags & VF_80COL)
 			{
-				if (g_eVideoType == VT_COLOR_SIMPLIFIED)
+				if (g_eVideoType == VT_COLOR_MONITOR_RGB)
 					g_pFuncUpdateGraphicsScreen = updateScreenDoubleLores80Simplified;
 				else
 					g_pFuncUpdateGraphicsScreen = updateScreenDoubleLores80;
@@ -1885,7 +1885,7 @@ void NTSC_SetVideoMode( uint32_t uVideoModeFlags )
 		}
 		else
 		{
-			if (g_eVideoType == VT_COLOR_SIMPLIFIED)
+			if (g_eVideoType == VT_COLOR_MONITOR_RGB)
 				g_pFuncUpdateGraphicsScreen = updateScreenSingleLores40Simplified;
 			else
 				g_pFuncUpdateGraphicsScreen = updateScreenSingleLores40;
@@ -1917,7 +1917,7 @@ void NTSC_SetVideoStyle() // (int v, int s)
 			}
 			break;
 
-		case VT_COLOR_MONITOR:
+		case VT_COLOR_MONITOR_NTSC:
 		default:
 			r = 0xFF;
 			g = 0xFF;
@@ -1960,7 +1960,7 @@ void NTSC_SetVideoStyle() // (int v, int s)
 			b = 0x00;
 			goto _mono;
 
-		case VT_COLOR_SIMPLIFIED:
+		case VT_COLOR_MONITOR_RGB:
 		case VT_MONO_WHITE:
 			r = 0xFF;
 			g = 0xFF;

--- a/source/NTSC.cpp
+++ b/source/NTSC.cpp
@@ -1720,7 +1720,8 @@ void updateScreenText80 (long cycles6502)
 					aux ^= g_nTextFlashMask;
 
 				uint16_t bits = (main << 7) | (aux & 0x7f);
-				bits = (bits << 1) | g_nLastColumnPixelNTSC;	// GH#555: Align TEXT80 chars with DHGR
+				if (g_eVideoType != VT_COLOR_STANDARD)				// No extra 14M bit needed for VT_COLOR_STANDARD
+					bits = (bits << 1) | g_nLastColumnPixelNTSC;	// GH#555: Align TEXT80 chars with DHGR
 				updatePixels( bits );
 				g_nLastColumnPixelNTSC = (bits >> 14) & 1;
 

--- a/source/NTSC.cpp
+++ b/source/NTSC.cpp
@@ -1991,7 +1991,7 @@ _mono:
 
 //===========================================================================
 void GenerateVideoTables( void );
-void GenerateBaseColors(baseColors_t baseColors);
+void GenerateBaseColors(baseColors_t pBaseNtscColors);
 
 void NTSC_VideoInit( uint8_t* pFramebuffer ) // wsVideoInit
 {
@@ -2298,7 +2298,7 @@ static void GenerateVideoTables( void )
 	SetApple2Type(currentApple2Type);
 }
 
-void GenerateBaseColors(baseColors_t baseColors)
+void GenerateBaseColors(baseColors_t pBaseNtscColors)
 {
 	for (UINT i=0; i<16; i++)
 	{
@@ -2322,6 +2322,6 @@ void GenerateBaseColors(baseColors_t baseColors)
 		int b = (((colors[0]    )&0xff) + ((colors[1]    )&0xff) + ((colors[2]    )&0xff) + ((colors[3]    )&0xff)) / 4;
 		uint32_t color = ((r<<16) | (g<<8) | b) | ALPHA32_MASK;
 
-		(*baseColors)[i] = * (bgra_t*) &color;
+		(*pBaseNtscColors)[i] = * (bgra_t*) &color;
 	}
 }

--- a/source/Video.cpp
+++ b/source/Video.cpp
@@ -97,8 +97,8 @@ static const bool g_bVideoScannerNTSC = true;  // NTSC video scanning (or PAL)
 	// NOTE: KEEP IN SYNC: VideoType_e g_aVideoChoices g_apVideoModeDesc
 	TCHAR g_aVideoChoices[] =
 		TEXT("Monochrome (Custom)\0")
-		TEXT("Color (Simplified)\0")
-		TEXT("Color Monitor\0")
+		TEXT("Color (RGB Monitor)\0")
+		TEXT("Color (NTSC Monitor)\0")
 		TEXT("Color TV\0")
 		TEXT("B&W TV\0")
 		TEXT("Monochrome (Amber)\0")
@@ -111,8 +111,8 @@ static const bool g_bVideoScannerNTSC = true;  // NTSC video scanning (or PAL)
 	char *g_apVideoModeDesc[ NUM_VIDEO_MODES ] =
 	{
 		  "Monochrome Monitor (Custom)"
-		, "Color (Simplified)"
-		, "Color Monitor"
+		, "Color (RGB Monitor)"
+		, "Color (NTSC Monitor)"
 		, "Color TV"
 		, "B&W TV"
 		, "Amber Monitor"
@@ -1204,7 +1204,7 @@ bool IsVideoRom4K(void)
 enum VideoType127_e
 {
 	  VT127_MONO_CUSTOM
-	, VT127_COLOR_MONITOR
+	, VT127_COLOR_MONITOR_NTSC
 	, VT127_MONO_TV
 	, VT127_COLOR_TV
 	, VT127_MONO_AMBER
@@ -1225,14 +1225,14 @@ void Config_Load_Video()
 	{
 		switch (g_eVideoType)
 		{
-		case VT127_MONO_CUSTOM:		g_eVideoType = VT_MONO_CUSTOM; break;
-		case VT127_COLOR_MONITOR:	g_eVideoType = VT_COLOR_MONITOR; break;
-		case VT127_MONO_TV:			g_eVideoType = VT_MONO_TV; break;
-		case VT127_COLOR_TV:		g_eVideoType = VT_COLOR_TV; break;
-		case VT127_MONO_AMBER:		g_eVideoType = VT_MONO_AMBER; break;
-		case VT127_MONO_GREEN:		g_eVideoType = VT_MONO_GREEN; break;
-		case VT127_MONO_WHITE:		g_eVideoType = VT_MONO_WHITE; break;
-		default:					g_eVideoType = VT_DEFAULT; break;
+		case VT127_MONO_CUSTOM:			g_eVideoType = VT_MONO_CUSTOM; break;
+		case VT127_COLOR_MONITOR_NTSC:	g_eVideoType = VT_COLOR_MONITOR_NTSC; break;
+		case VT127_MONO_TV:				g_eVideoType = VT_MONO_TV; break;
+		case VT127_COLOR_TV:			g_eVideoType = VT_COLOR_TV; break;
+		case VT127_MONO_AMBER:			g_eVideoType = VT_MONO_AMBER; break;
+		case VT127_MONO_GREEN:			g_eVideoType = VT_MONO_GREEN; break;
+		case VT127_MONO_WHITE:			g_eVideoType = VT_MONO_WHITE; break;
+		default:						g_eVideoType = VT_DEFAULT; break;
 		}
 	}
 #endif

--- a/source/Video.cpp
+++ b/source/Video.cpp
@@ -83,9 +83,6 @@ static LPBITMAPINFO  g_pFramebufferinfo = NULL;
 
        HBITMAP       g_hLogoBitmap;
 
-const int MAX_SOURCE_Y = 512;
-static LPBYTE        g_aSourceStartofLine[ MAX_SOURCE_Y ];
-
 COLORREF         g_nMonochromeRGB    = RGB(0xC0,0xC0,0xC0);
 
 uint32_t  g_uVideoMode     = VF_TEXT; // Current Video Mode (this is the last set one as it may change mid-scan line!)
@@ -130,6 +127,13 @@ static const bool g_bVideoScannerNTSC = true;  // NTSC video scanning (or PAL)
 	void Video_SaveScreenShot( const char *pScreenShotFileName, const VideoScreenShot_e ScreenShotType );
 	void Video_MakeScreenShot( FILE *pFile, const VideoScreenShot_e ScreenShotType );
 	void videoCreateDIBSection();
+
+//===========================================================================
+
+//LPBITMAPINFO GetFrameBufferInfo(void)
+//{
+//	return g_pFramebufferinfo;
+//}
 
 //===========================================================================
 void VideoInitialize ()
@@ -1242,9 +1246,9 @@ static void videoCreateDIBSection()
 		);
 	SelectObject(g_hDeviceDC,g_hDeviceBitmap);
 
-	// CREATE THE OFFSET TABLE FOR EACH SCAN LINE IN THE FRAME BUFFER
 	// DRAW THE SOURCE IMAGE INTO THE SOURCE BIT BUFFER
 	ZeroMemory( g_pFramebufferbits, GetFrameBufferWidth()*GetFrameBufferHeight()*sizeof(bgra_t) );
 
+	// CREATE THE OFFSET TABLE FOR EACH SCAN LINE IN THE FRAME BUFFER
 	NTSC_VideoInit( g_pFramebufferbits );
 }

--- a/source/Video.cpp
+++ b/source/Video.cpp
@@ -87,7 +87,7 @@ COLORREF         g_nMonochromeRGB    = RGB(0xC0,0xC0,0xC0);
 
 uint32_t  g_uVideoMode     = VF_TEXT; // Current Video Mode (this is the last set one as it may change mid-scan line!)
 
-DWORD     g_eVideoType     = VT_COLOR_TV;
+DWORD     g_eVideoType     = VT_DEFAULT;
 DWORD     g_uHalfScanLines = 1; // drop 50% scan lines for a more authentic look
 
 static const bool g_bVideoScannerNTSC = true;  // NTSC video scanning (or PAL)
@@ -100,6 +100,7 @@ static const bool g_bVideoScannerNTSC = true;  // NTSC video scanning (or PAL)
 		TEXT("Color Monitor\0")
 		TEXT("B&W TV\0")
 		TEXT("Color TV\0")
+		TEXT("Color Simplified\0")
 		TEXT("Monochrome (Amber)\0")
 		TEXT("Monochrome (Green)\0")
 		TEXT("Monochrome (White)\0")
@@ -113,6 +114,7 @@ static const bool g_bVideoScannerNTSC = true;  // NTSC video scanning (or PAL)
 		, "Color Monitor"
 		, "B&W TV"
 		, "Color TV"
+		, "Color Simplified"
 		, "Amber Monitor"
 		, "Green Monitor"
 		, "White Monitor"
@@ -1206,7 +1208,7 @@ void Config_Load_Video()
 	REGLOAD(TEXT(REGVALUE_VIDEO_MONO_COLOR     ),&g_nMonochromeRGB);
 
 	if (g_eVideoType >= NUM_VIDEO_MODES)
-		g_eVideoType = VT_COLOR_MONITOR;
+		g_eVideoType = VT_DEFAULT;
 }
 
 void Config_Save_Video()

--- a/source/Video.cpp
+++ b/source/Video.cpp
@@ -97,10 +97,10 @@ static const bool g_bVideoScannerNTSC = true;  // NTSC video scanning (or PAL)
 	// NOTE: KEEP IN SYNC: VideoType_e g_aVideoChoices g_apVideoModeDesc
 	TCHAR g_aVideoChoices[] =
 		TEXT("Monochrome (Custom)\0")
+		TEXT("Color (Simplified)\0")
 		TEXT("Color Monitor\0")
-		TEXT("B&W TV\0")
 		TEXT("Color TV\0")
-		TEXT("Color Simplified\0")
+		TEXT("B&W TV\0")
 		TEXT("Monochrome (Amber)\0")
 		TEXT("Monochrome (Green)\0")
 		TEXT("Monochrome (White)\0")
@@ -111,10 +111,10 @@ static const bool g_bVideoScannerNTSC = true;  // NTSC video scanning (or PAL)
 	char *g_apVideoModeDesc[ NUM_VIDEO_MODES ] =
 	{
 		  "Monochrome Monitor (Custom)"
+		, "Color (Simplified)"
 		, "Color Monitor"
-		, "B&W TV"
 		, "Color TV"
-		, "Color Simplified"
+		, "B&W TV"
 		, "Amber Monitor"
 		, "Green Monitor"
 		, "White Monitor"
@@ -1201,11 +1201,41 @@ bool IsVideoRom4K(void)
 
 //===========================================================================
 
+enum VideoType127_e
+{
+	  VT127_MONO_CUSTOM
+	, VT127_COLOR_MONITOR
+	, VT127_MONO_TV
+	, VT127_COLOR_TV
+	, VT127_MONO_AMBER
+	, VT127_MONO_GREEN
+	, VT127_MONO_WHITE
+	, VT127_NUM_VIDEO_MODES
+};
+
 void Config_Load_Video()
 {
 	REGLOAD(TEXT(REGVALUE_VIDEO_MODE           ),&g_eVideoType);
 	REGLOAD(TEXT(REGVALUE_VIDEO_HALF_SCAN_LINES),&g_uHalfScanLines);
 	REGLOAD(TEXT(REGVALUE_VIDEO_MONO_COLOR     ),&g_nMonochromeRGB);
+
+#if 0	/// TODO: Enable after bumping version in master to 1.28
+	const UINT16* pOldVersion = GetOldAppleWinVersion();
+	if (pOldVersion[0] == 1 && pOldVersion[2] <= 27)
+	{
+		switch (g_eVideoType)
+		{
+		case VT127_MONO_CUSTOM:		g_eVideoType = VT_MONO_CUSTOM; break;
+		case VT127_COLOR_MONITOR:	g_eVideoType = VT_COLOR_MONITOR; break;
+		case VT127_MONO_TV:			g_eVideoType = VT_MONO_TV; break;
+		case VT127_COLOR_TV:		g_eVideoType = VT_COLOR_TV; break;
+		case VT127_MONO_AMBER:		g_eVideoType = VT_MONO_AMBER; break;
+		case VT127_MONO_GREEN:		g_eVideoType = VT_MONO_GREEN; break;
+		case VT127_MONO_WHITE:		g_eVideoType = VT_MONO_WHITE; break;
+		default:					g_eVideoType = VT_DEFAULT; break;
+		}
+	}
+#endif
 
 	if (g_eVideoType >= NUM_VIDEO_MODES)
 		g_eVideoType = VT_DEFAULT;

--- a/source/Video.cpp
+++ b/source/Video.cpp
@@ -1219,9 +1219,8 @@ void Config_Load_Video()
 	REGLOAD(TEXT(REGVALUE_VIDEO_HALF_SCAN_LINES),&g_uHalfScanLines);
 	REGLOAD(TEXT(REGVALUE_VIDEO_MONO_COLOR     ),&g_nMonochromeRGB);
 
-#if 0	/// TODO: Enable after bumping version in master to 1.28
 	const UINT16* pOldVersion = GetOldAppleWinVersion();
-	if (pOldVersion[0] == 1 && pOldVersion[2] <= 27)
+	if (pOldVersion[0] == 1 && pOldVersion[1] <= 27 && pOldVersion[2] <= 13)
 	{
 		switch (g_eVideoType)
 		{
@@ -1235,7 +1234,6 @@ void Config_Load_Video()
 		default:						g_eVideoType = VT_DEFAULT; break;
 		}
 	}
-#endif
 
 	if (g_eVideoType >= NUM_VIDEO_MODES)
 		g_eVideoType = VT_DEFAULT;

--- a/source/Video.cpp
+++ b/source/Video.cpp
@@ -129,13 +129,6 @@ static const bool g_bVideoScannerNTSC = true;  // NTSC video scanning (or PAL)
 	void videoCreateDIBSection();
 
 //===========================================================================
-
-//LPBITMAPINFO GetFrameBufferInfo(void)
-//{
-//	return g_pFramebufferinfo;
-//}
-
-//===========================================================================
 void VideoInitialize ()
 {
 	// RESET THE VIDEO MODE SWITCHES AND THE CHARACTER SET OFFSET

--- a/source/Video.h
+++ b/source/Video.h
@@ -7,8 +7,8 @@
 	enum VideoType_e
 	{
 		  VT_MONO_CUSTOM
-		, VT_COLOR_SIMPLIFIED		// Color rendering from AppleWin 1.25 (GH#357)
-		, VT_COLOR_MONITOR
+		, VT_COLOR_MONITOR_RGB		// Color rendering from AppleWin 1.25 (GH#357)
+		, VT_COLOR_MONITOR_NTSC
 		, VT_COLOR_TV
 		, VT_MONO_TV
 		, VT_MONO_AMBER

--- a/source/Video.h
+++ b/source/Video.h
@@ -211,5 +211,3 @@ bool IsVideoRom4K(void);
 
 void Config_Load_Video(void);
 void Config_Save_Video(void);
-
-//LPBITMAPINFO GetFrameBufferInfo(void);

--- a/source/Video.h
+++ b/source/Video.h
@@ -10,10 +10,12 @@
 		, VT_COLOR_MONITOR
 		, VT_MONO_TV
 		, VT_COLOR_TV
+		, VT_COLOR_STANDARD		// Color rendering from AppleWin 1.25 (GH#357)
 		, VT_MONO_AMBER
 		, VT_MONO_GREEN
 		, VT_MONO_WHITE
 		, NUM_VIDEO_MODES
+		, VT_DEFAULT = VT_COLOR_TV
 	};
 
 	extern TCHAR g_aVideoChoices[];

--- a/source/Video.h
+++ b/source/Video.h
@@ -7,10 +7,10 @@
 	enum VideoType_e
 	{
 		  VT_MONO_CUSTOM
+		, VT_COLOR_SIMPLIFIED		// Color rendering from AppleWin 1.25 (GH#357)
 		, VT_COLOR_MONITOR
-		, VT_MONO_TV
 		, VT_COLOR_TV
-		, VT_COLOR_STANDARD		// Color rendering from AppleWin 1.25 (GH#357)
+		, VT_MONO_TV
 		, VT_MONO_AMBER
 		, VT_MONO_GREEN
 		, VT_MONO_WHITE
@@ -26,7 +26,7 @@
 		VF_80COL  = 0x00000001,
 		VF_DHIRES = 0x00000002,
 		VF_HIRES  = 0x00000004,
-		VF_80STORE= 0x00000008, // was called VF_MASK2
+		VF_80STORE= 0x00000008,
 		VF_MIXED  = 0x00000010,
 		VF_PAGE2  = 0x00000020,
 		VF_TEXT   = 0x00000040

--- a/source/Video.h
+++ b/source/Video.h
@@ -61,6 +61,7 @@
 	#define PACKED // TODO: FIXME: gcc/clang __attribute__
 #endif
 
+// TODO: Replace with WinGDI.h / RGBQUAD
 struct bgra_t
 {
 	uint8_t b;
@@ -210,3 +211,5 @@ bool IsVideoRom4K(void);
 
 void Config_Load_Video(void);
 void Config_Save_Video(void);
+
+//LPBITMAPINFO GetFrameBufferInfo(void);

--- a/source/Video_OriginalColorTVMode.cpp
+++ b/source/Video_OriginalColorTVMode.cpp
@@ -636,13 +636,13 @@ static void V_CreateDIBSections(void)
 	V_CreateLookup_DoubleHires();
 }
 
-void VideoInitializeOriginal(baseColors_t baseColors)
+void VideoInitializeOriginal(baseColors_t pBaseNtscColors)
 {
 	// CREATE THE SOURCE IMAGE AND DRAW INTO THE SOURCE BIT BUFFER
 	V_CreateDIBSections();
 
 #if 1
-	memcpy(&PalIndex2RGB[BLACK], *baseColors, sizeof(RGBQUAD)*kNumBaseColors);
+	memcpy(&PalIndex2RGB[BLACK], *pBaseNtscColors, sizeof(RGBQUAD)*kNumBaseColors);
 	PalIndex2RGB[HGR_BLUE]   = PalIndex2RGB[BLUE];
 	PalIndex2RGB[HGR_ORANGE] = PalIndex2RGB[ORANGE];
 	PalIndex2RGB[HGR_GREEN]  = PalIndex2RGB[GREEN];

--- a/source/Video_OriginalColorTVMode.cpp
+++ b/source/Video_OriginalColorTVMode.cpp
@@ -300,7 +300,7 @@ void V_CreateLookup_Lores()
 #define HALF_PIXEL_SOLID 1
 #define HALF_PIXEL_BLEED 0
 
-void V_CreateLookup_HiResHalfPixel_Authentic() // Colors are solid (100% coverage)
+void V_CreateLookup_HiResHalfPixel_Authentic(VideoType_e videoType) // Colors are solid (100% coverage)
 {
 	// 2-bits from previous byte, 2-bits from next byte = 2^4 = 16 total permutations
 	for (int iColumn = 0; iColumn < 16; iColumn++)
@@ -424,7 +424,7 @@ Legend:
 							SETSOURCEPIXEL(SRCOFFS_HIRES+offsetx+x+16,y+1, HGR_ORANGE );
 						}
 #else
-						if ((g_eVideoType == VT_COLOR_MONITOR_RGB) || ( !aPixels[3] ))
+						if ((videoType == VT_COLOR_MONITOR_RGB) || ( !aPixels[3] ))
 						{ // "Text optimized" IF this pixel on, and adjacent right pixel off, then colorize first half-pixel of this byte
 							SETSOURCEPIXEL(SRCOFFS_HIRES+offsetx+x+0 ,y  , HGR_BLUE ); // 2000:D5 AA D5
 							SETSOURCEPIXEL(SRCOFFS_HIRES+offsetx+x+0 ,y+1, HGR_BLUE );
@@ -457,8 +457,8 @@ Legend:
 					{
 						// Activate fringe reduction on white HGR text - drawback: loss of color mix patterns in HGR video mode.
 						if (
-							(g_eVideoType == VT_COLOR_MONITOR_RGB) // Fill in colors in between white pixels
-//						||	(g_eVideoType == VT_COLOR_TVEMU)    // Fill in colors in between white pixels (Post Processing will mix/merge colors)
+							(videoType == VT_COLOR_MONITOR_RGB) // Fill in colors in between white pixels
+//						||	(videoType == VT_COLOR_TVEMU)       // Fill in colors in between white pixels (Post Processing will mix/merge colors)
 						|| !(aPixels[iPixel-2] && aPixels[iPixel+2]) ) // VT_COLOR_TEXT_OPTIMIZED -> Don't fill in colors in between white
 						{
 							// Test Pattern: Ultima 4 Logo - Castle
@@ -631,7 +631,7 @@ static void V_CreateDIBSections(void)
 //	if ( g_eVideoType == VT_COLOR_TVEMU )
 //		V_CreateLookup_Hires();
 //	else
-		V_CreateLookup_HiResHalfPixel_Authentic();
+		V_CreateLookup_HiResHalfPixel_Authentic(VT_COLOR_MONITOR_RGB);
 
 	V_CreateLookup_DoubleHires();
 }

--- a/source/Video_OriginalColorTVMode.cpp
+++ b/source/Video_OriginalColorTVMode.cpp
@@ -254,7 +254,7 @@ static void V_CreateLookup_Hires()
 					else if (aPixels[iPixel-1] && aPixels[iPixel+1])
 					{
 						// Activate fringe reduction on white HGR text - drawback: loss of color mix patterns in HGR video mode.
-						// VT_COLOR_SIMPLIFIED = Fill in colors in between white pixels
+						// VT_COLOR_MONITOR_RGB = Fill in colors in between white pixels
 						// VT_COLOR_TVEMU    = Fill in colors in between white pixels  (Post Processing will mix/merge colors)
 						// VT_COLOR_TEXT_OPTIMIZED --> !(aPixels[iPixel-2] && aPixels[iPixel+2]) = Don't fill in colors in between white
 						if ((g_eVideoType == VT_COLOR_TVEMU) || !(aPixels[iPixel-2] && aPixels[iPixel+2]) )
@@ -424,7 +424,7 @@ Legend:
 							SETSOURCEPIXEL(SRCOFFS_HIRES+offsetx+x+16,y+1, HGR_ORANGE );
 						}
 #else
-						if ((g_eVideoType == VT_COLOR_SIMPLIFIED) || ( !aPixels[3] ))
+						if ((g_eVideoType == VT_COLOR_MONITOR_RGB) || ( !aPixels[3] ))
 						{ // "Text optimized" IF this pixel on, and adjacent right pixel off, then colorize first half-pixel of this byte
 							SETSOURCEPIXEL(SRCOFFS_HIRES+offsetx+x+0 ,y  , HGR_BLUE ); // 2000:D5 AA D5
 							SETSOURCEPIXEL(SRCOFFS_HIRES+offsetx+x+0 ,y+1, HGR_BLUE );
@@ -457,7 +457,7 @@ Legend:
 					{
 						// Activate fringe reduction on white HGR text - drawback: loss of color mix patterns in HGR video mode.
 						if (
-							(g_eVideoType == VT_COLOR_SIMPLIFIED) // Fill in colors in between white pixels
+							(g_eVideoType == VT_COLOR_MONITOR_RGB) // Fill in colors in between white pixels
 //						||	(g_eVideoType == VT_COLOR_TVEMU)    // Fill in colors in between white pixels (Post Processing will mix/merge colors)
 						|| !(aPixels[iPixel-2] && aPixels[iPixel+2]) ) // VT_COLOR_TEXT_OPTIMIZED -> Don't fill in colors in between white
 						{

--- a/source/Video_OriginalColorTVMode.cpp
+++ b/source/Video_OriginalColorTVMode.cpp
@@ -1,0 +1,352 @@
+// Sync'd with 1.25.0.4 source
+
+#include "StdAfx.h"
+
+#include "Frame.h"
+#include "Memory.h" // MemGetMainPtr() MemGetAuxPtr()
+#include "Video.h"
+
+const int SRCOFFS_40COL   = 0;                       //    0
+const int SRCOFFS_IIPLUS  = (SRCOFFS_40COL  +  256); //  256
+const int SRCOFFS_80COL   = (SRCOFFS_IIPLUS +  256); //  512
+const int SRCOFFS_LORES   = (SRCOFFS_80COL  +  128); //  640
+const int SRCOFFS_HIRES   = (SRCOFFS_LORES  +   16); //  656
+const int SRCOFFS_DHIRES  = (SRCOFFS_HIRES  +  512); // 1168
+const int SRCOFFS_TOTAL   = (SRCOFFS_DHIRES + 2560); // 3278
+
+const int MAX_SOURCE_Y = 512;
+static LPBYTE        g_aSourceStartofLine[ MAX_SOURCE_Y ];
+#define  SETSOURCEPIXEL(x,y,c)  g_aSourceStartofLine[(y)][(x)] = (c)
+
+
+enum Color_Palette_Index_e
+{
+	// ...
+// CUSTOM HGR COLORS (don't change order) - For tv emulation HGR Video Mode
+	  HGR_BLACK        
+	, HGR_WHITE        
+	, HGR_BLUE         // HCOLOR=6 BLUE   , 3000: 81 00 D5 AA
+	, HGR_ORANGE       // HCOLOR=5 ORANGE , 2C00: 82 00 AA D5
+	, HGR_GREEN        // HCOLOR=1 GREEN  , 2400: 02 00 2A 55
+	, HGR_VIOLET       // HCOLOR=2 VIOLET , 2800: 01 00 55 2A
+	, HGR_GREY1        
+	, HGR_GREY2        
+	, HGR_YELLOW       
+	, HGR_AQUA         
+	, HGR_PURPLE       
+	, HGR_PINK         
+};
+
+// __ Map HGR color index to Palette index
+enum ColorMapping
+{
+	  CM_Violet
+	, CM_Blue
+	, CM_Green
+	, CM_Orange
+	, CM_Black
+	, CM_White
+	, NUM_COLOR_MAPPING
+};
+
+const BYTE HiresToPalIndex[ NUM_COLOR_MAPPING ] =
+{
+	  HGR_VIOLET
+	, HGR_BLUE
+	, HGR_GREEN
+	, HGR_ORANGE
+	, HGR_BLACK
+	, HGR_WHITE
+};
+
+#define  SETRGBCOLOR(r,g,b) {b,g,r,0}
+
+static RGBQUAD PalIndex2RGB[] =
+{
+	SETRGBCOLOR(/*HGR_BLACK, */ 0x00,0x00,0x00), // For TV emulation HGR Video Mode
+	SETRGBCOLOR(/*HGR_WHITE, */ 0xFF,0xFF,0xFF),
+	SETRGBCOLOR(/*HGR_BLUE,  */   24, 115, 229), // HCOLOR=6 BLUE    3000: 81 00 D5 AA // 0x00,0x80,0xFF -> Linards Tweaked 0x0D,0xA1,0xFF
+	SETRGBCOLOR(/*HGR_ORANGE,*/  247,  64,  30), // HCOLOR=5 ORANGE  2C00: 82 00 AA D5 // 0xF0,0x50,0x00 -> Linards Tweaked 0xF2,0x5E,0x00 
+	SETRGBCOLOR(/*HGR_GREEN, */   27, 211,  79), // HCOLOR=1 GREEN   2400: 02 00 2A 55 // 0x20,0xC0,0x00 -> Linards Tweaked 0x38,0xCB,0x00
+	SETRGBCOLOR(/*HGR_VIOLET,*/  227,  20, 255), // HCOLOR=2 VIOLET  2800: 01 00 55 2A // 0xA0,0x00,0xFF -> Linards Tweaked 0xC7,0x34,0xFF
+
+	SETRGBCOLOR(/*HGR_GREY1, */ 0x80,0x80,0x80),
+	SETRGBCOLOR(/*HGR_GREY2, */ 0x80,0x80,0x80),
+	SETRGBCOLOR(/*HGR_YELLOW,*/ 0x9E,0x9E,0x00), // 0xD0,0xB0,0x10 -> 0x9E,0x9E,0x00
+	SETRGBCOLOR(/*HGR_AQUA,  */ 0x00,0xCD,0x4A), // 0x20,0xB0,0xB0 -> 0x00,0xCD,0x4A
+	SETRGBCOLOR(/*HGR_PURPLE,*/ 0x61,0x61,0xFF), // 0x60,0x50,0xE0 -> 0x61,0x61,0xFF
+	SETRGBCOLOR(/*HGR_PINK,  */ 0xFF,0x32,0xB5), // 0xD0,0x40,0xA0 -> 0xFF,0x32,0xB5
+};
+
+
+enum VideoTypeOld_e		// AppleWin 1.25.0.4
+{
+	  VT_MONO_HALFPIXEL_REAL // uses custom monochrome
+	, VT_COLOR_STANDARD
+	, VT_COLOR_TEXT_OPTIMIZED 
+	, VT_COLOR_TVEMU          
+//	, VT_MONO_AMBER // now half pixel
+//	, VT_MONO_GREEN // now half pixel
+//	, VT_MONO_WHITE // now half pixel
+//	, NUM_VIDEO_MODES
+};
+
+static DWORD g_eVideoTypeOld = VT_COLOR_TVEMU;
+
+
+static void V_CreateLookup_Hires()
+{
+//	int iMonochrome = GetMonochromeIndex();
+
+	// BYTE colorval[6] = {MAGENTA,BLUE,GREEN,ORANGE,BLACK,WHITE};
+	// BYTE colorval[6] = {HGR_MAGENTA,HGR_BLUE,HGR_GREEN,HGR_RED,HGR_BLACK,HGR_WHITE};
+	for (int iColumn = 0; iColumn < 16; iColumn++)
+	{
+		int coloffs = iColumn << 5;
+
+		for (unsigned iByte = 0; iByte < 256; iByte++)
+		{
+			int aPixels[11];
+
+			aPixels[ 0] = iColumn & 4;
+			aPixels[ 1] = iColumn & 8;
+			aPixels[ 9] = iColumn & 1;
+			aPixels[10] = iColumn & 2;
+
+			int nBitMask = 1;
+			int iPixel;
+			for (iPixel  = 2; iPixel < 9; iPixel++) {
+				aPixels[iPixel] = ((iByte & nBitMask) != 0);
+				nBitMask <<= 1;
+			}
+
+			int hibit = ((iByte & 0x80) != 0);
+			int x     = 0;
+			int y     = iByte << 1;
+
+			while (x < 28)
+			{
+				int adj = (x >= 14) << 1;
+				int odd = (x >= 14);
+
+				for (iPixel = 2; iPixel < 9; iPixel++)
+				{
+					int color = CM_Black;
+					if (aPixels[iPixel])
+					{
+						if (aPixels[iPixel-1] || aPixels[iPixel+1])
+							color = CM_White;
+						else
+							color = ((odd ^ (iPixel&1)) << 1) | hibit;
+					}
+					else if (aPixels[iPixel-1] && aPixels[iPixel+1])
+					{
+						// Activate fringe reduction on white HGR text - drawback: loss of color mix patterns in HGR video mode.
+						// VT_COLOR_STANDARD = Fill in colors in between white pixels
+						// VT_COLOR_TVEMU    = Fill in colors in between white pixels  (Post Processing will mix/merge colors)
+						// VT_COLOR_TEXT_OPTIMIZED --> !(aPixels[iPixel-2] && aPixels[iPixel+2]) = Don't fill in colors in between white
+						if ((g_eVideoTypeOld == VT_COLOR_TVEMU) || !(aPixels[iPixel-2] && aPixels[iPixel+2]) )
+							color = ((odd ^ !(iPixel&1)) << 1) | hibit;	// No white HGR text optimization
+					}
+
+					//if (g_eVideoTypeOld == VT_MONO_AUTHENTIC) {
+					//	int nMonoColor = (color != CM_Black) ? iMonochrome : BLACK;
+					//	SETSOURCEPIXEL(SRCOFFS_HIRES+coloffs+x+adj  ,y  , nMonoColor); // buggy
+					//	SETSOURCEPIXEL(SRCOFFS_HIRES+coloffs+x+adj+1,y  , nMonoColor); // buggy
+					//	SETSOURCEPIXEL(SRCOFFS_HIRES+coloffs+x+adj  ,y+1,BLACK); // BL
+					//	SETSOURCEPIXEL(SRCOFFS_HIRES+coloffs+x+adj+1,y+1,BLACK); // BR
+					//} else
+					{
+						// Colors - Top/Bottom Left/Right
+						// cTL cTR
+						// cBL cBR
+						SETSOURCEPIXEL(SRCOFFS_HIRES+coloffs+x+adj  ,y  ,HiresToPalIndex[color]); // cTL
+						SETSOURCEPIXEL(SRCOFFS_HIRES+coloffs+x+adj+1,y  ,HiresToPalIndex[color]); // cTR
+						SETSOURCEPIXEL(SRCOFFS_HIRES+coloffs+x+adj  ,y+1,HiresToPalIndex[color]); // cBL
+						SETSOURCEPIXEL(SRCOFFS_HIRES+coloffs+x+adj+1,y+1,HiresToPalIndex[color]); // cBR
+					}
+					x += 2;
+				}
+			}
+		}
+	}
+}
+
+//const UINT FRAMEBUFFER_H = 192*2;
+//static LPBYTE        g_aFrameBufferOffset[FRAMEBUFFER_H]; // array of pointers to start of each scanline
+//static UINT g_nFrameBufferPitch = 0;	// TODO
+
+static void CopySource(int /*dx*/, int /*dy*/, int w, int h, int sx, int sy, bgra_t *pVideoAddress)
+{
+//	UINT32* pDst = (UINT32*) (g_aFrameBufferOffset[ dy ] + dx*sizeof(UINT32));
+	UINT32* pDst = (UINT32*) pVideoAddress;
+	LPBYTE pSrc = g_aSourceStartofLine[ sy ] + sx;
+	int nBytes;
+
+	while (h--)
+	{
+		nBytes = w;
+		while (nBytes)
+		{
+			--nBytes;
+			if (g_uHalfScanLines && !(h & 1))
+			{
+				// 50% Half Scan Line clears every odd scanline (and SHIFT+PrintScreen saves only the even rows)
+				*(pDst+nBytes) = 0;
+			}
+			else
+			{
+//				const RGBQUAD& rRGB = GetFrameBufferInfo()->bmiColors[ *(pSrc+nBytes) ];
+				_ASSERT( *(pSrc+nBytes) < (sizeof(PalIndex2RGB)/sizeof(PalIndex2RGB[0])) );
+				const RGBQUAD& rRGB = PalIndex2RGB[ *(pSrc+nBytes) ];
+				const UINT32 rgb = (((UINT32)rRGB.rgbRed)<<16) | (((UINT32)rRGB.rgbGreen)<<8) | ((UINT32)rRGB.rgbBlue);
+				*(pDst+nBytes) = rgb;
+			}
+		}
+
+//		pDst -= g_nFrameBufferPitch / sizeof(UINT32);
+		pDst -= GetFrameBufferWidth();
+		pSrc -= SRCOFFS_TOTAL;
+	}
+}
+
+void UpdateHiResCell (int x, int y, uint16_t addr, bgra_t *pVideoAddress)
+{
+	int xpixel = x*14;
+	int ypixel = y*16;
+
+//	int offset = ((y & 7) << 7) + ((y >> 3) * 40) + x;
+//	BYTE* g_pHiresBank0 = MemGetMainPtr(0x2000);
+//	int  yoffset = 0;
+
+	uint8_t *pMain = MemGetMainPtr(addr);
+	BYTE byteval1 = (x >  0) ? *(pMain-1) : 0;
+	BYTE byteval2 =            *(pMain);
+	BYTE byteval3 = (x < 39) ? *(pMain+1) : 0;
+	{
+#define COLOFFS  (((byteval1 & 0x60) << 2) | ((byteval3 & 0x03) << 5))
+#if 0
+		if (g_eVideoTypeOld == VT_COLOR_TVEMU)
+		{
+			CopyMixedSource(
+				xpixel >> 1, (ypixel+(yoffset >> 9)) >> 1,
+				SRCOFFS_HIRES+COLOFFS+((x & 1) << 4), (((int)byteval2) << 1)
+			);
+		}
+		else
+#endif
+		{
+			CopySource(
+				0,0, /*xpixel,ypixel*/ /*+(yoffset >> 9)*/
+				14,2, // 2x upscale: 280x192 -> 560x384
+				SRCOFFS_HIRES+COLOFFS+((x & 1) << 4), (((int)byteval2) << 1),
+				pVideoAddress
+			);
+		}
+#undef COLOFFS
+	}
+}
+
+//===========================================================================
+
+static HBITMAP       g_hSourceBitmap = NULL;
+static LPBYTE        g_pSourcePixels = NULL;
+static LPBITMAPINFO  g_pSourceHeader = NULL;
+
+static void V_CreateDIBSections(void) 
+{
+//	CopyMemory(g_pSourceHeader->bmiColors,GetFrameBufferInfo()->bmiColors,256*sizeof(RGBQUAD));
+
+	// CREATE THE DEVICE CONTEXT
+	HWND window  = GetDesktopWindow();
+	HDC dc       = GetDC(window);
+#if 0
+	if (g_hDeviceDC)
+	{
+		DeleteDC(g_hDeviceDC);
+	}
+	g_hDeviceDC = CreateCompatibleDC(dc);
+
+	// CREATE THE FRAME BUFFER DIB SECTION
+	if (g_hDeviceBitmap)
+		DeleteObject(g_hDeviceBitmap);
+		g_hDeviceBitmap = CreateDIBSection(
+			dc,
+			g_pFramebufferinfo,
+			DIB_RGB_COLORS,
+			(LPVOID *)&g_pFramebufferbits,0,0
+		);
+	SelectObject(g_hDeviceDC,g_hDeviceBitmap);
+#endif
+
+	// CREATE THE SOURCE IMAGE DIB SECTION
+	HDC sourcedc = CreateCompatibleDC(dc);
+	ReleaseDC(window,dc);
+	if (g_hSourceBitmap)
+		DeleteObject(g_hSourceBitmap);
+
+	g_hSourceBitmap = CreateDIBSection(
+		sourcedc,
+		g_pSourceHeader,
+		DIB_RGB_COLORS,
+		(LPVOID *)&g_pSourcePixels,0,0
+	);
+	SelectObject(sourcedc,g_hSourceBitmap);
+
+	// CREATE THE OFFSET TABLE FOR EACH SCAN LINE IN THE SOURCE IMAGE
+	for (int y = 0; y < MAX_SOURCE_Y; y++)
+		g_aSourceStartofLine[ y ] = g_pSourcePixels + SRCOFFS_TOTAL*((MAX_SOURCE_Y-1) - y);
+
+	// DRAW THE SOURCE IMAGE INTO THE SOURCE BIT BUFFER
+	ZeroMemory(g_pSourcePixels,SRCOFFS_TOTAL*512); // 32 bytes/pixel * 16 colors = 512 bytes/row
+
+	// First monochrome mode is seperate from others
+//	if ((g_eVideoTypeOld >= VT_COLOR_STANDARD)	&& (g_eVideoTypeOld <  VT_MONO_AMBER))
+	{
+//		V_CreateLookup_Text(sourcedc);
+//		V_CreateLookup_Lores();
+		V_CreateLookup_Hires();
+//		V_CreateLookup_DoubleHires();
+	}
+
+	DeleteDC(sourcedc);
+}
+
+void VideoInitializeOriginal(void)
+{
+//	_ASSERT(GetFrameBufferInfo());
+
+	// CREATE A BITMAPINFO STRUCTURE FOR THE SOURCE IMAGE
+	g_pSourceHeader = (LPBITMAPINFO)VirtualAlloc(
+		NULL,
+		sizeof(BITMAPINFOHEADER) + 256*sizeof(RGBQUAD),
+		MEM_COMMIT,
+		PAGE_READWRITE);
+
+	ZeroMemory(g_pSourceHeader,sizeof(BITMAPINFOHEADER));
+	g_pSourceHeader->bmiHeader.biSize     = sizeof(BITMAPINFOHEADER);
+	g_pSourceHeader->bmiHeader.biWidth    = SRCOFFS_TOTAL;
+	g_pSourceHeader->bmiHeader.biHeight   = 512;
+	g_pSourceHeader->bmiHeader.biPlanes   = 1;
+	g_pSourceHeader->bmiHeader.biBitCount = 8;
+	g_pSourceHeader->bmiHeader.biClrUsed  = 256;
+
+//	// VideoReinitialize() ... except we set the frame buffer palette....
+//	V_CreateIdentityPalette();
+
+#if 0
+	//RGB() -> none
+	//PALETTERGB() -> PC_EXPLICIT
+	//??? RGB() -> PC_NOCOLLAPSE
+	for( int iColor = 0; iColor < NUM_COLOR_PALETTE; iColor++ )
+		customcolors[ iColor ] = ((DWORD)PC_EXPLICIT << 24) | RGB(
+		GetFrameBufferInfo()->bmiColors[iColor].rgbRed,
+		GetFrameBufferInfo()->bmiColors[iColor].rgbGreen,
+		GetFrameBufferInfo()->bmiColors[iColor].rgbBlue
+	);
+#endif
+
+	// CREATE THE FRAME BUFFER DIB SECTION AND DEVICE CONTEXT,
+	// CREATE THE SOURCE IMAGE DIB SECTION AND DRAW INTO THE SOURCE BIT BUFFER
+	V_CreateDIBSections();
+}

--- a/source/Video_OriginalColorTVMode.cpp
+++ b/source/Video_OriginalColorTVMode.cpp
@@ -254,7 +254,7 @@ static void V_CreateLookup_Hires()
 					else if (aPixels[iPixel-1] && aPixels[iPixel+1])
 					{
 						// Activate fringe reduction on white HGR text - drawback: loss of color mix patterns in HGR video mode.
-						// VT_COLOR_STANDARD = Fill in colors in between white pixels
+						// VT_COLOR_SIMPLIFIED = Fill in colors in between white pixels
 						// VT_COLOR_TVEMU    = Fill in colors in between white pixels  (Post Processing will mix/merge colors)
 						// VT_COLOR_TEXT_OPTIMIZED --> !(aPixels[iPixel-2] && aPixels[iPixel+2]) = Don't fill in colors in between white
 						if ((g_eVideoType == VT_COLOR_TVEMU) || !(aPixels[iPixel-2] && aPixels[iPixel+2]) )
@@ -424,7 +424,7 @@ Legend:
 							SETSOURCEPIXEL(SRCOFFS_HIRES+offsetx+x+16,y+1, HGR_ORANGE );
 						}
 #else
-						if ((g_eVideoType == VT_COLOR_STANDARD) || ( !aPixels[3] ))
+						if ((g_eVideoType == VT_COLOR_SIMPLIFIED) || ( !aPixels[3] ))
 						{ // "Text optimized" IF this pixel on, and adjacent right pixel off, then colorize first half-pixel of this byte
 							SETSOURCEPIXEL(SRCOFFS_HIRES+offsetx+x+0 ,y  , HGR_BLUE ); // 2000:D5 AA D5
 							SETSOURCEPIXEL(SRCOFFS_HIRES+offsetx+x+0 ,y+1, HGR_BLUE );
@@ -457,7 +457,7 @@ Legend:
 					{
 						// Activate fringe reduction on white HGR text - drawback: loss of color mix patterns in HGR video mode.
 						if (
-							(g_eVideoType == VT_COLOR_STANDARD) // Fill in colors in between white pixels
+							(g_eVideoType == VT_COLOR_SIMPLIFIED) // Fill in colors in between white pixels
 //						||	(g_eVideoType == VT_COLOR_TVEMU)    // Fill in colors in between white pixels (Post Processing will mix/merge colors)
 						|| !(aPixels[iPixel-2] && aPixels[iPixel+2]) ) // VT_COLOR_TEXT_OPTIMIZED -> Don't fill in colors in between white
 						{

--- a/source/Video_OriginalColorTVMode.cpp
+++ b/source/Video_OriginalColorTVMode.cpp
@@ -147,23 +147,6 @@ static RGBQUAD PalIndex2RGB[] =
 	SETRGBCOLOR(/*WHITE,*/      0xFF,0xFF,0xFF),
 };
 
-
-enum VideoTypeOld_e		// AppleWin 1.25.0.4
-{
-	  VT_MONO_HALFPIXEL_REAL // uses custom monochrome
-	, VT_COLOR_STANDARD
-	, VT_COLOR_TEXT_OPTIMIZED 
-	, VT_COLOR_TVEMU          
-//	, VT_MONO_AMBER // now half pixel
-//	, VT_MONO_GREEN // now half pixel
-//	, VT_MONO_WHITE // now half pixel
-//	, NUM_VIDEO_MODES
-};
-
-//static DWORD g_eVideoTypeOld = VT_COLOR_TVEMU;
-static DWORD g_eVideoTypeOld = VT_COLOR_STANDARD;
-
-
 //===========================================================================
 
 static void V_CreateLookup_DoubleHires ()
@@ -194,6 +177,7 @@ static void V_CreateLookup_DoubleHires ()
         }
       }
 
+#if 0
 	  if (g_eVideoType == VT_COLOR_TEXT_OPTIMIZED)
 	  {
 	    // Activate for fringe reduction on white HGR text - drawback: loss of color mix patterns in HGR Video Mode.
@@ -205,6 +189,7 @@ static void V_CreateLookup_DoubleHires ()
 				color[pos-OFFSET] = 15;
 		}
 	  }
+#endif
 
       int y = byteval << 1;
       for (int x = 0; x < SIZE; x++) {
@@ -271,11 +256,11 @@ static void V_CreateLookup_Hires()
 						// VT_COLOR_STANDARD = Fill in colors in between white pixels
 						// VT_COLOR_TVEMU    = Fill in colors in between white pixels  (Post Processing will mix/merge colors)
 						// VT_COLOR_TEXT_OPTIMIZED --> !(aPixels[iPixel-2] && aPixels[iPixel+2]) = Don't fill in colors in between white
-						if ((g_eVideoTypeOld == VT_COLOR_TVEMU) || !(aPixels[iPixel-2] && aPixels[iPixel+2]) )
+						if ((g_eVideoType == VT_COLOR_TVEMU) || !(aPixels[iPixel-2] && aPixels[iPixel+2]) )
 							color = ((odd ^ !(iPixel&1)) << 1) | hibit;	// No white HGR text optimization
 					}
 
-					//if (g_eVideoTypeOld == VT_MONO_AUTHENTIC) {
+					//if (g_eVideoType == VT_MONO_AUTHENTIC) {
 					//	int nMonoColor = (color != CM_Black) ? iMonochrome : BLACK;
 					//	SETSOURCEPIXEL(SRCOFFS_HIRES+coloffs+x+adj  ,y  , nMonoColor); // buggy
 					//	SETSOURCEPIXEL(SRCOFFS_HIRES+coloffs+x+adj+1,y  , nMonoColor); // buggy
@@ -438,7 +423,7 @@ Legend:
 							SETSOURCEPIXEL(SRCOFFS_HIRES+offsetx+x+16,y+1, HGR_ORANGE );
 						}
 #else
-						if ((g_eVideoTypeOld == VT_COLOR_STANDARD) || ( !aPixels[3] ))
+						if ((g_eVideoType == VT_COLOR_STANDARD) || ( !aPixels[3] ))
 						{ // "Text optimized" IF this pixel on, and adjacent right pixel off, then colorize first half-pixel of this byte
 							SETSOURCEPIXEL(SRCOFFS_HIRES+offsetx+x+0 ,y  , HGR_BLUE ); // 2000:D5 AA D5
 							SETSOURCEPIXEL(SRCOFFS_HIRES+offsetx+x+0 ,y+1, HGR_BLUE );
@@ -471,8 +456,8 @@ Legend:
 					{
 						// Activate fringe reduction on white HGR text - drawback: loss of color mix patterns in HGR video mode.
 						if (
-							(g_eVideoTypeOld == VT_COLOR_STANDARD) // Fill in colors in between white pixels
-						||	(g_eVideoTypeOld == VT_COLOR_TVEMU)    // Fill in colors in between white pixels (Post Processing will mix/merge colors)
+							(g_eVideoType == VT_COLOR_STANDARD) // Fill in colors in between white pixels
+//						||	(g_eVideoType == VT_COLOR_TVEMU)    // Fill in colors in between white pixels (Post Processing will mix/merge colors)
 						|| !(aPixels[iPixel-2] && aPixels[iPixel+2]) ) // VT_COLOR_TEXT_OPTIMIZED -> Don't fill in colors in between white
 						{
 							// Test Pattern: Ultima 4 Logo - Castle
@@ -539,7 +524,7 @@ void UpdateHiResCell (int x, int y, uint16_t addr, bgra_t *pVideoAddress)
 
 #define COLOFFS  (((byteval1 & 0x60) << 2) | ((byteval3 & 0x03) << 5))
 #if 0
-	if (g_eVideoTypeOld == VT_COLOR_TVEMU)
+	if (g_eVideoType == VT_COLOR_TVEMU)
 	{
 		CopyMixedSource(
 			xpixel >> 1, (ypixel+(yoffset >> 9)) >> 1,

--- a/source/Video_OriginalColorTVMode.cpp
+++ b/source/Video_OriginalColorTVMode.cpp
@@ -5,6 +5,7 @@
 #include "Frame.h"
 #include "Memory.h" // MemGetMainPtr() MemGetAuxPtr()
 #include "Video.h"
+#include "Video_OriginalColorTVMode.h"
 
 const int SRCOFFS_LORES   = 0;                       //    0
 const int SRCOFFS_HIRES   = (SRCOFFS_LORES  +   16); //   16
@@ -614,7 +615,7 @@ void UpdateDLoResCell (int x, int y, uint16_t addr, bgra_t *pVideoAddress)
 
 static LPBYTE g_pSourcePixels = NULL;
 
-static void V_CreateDIBSections(void) 
+static void V_CreateDIBSections(void)
 {
 	g_pSourcePixels = new BYTE[SRCOFFS_TOTAL * MAX_SOURCE_Y];
 
@@ -635,8 +636,16 @@ static void V_CreateDIBSections(void)
 	V_CreateLookup_DoubleHires();
 }
 
-void VideoInitializeOriginal(void)
+void VideoInitializeOriginal(baseColors_t baseColors)
 {
 	// CREATE THE SOURCE IMAGE AND DRAW INTO THE SOURCE BIT BUFFER
 	V_CreateDIBSections();
+
+#if 1
+	memcpy(&PalIndex2RGB[BLACK], *baseColors, sizeof(RGBQUAD)*kNumBaseColors);
+	PalIndex2RGB[HGR_BLUE]   = PalIndex2RGB[BLUE];
+	PalIndex2RGB[HGR_ORANGE] = PalIndex2RGB[ORANGE];
+	PalIndex2RGB[HGR_GREEN]  = PalIndex2RGB[GREEN];
+	PalIndex2RGB[HGR_VIOLET] = PalIndex2RGB[MAGENTA];
+#endif
 }

--- a/source/Video_OriginalColorTVMode.cpp
+++ b/source/Video_OriginalColorTVMode.cpp
@@ -65,11 +65,18 @@ static RGBQUAD PalIndex2RGB[] =
 {
 	SETRGBCOLOR(/*HGR_BLACK, */ 0x00,0x00,0x00), // For TV emulation HGR Video Mode
 	SETRGBCOLOR(/*HGR_WHITE, */ 0xFF,0xFF,0xFF),
-	SETRGBCOLOR(/*HGR_BLUE,  */   24, 115, 229), // HCOLOR=6 BLUE    3000: 81 00 D5 AA // 0x00,0x80,0xFF -> Linards Tweaked 0x0D,0xA1,0xFF
-	SETRGBCOLOR(/*HGR_ORANGE,*/  247,  64,  30), // HCOLOR=5 ORANGE  2C00: 82 00 AA D5 // 0xF0,0x50,0x00 -> Linards Tweaked 0xF2,0x5E,0x00 
-	SETRGBCOLOR(/*HGR_GREEN, */   27, 211,  79), // HCOLOR=1 GREEN   2400: 02 00 2A 55 // 0x20,0xC0,0x00 -> Linards Tweaked 0x38,0xCB,0x00
-	SETRGBCOLOR(/*HGR_VIOLET,*/  227,  20, 255), // HCOLOR=2 VIOLET  2800: 01 00 55 2A // 0xA0,0x00,0xFF -> Linards Tweaked 0xC7,0x34,0xFF
 
+//	SETRGBCOLOR(/*HGR_BLUE,  */   24, 115, 229), // HCOLOR=6 BLUE    3000: 81 00 D5 AA // 0x00,0x80,0xFF -> Linards Tweaked 0x0D,0xA1,0xFF
+//	SETRGBCOLOR(/*HGR_ORANGE,*/  247,  64,  30), // HCOLOR=5 ORANGE  2C00: 82 00 AA D5 // 0xF0,0x50,0x00 -> Linards Tweaked 0xF2,0x5E,0x00 
+//	SETRGBCOLOR(/*HGR_GREEN, */   27, 211,  79), // HCOLOR=1 GREEN   2400: 02 00 2A 55 // 0x20,0xC0,0x00 -> Linards Tweaked 0x38,0xCB,0x00
+//	SETRGBCOLOR(/*HGR_VIOLET,*/  227,  20, 255), // HCOLOR=2 VIOLET  2800: 01 00 55 2A // 0xA0,0x00,0xFF -> Linards Tweaked 0xC7,0x34,0xFF
+	SETRGBCOLOR(/*BLUE,      */ 0x0D,0xA1,0xFF), // FC Linards Tweaked 0x00,0x00,0xFF -> 0x0D,0xA1,0xFF
+	SETRGBCOLOR(/*ORANGE,    */ 0xF2,0x5E,0x00), // 0xFF,0x80,0x00 -> Linards Tweaked 0xF2,0x5E,0x00
+	SETRGBCOLOR(/*GREEN,     */ 0x38,0xCB,0x00), // FA Linards Tweaked 0x00,0xFF,0x00 -> 0x38,0xCB,0x00
+	SETRGBCOLOR(/*MAGENTA,   */ 0xC7,0x34,0xFF), // FD Linards Tweaked 0xFF,0x00,0xFF -> 0xC7,0x34,0xFF
+
+
+// For TV Emu:
 //	SETRGBCOLOR(/*HGR_GREY1, */ 0x80,0x80,0x80),
 //	SETRGBCOLOR(/*HGR_GREY2, */ 0x80,0x80,0x80),
 //	SETRGBCOLOR(/*HGR_YELLOW,*/ 0x9E,0x9E,0x00), // 0xD0,0xB0,0x10 -> 0x9E,0x9E,0x00
@@ -91,7 +98,8 @@ enum VideoTypeOld_e		// AppleWin 1.25.0.4
 //	, NUM_VIDEO_MODES
 };
 
-static DWORD g_eVideoTypeOld = VT_COLOR_TVEMU;
+//static DWORD g_eVideoTypeOld = VT_COLOR_TVEMU;
+static DWORD g_eVideoTypeOld = VT_COLOR_STANDARD;
 
 
 static void V_CreateLookup_Hires()
@@ -172,6 +180,191 @@ static void V_CreateLookup_Hires()
 	}
 }
 
+#define HALF_PIXEL_SOLID 1
+#define HALF_PIXEL_BLEED 0
+
+void V_CreateLookup_HiResHalfPixel_Authentic() // Colors are solid (100% coverage)
+{
+	// 2-bits from previous byte, 2-bits from next byte = 2^4 = 16 total permutations
+	for (int iColumn = 0; iColumn < 16; iColumn++)
+	{
+		int offsetx = iColumn << 5; // every column is 32 bytes wide -- 7 apple pixels = 14 pixels + 2 pad + 14 pixels + 2 pad
+
+		for (unsigned iByte = 0; iByte < 256; iByte++)
+		{
+			int aPixels[11]; // c2 c1 b7 b6 b5 b4 b3 b2 b1 b0 c8 c4
+
+/*
+aPixel[i]
+ A 9|8 7 6 5 4 3 2|1 0
+ Z W|b b b b b b b|X Y
+----+-------------+----
+prev|  existing   |next
+bits| hi-res byte |bits
+
+Legend:
+ XYZW = iColumn in binary
+ b = Bytes in binary
+*/
+			// aPixel[] = 48bbbbbbbb12, where b = iByte in binary, # is bit-n of column
+			aPixels[ 0] = iColumn & 4; // previous byte, 2nd last pixel
+			aPixels[ 1] = iColumn & 8; // previous byte, last pixel
+			aPixels[ 9] = iColumn & 1; // next byte, first pixel
+			aPixels[10] = iColumn & 2; // next byte, second pixel
+
+			// Convert raw pixel Byte value to binary and stuff into bit array of pixels on off
+			int nBitMask = 1;
+			int iPixel;
+			for (iPixel  = 2; iPixel < 9; iPixel++)
+			{
+				aPixels[iPixel] = ((iByte & nBitMask) != 0);
+				nBitMask <<= 1;
+			}
+
+			int hibit = (iByte >> 7) & 1; // ((iByte & 0x80) != 0);
+			int x     = 0;
+			int y     = iByte << 1;
+
+/* Test cases
+ 81 blue
+   2000:D5 AA D5 AA
+ 82 orange
+   2800:AA D5 AA D5
+ FF white bleed "thru"
+   3000:7F 80 7F 80
+   3800:FF 80 FF 80
+   2028:80 7F 80 7F
+   2828:80 FF 80 FF
+ Edge Case for Half Luminance !
+   2000:C4 00  // Green  HalfLumBlue
+   2400:C4 80  // Green  Green
+ Edge Case for Color Bleed !
+   2000:40 00
+   2400:40 80
+*/
+
+			// Fixup missing pixels that normally have been scan-line shifted -- Apple "half-pixel" -- but cross 14-pixel boundaries.
+			if( hibit )
+			{
+				if ( aPixels[1] ) // preceeding pixel on?
+#if 0 // Optimization: Doesn't seem to matter if we ignore the 2 pixels of the next byte
+					for (iPixel = 0; iPixel < 9; iPixel++) // NOTE: You MUST start with the preceding 2 pixels !!!
+						if (aPixels[iPixel]) // pixel on
+#endif
+						{
+							if (aPixels[2] || aPixels[0]) // White if pixel from previous byte and first pixel of this byte is on
+							{
+								SETSOURCEPIXEL(SRCOFFS_HIRES+offsetx+x+0 ,y  , HGR_WHITE );
+								SETSOURCEPIXEL(SRCOFFS_HIRES+offsetx+x+0 ,y+1, HGR_WHITE );
+								SETSOURCEPIXEL(SRCOFFS_HIRES+offsetx+x+16,y  , HGR_WHITE );
+								SETSOURCEPIXEL(SRCOFFS_HIRES+offsetx+x+16,y+1, HGR_WHITE );
+							} else {   // Optimization:   odd = (iPixel & 1); if (!odd) case is same as if(odd) !!! // Reference: Gumball - Gumball Machine
+								SETSOURCEPIXEL(SRCOFFS_HIRES+offsetx+x+0 ,y  , HGR_ORANGE ); // left half of orange pixels 
+								SETSOURCEPIXEL(SRCOFFS_HIRES+offsetx+x+0 ,y+1, HGR_ORANGE );
+								SETSOURCEPIXEL(SRCOFFS_HIRES+offsetx+x+16,y  , HGR_BLUE ); // right half of blue pixels 4, 11, 18, ...
+								SETSOURCEPIXEL(SRCOFFS_HIRES+offsetx+x+16,y+1, HGR_BLUE );
+							}
+						}
+#if HALF_PIXEL_SOLID
+// Test Patterns 
+// 81 blue
+//   2000:D5 AA D5 AA -> 2001:AA D5  should not have black gap, should be blue
+// 82 orange
+//   2800:AA D5 AA D5
+// Game: Elite -- Loading Logo 
+//   2444:BB F7 -> 2000:BB F7    // Should not have orange in-between gap -- Elite "Firebird" Logo
+//              -> 2400:00 BB F7 // Should not have blue in-between gap )
+//   21D0:C0 00    -> HalfLumBlue
+//   25D0:C0 D0 88 -> Blue black orange black orange
+//   29D0:C0 90 88 -> Blue black orange
+// Game: Ultima 4 -- Ultima 4 Logo - bottom half of screen has a "mini-game" / demo -- far right has tree and blue border
+//   2176:2A AB green black_gap white blue_border // Should have black gap between green and white
+				else if ( aPixels[0] ) // prev prev pixel on
+				{
+// Game: Gumball
+//   218E:AA 97    => 2000: A9 87          orange_white            // Should have no gap between orange and white
+//   229A:AB A9 87 -> 2000: 00 A9 87 white orange black blue_white // Should have no gap between blue and white
+//   2001:BB F7                            white blue white  (Gumball Intermission)
+// Torture Half-Pixel HGR Tests:  This is a real bitch to solve -- we really need to check:
+//     if (hibit_prev_byte && !aPixels[iPixel-3] && aPixels[iPixel-2] && !aPixels[iPixel] && hibit_this_byte) then set first half-pixel of this byte to either blue or orange
+//   2000:A9 87 halfblack blue black black orange black orange black
+//   2400:BB F7 halfblack white white black white white white halfblack
+//  or
+//   2000:A0 83 orange should "bleed" thru
+//   2400:B0 83 should have black gap
+
+					if ( aPixels[2] )
+#if HALF_PIXEL_BLEED // No Half-Pixel Bleed
+						if ( aPixels[3] ) {
+							SETSOURCEPIXEL(SRCOFFS_HIRES+offsetx+x+0 ,y  , DARK_BLUE ); // Gumball: 229A: AB A9 87
+							SETSOURCEPIXEL(SRCOFFS_HIRES+offsetx+x+0 ,y+1, DARK_BLUE );
+							SETSOURCEPIXEL(SRCOFFS_HIRES+offsetx+x+16,y  , BROWN ); // half luminance red Elite: 2444: BB F7
+							SETSOURCEPIXEL(SRCOFFS_HIRES+offsetx+x+16,y+1, BROWN ); // half luminance red Gumball: 218E: AA 97
+						} else {
+							SETSOURCEPIXEL(SRCOFFS_HIRES+offsetx+x+0 ,y  , HGR_BLUE ); // 2000:D5 AA D5
+							SETSOURCEPIXEL(SRCOFFS_HIRES+offsetx+x+0 ,y+1, HGR_BLUE );
+							SETSOURCEPIXEL(SRCOFFS_HIRES+offsetx+x+16,y  , HGR_ORANGE ); // 2000: AA D5
+							SETSOURCEPIXEL(SRCOFFS_HIRES+offsetx+x+16,y+1, HGR_ORANGE );
+						}
+#else
+						if ((g_eVideoTypeOld == VT_COLOR_STANDARD) || ( !aPixels[3] ))
+						{ // "Text optimized" IF this pixel on, and adjacent right pixel off, then colorize first half-pixel of this byte
+							SETSOURCEPIXEL(SRCOFFS_HIRES+offsetx+x+0 ,y  , HGR_BLUE ); // 2000:D5 AA D5
+							SETSOURCEPIXEL(SRCOFFS_HIRES+offsetx+x+0 ,y+1, HGR_BLUE );
+							SETSOURCEPIXEL(SRCOFFS_HIRES+offsetx+x+16,y  , HGR_ORANGE ); // 2000: AA D5
+							SETSOURCEPIXEL(SRCOFFS_HIRES+offsetx+x+16,y+1, HGR_ORANGE );
+						}
+#endif // HALF_PIXEL_BLEED
+				}
+#endif // HALF_PIXEL_SOLID
+			}
+			x += hibit;
+
+			while (x < 28)
+			{
+				int adj = (x >= 14) << 1; // Adjust start of 7 last pixels to be 16-byte aligned!
+				int odd = (x >= 14);
+				for (iPixel = 2; iPixel < 9; iPixel++)
+				{
+					int color = CM_Black;
+					if (aPixels[iPixel]) // pixel on
+					{
+						color = CM_White; 
+						if (aPixels[iPixel-1] || aPixels[iPixel+1]) // adjacent pixels are always white
+							color = CM_White; 
+						else
+							color = ((odd ^ (iPixel&1)) << 1) | hibit; // map raw color to our hi-res colors
+					}
+#if HALF_PIXEL_SOLID
+					else if (aPixels[iPixel-1] && aPixels[iPixel+1]) // IF prev_pixel && next_pixel THEN
+					{
+						// Activate fringe reduction on white HGR text - drawback: loss of color mix patterns in HGR video mode.
+						if (
+							(g_eVideoTypeOld == VT_COLOR_STANDARD) // Fill in colors in between white pixels
+						||	(g_eVideoTypeOld == VT_COLOR_TVEMU)    // Fill in colors in between white pixels (Post Processing will mix/merge colors)
+						|| !(aPixels[iPixel-2] && aPixels[iPixel+2]) ) // VT_COLOR_TEXT_OPTIMIZED -> Don't fill in colors in between white
+						{
+							// Test Pattern: Ultima 4 Logo - Castle
+							// 3AC8: 36 5B 6D 36
+							color = ((odd ^ !(iPixel&1)) << 1) | hibit;	// No white HGR text optimization
+						}
+					}
+#endif
+					// Colors - Top/Bottom Left/Right
+					// cTL cTR
+					// cBL cBR
+					SETSOURCEPIXEL(SRCOFFS_HIRES+offsetx+x+adj  ,y  ,HiresToPalIndex[color]); // cTL
+					SETSOURCEPIXEL(SRCOFFS_HIRES+offsetx+x+adj+1,y  ,HiresToPalIndex[color]); // cTR
+					SETSOURCEPIXEL(SRCOFFS_HIRES+offsetx+x+adj  ,y+1,HiresToPalIndex[color]); // cBL
+					SETSOURCEPIXEL(SRCOFFS_HIRES+offsetx+x+adj+1,y+1,HiresToPalIndex[color]); // cBR
+					x += 2;
+				}
+			}
+		}
+	}
+}
+
+
 static void CopySource(int /*dx*/, int /*dy*/, int w, int h, int sx, int sy, bgra_t *pVideoAddress)
 {
 	UINT32* pDst = (UINT32*) pVideoAddress;
@@ -242,7 +435,7 @@ void UpdateHiResCell (int x, int y, uint16_t addr, bgra_t *pVideoAddress)
 
 //===========================================================================
 
-static LPBYTE        g_pSourcePixels = NULL;
+static LPBYTE g_pSourcePixels = NULL;
 
 static void V_CreateDIBSections(void) 
 {
@@ -253,14 +446,17 @@ static void V_CreateDIBSections(void)
 		g_aSourceStartofLine[ y ] = g_pSourcePixels + SRCOFFS_TOTAL*((MAX_SOURCE_Y-1) - y);
 
 	// DRAW THE SOURCE IMAGE INTO THE SOURCE BIT BUFFER
-	ZeroMemory(g_pSourcePixels,SRCOFFS_TOTAL*MAX_SOURCE_Y); // 32 bytes/pixel * 16 colors = 512 bytes/row
+	ZeroMemory(g_pSourcePixels, SRCOFFS_TOTAL*MAX_SOURCE_Y); // 32 bytes/pixel * 16 colors = 512 bytes/row
 
 	// First monochrome mode is seperate from others
 //	if ((g_eVideoTypeOld >= VT_COLOR_STANDARD)	&& (g_eVideoTypeOld <  VT_MONO_AMBER))
 	{
 //		V_CreateLookup_Text(sourcedc);
 //		V_CreateLookup_Lores();
-		V_CreateLookup_Hires();
+		if ( g_eVideoType == VT_COLOR_TVEMU )
+			V_CreateLookup_Hires();
+		else
+			V_CreateLookup_HiResHalfPixel_Authentic();
 //		V_CreateLookup_DoubleHires();
 	}
 }

--- a/source/Video_OriginalColorTVMode.h
+++ b/source/Video_OriginalColorTVMode.h
@@ -1,0 +1,2 @@
+void UpdateHiResCell (int x, int y, uint16_t addr, bgra_t *pVideoAddress);
+void VideoInitializeOriginal(void);

--- a/source/Video_OriginalColorTVMode.h
+++ b/source/Video_OriginalColorTVMode.h
@@ -2,4 +2,7 @@ void UpdateHiResCell(int x, int y, uint16_t addr, bgra_t *pVideoAddress);
 void UpdateDHiResCell(int x, int y, uint16_t addr, bgra_t *pVideoAddress);
 void UpdateLoResCell(int x, int y, uint16_t addr, bgra_t *pVideoAddress);
 void UpdateDLoResCell(int x, int y, uint16_t addr, bgra_t *pVideoAddress);
-void VideoInitializeOriginal(void);
+
+const UINT kNumBaseColors = 16;
+typedef bgra_t (*baseColors_t)[kNumBaseColors];
+void VideoInitializeOriginal(baseColors_t baseColors);

--- a/source/Video_OriginalColorTVMode.h
+++ b/source/Video_OriginalColorTVMode.h
@@ -1,2 +1,5 @@
-void UpdateHiResCell (int x, int y, uint16_t addr, bgra_t *pVideoAddress);
+void UpdateHiResCell(int x, int y, uint16_t addr, bgra_t *pVideoAddress);
+void UpdateDHiResCell(int x, int y, uint16_t addr, bgra_t *pVideoAddress);
+void UpdateLoResCell(int x, int y, uint16_t addr, bgra_t *pVideoAddress);
+void UpdateDLoResCell(int x, int y, uint16_t addr, bgra_t *pVideoAddress);
 void VideoInitializeOriginal(void);

--- a/source/Video_OriginalColorTVMode.h
+++ b/source/Video_OriginalColorTVMode.h
@@ -5,4 +5,4 @@ void UpdateDLoResCell(int x, int y, uint16_t addr, bgra_t *pVideoAddress);
 
 const UINT kNumBaseColors = 16;
 typedef bgra_t (*baseColors_t)[kNumBaseColors];
-void VideoInitializeOriginal(baseColors_t baseColors);
+void VideoInitializeOriginal(baseColors_t pBaseNtscColors);


### PR DESCRIPTION
PR for #357.

Renamed this video mode to: "Color (RGB Monitor)"
Also renamed "Color (Monitor)" to "Color (NTSC Monitor)".

As for the colours: I've changed them from the original 1.25 colours. Instead I *runtime-generate* the colours from the NTSC code. See NTSC.cpp's GenerateBaseColors(). This shifts the same 4-bit pattern in, combining with NTSC color phase, until the colour stabilises. Then I average the next 4 RGB values to get the final colour. The reason for this is that we now have consistent colours between NTSC and this simplified rendering mode.

NB. The 2 greys (in GR,DGR,DHGR) are now the same RGB value.