### PR TITLE
Do not reset on minor state load errors

### DIFF
--- a/source/SaveState.cpp
+++ b/source/SaveState.cpp
@@ -358,13 +358,28 @@ static void Snapshot_LoadState_v2(void)
 {
 	try
 	{
+		std::string err_msg = "";
 		int res = yamlHelper.InitParser( g_strSaveStatePathname.c_str() );
 		if (!res)
-			throw std::string("Failed to initialize parser or open file");	// TODO: disambiguate
+		{
+			err_msg = "Failed to initialize parser or open file";
+		}
+		else
+		{
+			UINT version = ParseFileHdr();
+			if (version != SS_FILE_VER)
+				err_msg = "Version mismatch";
+		}
 
-		UINT version = ParseFileHdr();
-		if (version != SS_FILE_VER)
-			throw std::string("Version mismatch");
+		if (err_msg != "")
+		{
+			MessageBox(g_hFrameWindow,
+				err_msg.c_str(),
+				TEXT("Load State"),
+				MB_ICONEXCLAMATION | MB_SETFOREGROUND);
+
+			return;
+		}
 
 		//
 


### PR DESCRIPTION
The state load function resets the machine too aggressively in my opinion. Occasionally I press F12 instead of F11 to save a state, and after specifying an invalid file name get an error and the system resets, despite no configuration being set. For those minor errors that occur at the start of the state load process, instead of throwing an exception, this displays the error message and cancels the state load.