### PR TITLE
Prevent uninitialized value bugs and improve string safety.

### DIFF
--- a/source/Applewin.h
+++ b/source/Applewin.h
@@ -9,7 +9,7 @@ void LogFileTimeUntilFirstKeyRead(void);
 bool SetCurrentImageDir(const char* pszImageDir);
 
 extern const UINT16* GetOldAppleWinVersion(void);
-extern char VERSIONSTRING[];	// Constructed in WinMain()
+extern TCHAR VERSIONSTRING[];	// Constructed in WinMain()
 
 extern const TCHAR     *g_pAppTitle;
 

--- a/source/Configuration/About.cpp
+++ b/source/Configuration/About.cpp
@@ -27,7 +27,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "../Frame.h"
 #include "../resource/resource.h"
 
-static const char g_szGPL[] = 
+static const TCHAR g_szGPL[] = 
 "This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.\r\n\
 \r\n\
 This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.\r\n\
@@ -65,8 +65,8 @@ static BOOL CALLBACK DlgProcAbout(HWND hWnd, UINT message, WPARAM wparam, LPARAM
 			HICON hIcon = LoadIcon(g_hInstance, TEXT("APPLEWIN_ICON"));
 			SendDlgItemMessage(hWnd, IDC_APPLEWIN_ICON, STM_SETIMAGE, IMAGE_ICON, (LPARAM)hIcon);
 
-			char szAppleWinVersion[50];
-			sprintf(szAppleWinVersion, "AppleWin v%s", VERSIONSTRING);
+			TCHAR szAppleWinVersion[50];
+			StringCbPrintf(szAppleWinVersion, 50, "AppleWin v%s", VERSIONSTRING);
 			SendDlgItemMessage(hWnd, IDC_APPLEWIN_VERSION, WM_SETTEXT, 0, (LPARAM)szAppleWinVersion);
 
 			SendDlgItemMessage(hWnd, IDC_GPL_TEXT, WM_SETTEXT, 0, (LPARAM)g_szGPL);

--- a/source/Configuration/PageConfig.cpp
+++ b/source/Configuration/PageConfig.cpp
@@ -217,8 +217,9 @@ BOOL CPageConfig::DlgProcInternal(HWND hWnd, UINT message, WPARAM wparam, LPARAM
 				BOOL bCustom = TRUE;
 				if (g_dwSpeed == SPEED_NORMAL)
 				{
-					bCustom = FALSE;
-					REGLOAD(TEXT(REGVALUE_CUSTOM_SPEED),(DWORD *)&bCustom);
+					DWORD dwCustomSpeed;
+					REGLOAD_DEFAULT(TEXT(REGVALUE_CUSTOM_SPEED), &dwCustomSpeed, 0);
+					bCustom = dwCustomSpeed ? TRUE : FALSE;
 				}
 				CheckRadioButton(hWnd, IDC_AUTHENTIC_SPEED, IDC_CUSTOM_SPEED, bCustom ? IDC_CUSTOM_SPEED : IDC_AUTHENTIC_SPEED);
 				SetFocus(GetDlgItem(hWnd, bCustom ? IDC_SLIDER_CPU_SPEED : IDC_AUTHENTIC_SPEED));

--- a/source/Configuration/PageConfigTfe.cpp
+++ b/source/Configuration/PageConfigTfe.cpp
@@ -143,10 +143,10 @@ int CPageConfigTfe::gray_ungray_items(HWND hwnd)
 	int enable;
 	int number;
 
-	int disabled = 0;
-
 	//resources_get_value("ETHERNET_DISABLED", (void *)&disabled);
-	REGLOAD(TEXT("Uthernet Disabled")  ,(DWORD *)&disabled);
+	DWORD dwDisabled;
+	REGLOAD_DEFAULT(TEXT("Uthernet Disabled"), &dwDisabled, 0);
+	int disabled = dwDisabled ? 1 : 0;
 	get_disabled_state(&disabled);
 
 	if (disabled)

--- a/source/Configuration/PageDisk.cpp
+++ b/source/Configuration/PageDisk.cpp
@@ -148,8 +148,8 @@ BOOL CPageDisk::DlgProcInternal(HWND hWnd, UINT message, WPARAM wparam, LPARAM l
 
 			InitComboHDD(hWnd);
 
-			TCHAR PathToCiderPress[MAX_PATH] = "";
-			RegLoadString(TEXT(REG_CONFIG), REGVALUE_CIDERPRESSLOC, 1, PathToCiderPress,MAX_PATH);
+			TCHAR PathToCiderPress[MAX_PATH];
+			RegLoadString(TEXT(REG_CONFIG), REGVALUE_CIDERPRESSLOC, 1, PathToCiderPress, MAX_PATH, TEXT(""));
 			SendDlgItemMessage(hWnd, IDC_CIDERPRESS_FILENAME ,WM_SETTEXT, 0, (LPARAM)PathToCiderPress);
 
 			CheckDlgButton(hWnd, IDC_HDD_ENABLE, HD_CardIsEnabled() ? BST_CHECKED : BST_UNCHECKED);

--- a/source/Configuration/PropertySheetHelper.cpp
+++ b/source/Configuration/PropertySheetHelper.cpp
@@ -141,8 +141,7 @@ std::string CPropertySheetHelper::BrowseToFile(HWND hWindow, TCHAR* pszTitle, TC
 	strcpy(PathToFile, Snapshot_GetFilename()); //RAPCS, line 2.
 	TCHAR szDirectory[MAX_PATH] = TEXT("");
 	TCHAR szFilename[MAX_PATH];
-	strcpy(szFilename, "");
-	RegLoadString(TEXT("Configuration"), REGVALUE, 1, szFilename ,MAX_PATH);
+	RegLoadString(TEXT("Configuration"), REGVALUE, 1, szFilename, MAX_PATH, TEXT(""));
 	std::string PathName = szFilename;
 
 	OPENFILENAME ofn;
@@ -175,7 +174,7 @@ std::string CPropertySheetHelper::BrowseToFile(HWND hWindow, TCHAR* pszTitle, TC
 	}
 	else		// Cancel is pressed
 	{
-		RegLoadString(TEXT("Configuration"), REGVALUE, 1, szFilename,MAX_PATH);
+		RegLoadString(TEXT("Configuration"), REGVALUE, 1, szFilename, MAX_PATH, TEXT(""));
 		PathName = szFilename;
 	}
 

--- a/source/Frame.cpp
+++ b/source/Frame.cpp
@@ -2050,10 +2050,17 @@ static void ProcessButtonClick(int button, bool bFromButtonUI /*=false*/)
 // http://www.codeproject.com/menu/MenusForBeginners.asp?df=100&forumid=67645&exp=0&select=903061
 
 void ProcessDiskPopupMenu(HWND hwnd, POINT pt, const int iDrive)
-{		
-	//This is the default installation path of CiderPress. It shall not be left blank, otherwise  an explorer window will be open.
-	TCHAR PathToCiderPress[MAX_PATH] = "C:\\Program Files\\faddenSoft\\CiderPress\\CiderPress.exe";
-	RegLoadString(TEXT("Configuration"), REGVALUE_CIDERPRESSLOC, 1, PathToCiderPress,MAX_PATH);
+{
+	// This is the default installation path of CiderPress. 
+	// It shall not be left blank, otherwise  an explorer window will be open.
+	TCHAR PathToCiderPress[MAX_PATH];
+	RegLoadString(
+		TEXT("Configuration"),
+		REGVALUE_CIDERPRESSLOC,
+		1,
+		PathToCiderPress,
+		MAX_PATH,
+		TEXT("C:\\Program Files\\faddenSoft\\CiderPress\\CiderPress.exe"));
 	//TODO: A directory is open if an empty path to CiderPress is set. This has to be fixed.
 
 	std::string filename1= "\"";

--- a/source/Harddisk.cpp
+++ b/source/Harddisk.cpp
@@ -210,17 +210,13 @@ void HD_LoadLastDiskImage(const int iDrive)
 {
 	_ASSERT(iDrive == HARDDISK_1 || iDrive == HARDDISK_2);
 
-	char sFilePath[ MAX_PATH + 1];
-	sFilePath[0] = 0;
-
 	const char *pRegKey = (iDrive == HARDDISK_1)
 		? REGVALUE_PREF_LAST_HARDDISK_1
 		: REGVALUE_PREF_LAST_HARDDISK_2;
 
-	if (RegLoadString(TEXT(REG_PREFS), pRegKey, 1, sFilePath, MAX_PATH))
+	TCHAR sFilePath[MAX_PATH];
+	if (RegLoadString(TEXT(REG_PREFS), pRegKey, 1, sFilePath, MAX_PATH, TEXT("")))
 	{
-		sFilePath[ MAX_PATH ] = 0;
-
 		g_bSaveDiskImage = false;
 		// Pass in ptr to local copy of filepath, since RemoveDisk() sets DiskPathFilename = ""		// todo: update comment for HD func
 		HD_Insert(iDrive, sFilePath);
@@ -419,13 +415,13 @@ BOOL HD_Insert(const int iDrive, LPCTSTR pszImageFilename)
 
 static bool HD_SelectImage(const int iDrive, LPCSTR pszFilename)
 {
-	TCHAR directory[MAX_PATH] = TEXT("");
-	TCHAR filename[MAX_PATH]  = TEXT("");
+	TCHAR directory[MAX_PATH];
+	TCHAR filename[MAX_PATH];
 	TCHAR title[40];
 
 	strcpy(filename, pszFilename);
 
-	RegLoadString(TEXT(REG_PREFS), TEXT(REGVALUE_PREF_HDV_START_DIR), 1, directory, MAX_PATH);
+	RegLoadString(TEXT(REG_PREFS), TEXT(REGVALUE_PREF_HDV_START_DIR), 1, directory, MAX_PATH, TEXT(""));
 	_tcscpy(title, TEXT("Select HDV Image For HDD "));
 	_tcscat(title, iDrive ? TEXT("2") : TEXT("1"));
 

--- a/source/Registry.cpp
+++ b/source/Registry.cpp
@@ -30,70 +30,95 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
 //===========================================================================
-BOOL RegLoadString (LPCTSTR section, LPCTSTR key, BOOL peruser,
-                    LPTSTR buffer, DWORD chars) {
-  int  success = 0;
-  TCHAR fullkeyname[256];
-  wsprintf(fullkeyname,
-           TEXT("Software\\AppleWin\\CurrentVersion\\%s"),
-           (LPCTSTR)section);
-  HKEY keyhandle;
-  if (!RegOpenKeyEx((peruser ? HKEY_CURRENT_USER : HKEY_LOCAL_MACHINE),
-                    fullkeyname,
-                    0,
-                    KEY_READ,
-                    &keyhandle)) {
-    DWORD type;
-    DWORD size = chars;
-    success = (!RegQueryValueEx(keyhandle,key,0,&type,(LPBYTE)buffer,&size)) &&
-                                size;
-    RegCloseKey(keyhandle);
-  }
-  return success;
+BOOL RegLoadString (LPCTSTR section, LPCTSTR key, BOOL peruser, LPTSTR buffer, DWORD chars)
+{
+	TCHAR fullkeyname[256];
+	StringCbPrintf(fullkeyname, 256, TEXT("Software\\AppleWin\\CurrentVersion\\%s"), section);
+
+	BOOL success = FALSE;
+	HKEY keyhandle;
+	LSTATUS status = RegOpenKeyEx(
+		(peruser ? HKEY_CURRENT_USER : HKEY_LOCAL_MACHINE),
+		fullkeyname,
+		0,
+		KEY_READ,
+		&keyhandle);
+	if (status == 0)
+	{
+		DWORD type;
+		DWORD size = chars;
+		status = RegQueryValueEx(keyhandle, key, NULL, &type, (LPBYTE)buffer, &size);
+		if (status == 0 && size != 0)
+			success = TRUE;
+	}
+
+	RegCloseKey(keyhandle);
+
+	return success;
 }
 
 //===========================================================================
-BOOL RegLoadValue (LPCTSTR section, LPCTSTR key, BOOL peruser, DWORD *value) {
-  if (!value)
-    return 0;
-  TCHAR buffer[32] = TEXT("");
-  if (!RegLoadString(section,key,peruser,buffer,32))
-    return 0;
-  buffer[31] = 0;
-  *value = (DWORD)_ttoi(buffer);
-  return 1;
+BOOL RegLoadString (LPCTSTR section, LPCTSTR key, BOOL peruser, LPTSTR buffer, DWORD chars, LPCTSTR defaultValue)
+{
+	BOOL success = RegLoadString(section, key, peruser, buffer, chars);
+	if (!success)
+		StringCbCopy(buffer, chars, defaultValue);
+	return success;
+}
+
+//===========================================================================
+BOOL RegLoadValue (LPCTSTR section, LPCTSTR key, BOOL peruser, DWORD* value) {
+	TCHAR buffer[32];
+	if (!RegLoadString(section, key, peruser, buffer, 32))
+	{
+		return FALSE;
+	}
+
+	*value = (DWORD)_ttoi(buffer);
+	return TRUE;
+}
+
+//===========================================================================
+BOOL RegLoadValue (LPCTSTR section, LPCTSTR key, BOOL peruser, DWORD* value, DWORD defaultValue) {
+	BOOL success = RegLoadValue(section, key, peruser, value);
+	if (!success)
+		*value = defaultValue;
+	return success;
 }
 
 //===========================================================================
 void RegSaveString (LPCTSTR section, LPCTSTR key, BOOL peruser, LPCTSTR buffer) {
-  TCHAR fullkeyname[256];
-  wsprintf(fullkeyname,
-           TEXT("Software\\AppleWin\\CurrentVersion\\%s"),
-           (LPCTSTR)section);
-  HKEY  keyhandle;
-  DWORD disposition;
-  if (!RegCreateKeyEx((peruser ? HKEY_CURRENT_USER : HKEY_LOCAL_MACHINE),
-                      fullkeyname,
-                      0,
-                      NULL,
-                      REG_OPTION_NON_VOLATILE,
-                      KEY_READ | KEY_WRITE,
-                      (LPSECURITY_ATTRIBUTES)NULL,
-                      &keyhandle,
-                      &disposition)) {
-    RegSetValueEx(keyhandle,
-                  key,
-                  0,
-                  REG_SZ,
-                  (CONST BYTE *)buffer,
-                  (_tcslen(buffer)+1)*sizeof(TCHAR));
-    RegCloseKey(keyhandle);
-  }
+	TCHAR fullkeyname[256];
+	StringCbPrintf(fullkeyname, 256, TEXT("Software\\AppleWin\\CurrentVersion\\%s"), section);
+
+	HKEY  keyhandle;
+	DWORD disposition;
+	LSTATUS status = RegCreateKeyEx(
+		(peruser ? HKEY_CURRENT_USER : HKEY_LOCAL_MACHINE),
+		fullkeyname,
+		0,
+		NULL,
+		REG_OPTION_NON_VOLATILE,
+		KEY_READ | KEY_WRITE,
+		(LPSECURITY_ATTRIBUTES)NULL,
+		&keyhandle,
+		&disposition);
+	if (status == 0)
+	{
+		RegSetValueEx(
+			keyhandle,
+			key,
+			0,
+			REG_SZ,
+			(CONST LPBYTE)buffer,
+			(_tcslen(buffer) + 1) * sizeof(TCHAR));
+		RegCloseKey(keyhandle);
+	}
 }
 
 //===========================================================================
 void RegSaveValue (LPCTSTR section, LPCTSTR key, BOOL peruser, DWORD value) {
-  TCHAR buffer[32] = TEXT("");
-  _ultot(value,buffer,10);
-  RegSaveString(section,key,peruser,buffer);
+	TCHAR buffer[32] = TEXT("");
+	StringCbPrintf(buffer, 32, "%d", value);
+	RegSaveString(section, key, peruser, buffer);
 }

--- a/source/Registry.h
+++ b/source/Registry.h
@@ -1,11 +1,12 @@
 #pragma once
 
-#define  REGLOAD(a,b) RegLoadValue(TEXT(REG_CONFIG),a,1,b)
-#define  REGSAVE(a,b) RegSaveValue(TEXT(REG_CONFIG),a,1,b)
+#define  REGLOAD(a, b)				RegLoadValue(TEXT(REG_CONFIG), (a), TRUE, (b))
+#define  REGLOAD_DEFAULT(a, b, c)	RegLoadValue(TEXT(REG_CONFIG), (a), TRUE, (b), (c))
+#define  REGSAVE(a, b)				RegSaveValue(TEXT(REG_CONFIG), (a), TRUE, (b))
 
-BOOL    RegLoadString (LPCTSTR,LPCTSTR,BOOL,LPTSTR,DWORD);
-BOOL    RegLoadValue (LPCTSTR,LPCTSTR,BOOL,DWORD *);
-void    RegSaveString (LPCTSTR,LPCTSTR,BOOL,LPCTSTR);
-void    RegSaveValue (LPCTSTR,LPCTSTR,BOOL,DWORD);
-
-BOOL    RegLoadValue (LPCTSTR,LPCTSTR,BOOL,BOOL *);
+BOOL RegLoadString (LPCTSTR section, LPCTSTR key, BOOL peruser, LPTSTR buffer, DWORD chars);
+BOOL RegLoadString (LPCTSTR section, LPCTSTR key, BOOL peruser, LPTSTR buffer, DWORD chars, LPCTSTR defaultValue);
+BOOL RegLoadValue (LPCTSTR section, LPCTSTR key, BOOL peruser, DWORD* value);
+BOOL RegLoadValue (LPCTSTR section, LPCTSTR key, BOOL peruser, DWORD* value, DWORD defaultValue);
+void RegSaveString (LPCTSTR section, LPCTSTR key, BOOL peruser, LPCTSTR buffer);
+void RegSaveValue (LPCTSTR section, LPCTSTR key, BOOL peruser, DWORD value);

--- a/source/StdAfx.h
+++ b/source/StdAfx.h
@@ -36,6 +36,7 @@ typedef UINT64 uint64_t;
 
 #include <windows.h>
 #include <winuser.h> // WM_MOUSEWHEEL
+#include <strsafe.h>
 #include <commctrl.h>
 #include <ddraw.h>
 #include <htmlhelp.h>


### PR DESCRIPTION
This change does two things:

**1. Updates the registry APIs to reduce the likelihood of uninitialized
variables.**

The code wasn't always checking the return value of registry load operations.
In some cases, this led to uninitialized memory being used, and crashes could
result. For example, LoadConfiguration in Applewin.cpp was using an
uninitialized value for the computer type if no registry variable for the
"Apple 2 type" was set.

New registry reading methods and macros have also been introduced, allowing
default value fallbacks for the cases where a registry variable is not found.
This makes registry access simpler and safer when a default value is known in
advance.

The registry code's style has also been updated to conform with the rest of
the code base (tabs instead of spaces, naming conventions, etc.)

**2. Introduces string safety improvements.**

A number of code paths have been modified to use safe-string functions instead
of their unsafe counterparts (e.g., strcpy, sprintf).  In the process, some
strings were converted from "char" to "TCHAR". This was done mostly for
consistency with the rest of the code-base.