### PR TITLE
Add support for a 64-bit version of AppleWin

### DIFF
--- a/HookFilter/HookFilter.cpp
+++ b/HookFilter/HookFilter.cpp
@@ -6,13 +6,15 @@ static bool g_bHookAltGrControl = false;
 
 // NB. __stdcall (or WINAPI) and extern "C":
 // . symbol is decorated as _<symbol>@bytes
-// . so use the #pragma to create an undecorated alias for our symbol
+// . so use the #pragma to create an undecorated alias for our symbol (only in 32-bit mode)
 extern "C" __declspec(dllexport) LRESULT CALLBACK LowLevelKeyboardProc(
   _In_ int    nCode,
   _In_ WPARAM wParam,
   _In_ LPARAM lParam)
 {
+#ifndef _WIN64
 	#pragma comment(linker, "/EXPORT:" __FUNCTION__ "=" __FUNCDNAME__)
+#endif
 
 	if (nCode == HC_ACTION)
 	{

--- a/Make_Solution.bat
+++ b/Make_Solution.bat
@@ -1,0 +1,21 @@
+@echo off
+
+set version=%1
+if "%1"=="" (
+    set version=vs2019
+)
+
+set geniepath=%~dp0genie
+pushd %geniepath%
+genie.exe %version%
+popd
+if ERRORLEVEL 1 goto FAIL
+
+echo Visual Studio solution created: %geniepath%\AppleWin.sln
+exit /b
+
+:FAIL
+echo.
+echo The GENie tool failed to run. Please download the genie.exe file
+echo from https://github.com/bkaradzic/GENie and place it in the genie
+echo subdirectory (or somewhere in your path).

--- a/genie/.gitignore
+++ b/genie/.gitignore
@@ -1,0 +1,4 @@
+.vs/
+*.sln
+*.vcxproj*
+[gG]enie.exe

--- a/genie/solution.lua
+++ b/genie/solution.lua
@@ -77,6 +77,7 @@ solution("AppleWin")
 
     platforms {
         "x32",
+        "x64",
     }
 
     flags {

--- a/genie/solution.lua
+++ b/genie/solution.lua
@@ -1,0 +1,452 @@
+------------------------------------------------------------------------------
+-- GENie configuration script for AppleWin
+--
+-- GENie is project generator tool. It generates compiler solution and project
+-- files from Lua scripts and supports many different compiler versions.
+--
+-- This configuration script generates Visual Studio solution and project
+-- files for any Visual Studio version of interest. For instance, to generate
+-- a solution for Visual Studio 2019, open a command prompt in the directory
+-- containing this file, and type:
+--
+--   genie vs2019
+--
+-- This will create a Visual Studio solution file called AppleWin.sln in the
+-- same directory.
+--
+-- See https://github.com/bkaradzic/GENie for more information.
+--
+-- Full documentation:
+--  https://github.com/bkaradzic/GENie/blob/master/docs/scripting-reference.md
+------------------------------------------------------------------------------
+
+-- Add the genie "clean" action
+newaction {
+    trigger     = "clean",
+    description = "Clean the build directory",
+}
+
+-- Display usage if no action is specified on the command line.
+if _ACTION == nil then
+    return
+end
+
+-- We're always building for Windows.
+_OPTIONS['os'] = "windows"
+
+-- Prepare commonly-used directory variables.
+solutionDir = path.getabsolute(".")
+rootDir     = path.getabsolute("..")
+targetDir   = path.join(rootDir, "build")
+objDir      = path.join(rootDir, "build/obj")
+srcDir      = path.join(rootDir, "source")
+rsrcDir     = path.join(rootDir, "resource")
+
+if _ACTION == "clean" then
+    os.rmdir(targetDir)
+    return
+end
+
+if not string.match(_ACTION, "vs.*") then
+    print("ERROR: Only visual studio is currently supported.\n")
+    return
+end
+
+if _ACTION == "vs2019" then
+    premake.vstudio.diagformat = "Column"
+end
+
+
+------------------------------------------------------------------------------
+-- AppleWin solution
+--
+-- Generate the Visual Studio solution file.
+------------------------------------------------------------------------------
+solution("AppleWin")
+    location(solutionDir)
+    startproject("AppleWin")
+
+    language "C++"
+
+    configurations {
+        "Debug",
+        "DebugNoDX",
+        "Release",
+        "ReleaseNoDX",
+    }
+
+    platforms {
+        "x32",
+    }
+
+    flags {
+        "NativeWChar",
+        "Symbols",
+    }
+
+    configuration { "Debug*" }
+        defines {
+            "_DEBUG",
+        }
+        flags {
+            "DebugRuntime",
+        }
+
+    configuration { "Release*" }
+        defines {
+            "NDEBUG",
+        }
+        flags {
+            "OptimizeSpeed",
+            "ReleaseRuntime",
+        }
+
+    configuration { "windows" }
+        defines {
+            "_WINDOWS",
+            "WIN32",
+        }
+
+    configuration {} -- reset
+
+
+------------------------------------------------------------------------------
+-- set_output_dirs
+--
+-- Helper function to set a project's target and object directories.
+------------------------------------------------------------------------------
+function set_output_dirs(name)
+    configuration { "Debug" }
+        targetdir(path.join(targetDir, "Debug"))
+        objdir(path.join(targetDir, "Debug/obj", name))
+
+    configuration { "DebugNoDX" }
+        defines { "NO_DIRECT_X" }
+        targetdir(path.join(targetDir, "DebugNoDX"))
+        objdir(path.join(targetDir, "DebugNoDX/obj", name))
+
+    configuration { "Release" }
+        targetdir(path.join(targetDir, "Release"))
+        objdir(path.join(targetDir, "Release/obj", name))
+
+    configuration { "ReleaseNoDX" }
+        defines { "NO_DIRECT_X" }
+        targetdir(path.join(targetDir, "ReleaseNoDX"))
+        objdir(path.join(targetDir, "ReleaseNoDX/obj", name))
+
+    configuration {} -- reset
+end
+
+------------------------------------------------------------------------------
+-- AppleWin project
+--
+-- Generate the AppleWin executable project
+------------------------------------------------------------------------------
+project("AppleWin")
+    kind "WindowedApp"
+    uuid(os.uuid("app-AppleWin"))
+    set_output_dirs("AppleWin")
+
+    flags {
+        "StaticRuntime",
+        "WinMain",
+    }
+
+    -- Add -D compile options
+    defines {
+        "NO_DSHOW_STRSAFE",
+        "YAML_DECLARE_STATIC",
+        "_CRT_SECURE_NO_DEPRECATE",
+    }
+
+    -- Add additional compile options
+    buildoptions {
+        "/utf-8",
+    }
+
+    -- List include paths
+    includedirs {
+        path.join(srcDir, "cpu"),
+        path.join(srcDir, "emulator"),
+        path.join(srcDir, "debugger"),
+        path.join(rootDir, "zlib"),
+        path.join(rootDir, "zip_lib"),
+        path.join(rootDir, "libyaml/include"),
+    }
+
+    -- List all files that should appear in the project
+    files {
+        path.join(srcDir, "**.h"),
+        path.join(srcDir, "**.cpp"),
+        path.join(srcDir, "**.inl"),
+        path.join(rsrcDir, "*"),
+        path.join(rootDir, "bin/History.txt"),
+        path.join(rootDir, "docs/CodingConventions.txt"),
+        path.join(rootDir, "docs/Debugger_Changelog.txt"),
+        path.join(rootDir, "docs/FAQ.txt"),
+        path.join(rootDir, "docs/ToDo.txt"),
+        path.join(rootDir, "docs/Video_Cleanup.txt"),
+        path.join(rootDir, "docs/Wishlist.txt"),
+    }
+    removefiles {
+        path.join(srcDir, "Peripheral_Clock*"),
+    }
+
+    -- Libraries that must be linked to build the executable
+    links {
+        "advapi32",
+        "comctl32",
+        "comdlg32",
+        "dinput8",
+        "dsound",
+        "dxguid",
+        "gdi32",
+        "htmlhelp",
+        "ole32",
+        "shell32",
+        "strmiids",
+        "user32",
+        "version",
+        "winmm",
+        "wsock32",
+        "yaml",
+        "zlib",
+        "zip_lib",
+        "HookFilter",
+        "TestCPU6502",
+    }
+
+    -- Set up precompiled headers
+    configuration { "vs*" }
+        pchheader("StdAfx.h")
+        pchsource(path.join(srcDir, "StdAfx.cpp"))
+        nopch {
+            path.join(srcDir, "Tfe/*.cpp"),
+            path.join(srcDir, "Z80VICE/*.cpp"),
+        }
+    configuration {} -- reset
+
+    -- Run the CPU unit test before building
+    prebuildcommands { "echo Performing unit-test: TestCPU6502" }
+    configuration { "Debug" }
+        prebuildcommands { path.join(targetDir, "Debug", "TestCPU6502") }
+    configuration { "DebugNoDX" }
+        prebuildcommands { path.join(targetDir, "DebugNoDX", "TestCPU6502") }
+    configuration { "Release" }
+        prebuildcommands { path.join(targetDir, "Release", "TestCPU6502") }
+    configuration { "ReleaseNoDX" }
+        prebuildcommands { path.join(targetDir, "ReleaseNoDX", "TestCPU6502") }
+    configuration {} -- reset
+
+
+    -- Organize files into VS filter folders
+    vpaths {
+        ["Docs"] = {
+            path.join(rootDir, "docs/**"),
+            path.join(rootDir, "bin/**"),
+        },
+        ["Resource Files"] = {
+            path.join(rootDir, "resource/**"),
+        },
+        ["Source Files"] = {
+            path.join(srcDir, "Applewin.*"),
+            path.join(srcDir, "StdAfx.*"),
+        },
+        ["Source Files/_Headers"] = {
+            path.join(srcDir, "Common.h"),
+            path.join(rsrcDir, "resource.h"),
+        },
+        ["Source Files/CommonVICE"] = {
+            path.join(srcDir, "CommonVICE/*"),
+        },
+        ["Source Files/Configuration"] = {
+            path.join(srcDir, "Configuration/*"),
+        },
+        ["Source Files/CPU"] = {
+            path.join(srcDir, "CPU*"),
+            path.join(srcDir, "cpu/*"),
+        },
+        ["Source Files/Debugger"] = {
+            path.join(srcDir, "Debugger/*"),
+        },
+        ["Source Files/Disk"] = {
+            path.join(srcDir, "Disk*"),
+            path.join(srcDir, "Harddisk*"),
+        },
+        ["Source Files/Emulator"] = {
+            path.join(srcDir, "6821*"),
+            path.join(srcDir, "AY8910*"),
+            path.join(srcDir, "Joystick*"),
+            path.join(srcDir, "Keyboard*"),
+            path.join(srcDir, "LanguageCard*"),
+            path.join(srcDir, "Log*"),
+            path.join(srcDir, "Memory*"),
+            path.join(srcDir, "Mockingboard*"),
+            path.join(srcDir, "MouseInterface*"),
+            path.join(srcDir, "NoSlotClock*"),
+            path.join(srcDir, "ParallelPrinter*"),
+            path.join(srcDir, "Registry*"),
+            path.join(srcDir, "Riff*"),
+            path.join(srcDir, "SAM*"),
+            path.join(srcDir, "SaveState*"),
+            path.join(srcDir, "SerialComms*"),
+            path.join(srcDir, "SoundCore*"),
+            path.join(srcDir, "Speaker*"),
+            path.join(srcDir, "Speech*"),
+            path.join(srcDir, "SSI263Phonemes.h"),
+            path.join(srcDir, "Tape*"),
+            path.join(srcDir, "YamlHelper*"),
+            path.join(srcDir, "z80emu*"),
+        },
+        ["Source Files/Model"] = {
+            path.join(srcDir, "Pravets*"),
+        },
+        ["Source Files/Uthernet"] = {
+            path.join(srcDir, "Tfe/*"),
+        },
+        ["Source Files/Video"] = {
+            path.join(srcDir, "Frame*"),
+            path.join(srcDir, "NTSC*"),
+            path.join(srcDir, "RGB*"),
+            path.join(srcDir, "Video*"),
+        },
+        ["Source Files/Z80VICE"] = {
+            path.join(srcDir, "Z80VICE/*"),
+        },
+    }
+
+
+------------------------------------------------------------------------------
+-- yaml project
+--
+-- Generate the yaml static library.
+------------------------------------------------------------------------------
+project("yaml")
+    kind "StaticLib"
+    uuid(os.uuid("lib-yaml"))
+    set_output_dirs("yaml")
+
+    flags {
+        "StaticRuntime",
+    }
+
+    includedirs {
+        path.join(rootDir, "libyaml/win32"),
+        path.join(rootDir, "libyaml/include"),
+    }
+
+    defines {
+        "_LIB",
+        "HAVE_CONFIG_H",
+        "YAML_DECLARE_STATIC",
+        "_CRT_SECURE_NO_WARNINGS",
+    }
+
+    files {
+        path.join(rootDir, "libyaml/**.h"),
+        path.join(rootDir, "libyaml/**.c"),
+    }
+
+    vpaths {
+        ["Source Files"] = { path.join(rootDir, "libyaml/*") },
+    }
+
+
+------------------------------------------------------------------------------
+-- zlib project
+--
+-- Generate the zlib static library.
+------------------------------------------------------------------------------
+project("zlib")
+    kind "StaticLib"
+    uuid(os.uuid("lib-zlib"))
+    set_output_dirs("zlib")
+
+    flags {
+        "StaticRuntime",
+    }
+
+    defines {
+        "_LIB",
+        "_CRT_SECURE_NO_WARNINGS",
+    }
+
+    files {
+        path.join(rootDir, "zlib/**.h"),
+        path.join(rootDir, "zlib/**.c"),
+    }
+
+
+------------------------------------------------------------------------------
+-- zip_lib project
+--
+-- Generate the zip_lib static library.
+------------------------------------------------------------------------------
+project("zip_lib")
+    kind "StaticLib"
+    uuid(os.uuid("lib-zip_lib"))
+    set_output_dirs("zip_lib")
+
+    flags {
+        "StaticRuntime",
+    }
+
+    includedirs {
+        path.join(rootDir, "zlib"),
+    }
+
+    defines {
+        "_LIB",
+        "_CRT_SECURE_NO_WARNINGS",
+    }
+
+    files {
+        path.join(rootDir, "zip_lib/**.h"),
+        path.join(rootDir, "zip_lib/**.c"),
+    }
+
+
+
+------------------------------------------------------------------------------
+-- HookFilter DLL project
+--
+-- Generate the HookFilter DLL.
+------------------------------------------------------------------------------
+project("HookFilter")
+    kind "SharedLib"
+    uuid(os.uuid("lib-HookFilter"))
+    set_output_dirs("HookFilter")
+
+    includedirs {
+        path.join(rootDir, "zlib"),
+    }
+
+    defines {
+        "_USRDLL",
+        "HOOKFILTER_EXPORTS",
+    }
+
+    files {
+        path.join(rootDir, "HookFilter/**.cpp"),
+    }
+
+
+------------------------------------------------------------------------------
+-- TestCPU6502 application project
+--
+-- Generate the TestCPU6502 executable.
+------------------------------------------------------------------------------
+project("TestCPU6502")
+    kind "ConsoleApp"
+    uuid(os.uuid("app-TestCPU6502"))
+    set_output_dirs("TestCPU6502")
+
+    defines {
+        "_CONSOLE",
+        "_LIB",
+    }
+
+    files {
+        path.join(rootDir, "test/TestCPU6502/**.h"),
+        path.join(rootDir, "test/TestCPU6502/**.cpp"),
+    }

--- a/libyaml/src/api.c
+++ b/libyaml/src/api.c
@@ -839,7 +839,7 @@ yaml_scalar_event_initialize(yaml_event_t *event,
     }
 
     if (length < 0) {
-        length = strlen((char *)value);
+        length = (int)strlen((char *)value);
     }
 
     if (!yaml_check_utf8(value, length)) goto error;
@@ -1215,7 +1215,7 @@ yaml_document_add_scalar(yaml_document_t *document,
     if (!tag_copy) goto error;
 
     if (length < 0) {
-        length = strlen((char *)value);
+        length = (int)strlen((char *)value);
     }
 
     if (!yaml_check_utf8(value, length)) goto error;
@@ -1227,7 +1227,7 @@ yaml_document_add_scalar(yaml_document_t *document,
     SCALAR_NODE_INIT(node, tag_copy, value_copy, length, style, mark, mark);
     if (!PUSH(&context, document->nodes, node)) goto error;
 
-    return document->nodes.top - document->nodes.start;
+    return (int)(document->nodes.top - document->nodes.start);
 
 error:
     yaml_free(tag_copy);
@@ -1272,7 +1272,7 @@ yaml_document_add_sequence(yaml_document_t *document,
             style, mark, mark);
     if (!PUSH(&context, document->nodes, node)) goto error;
 
-    return document->nodes.top - document->nodes.start;
+    return (int)(document->nodes.top - document->nodes.start);
 
 error:
     STACK_DEL(&context, items);
@@ -1317,7 +1317,7 @@ yaml_document_add_mapping(yaml_document_t *document,
             style, mark, mark);
     if (!PUSH(&context, document->nodes, node)) goto error;
 
-    return document->nodes.top - document->nodes.start;
+    return (int)(document->nodes.top - document->nodes.start);
 
 error:
     STACK_DEL(&context, pairs);

--- a/libyaml/src/loader.c
+++ b/libyaml/src/loader.c
@@ -300,7 +300,7 @@ yaml_parser_load_scalar(yaml_parser_t *parser, yaml_event_t *first_event)
 
     if (!PUSH(parser, parser->document->nodes, node)) goto error;
 
-    index = parser->document->nodes.top - parser->document->nodes.start;
+    index = (int)(parser->document->nodes.top - parser->document->nodes.start);
 
     if (!yaml_parser_register_anchor(parser, index,
                 first_event->data.scalar.anchor)) return 0;
@@ -347,7 +347,7 @@ yaml_parser_load_sequence(yaml_parser_t *parser, yaml_event_t *first_event)
 
     if (!PUSH(parser, parser->document->nodes, node)) goto error;
 
-    index = parser->document->nodes.top - parser->document->nodes.start;
+    index = (int)(parser->document->nodes.top - parser->document->nodes.start);
 
     if (!yaml_parser_register_anchor(parser, index,
                 first_event->data.sequence_start.anchor)) return 0;
@@ -410,7 +410,7 @@ yaml_parser_load_mapping(yaml_parser_t *parser, yaml_event_t *first_event)
 
     if (!PUSH(parser, parser->document->nodes, node)) goto error;
 
-    index = parser->document->nodes.top - parser->document->nodes.start;
+    index = (int)(parser->document->nodes.top - parser->document->nodes.start);
 
     if (!yaml_parser_register_anchor(parser, index,
                 first_event->data.mapping_start.anchor)) return 0;

--- a/libyaml/src/scanner.c
+++ b/libyaml/src/scanner.c
@@ -1236,7 +1236,7 @@ yaml_parser_roll_indent(yaml_parser_t *parser, ptrdiff_t column,
             return 0;
         }
 
-        parser->indent = column;
+        parser->indent = (int)column;
 
         /* Create a token and insert it into the queue. */
 

--- a/source/Applewin.cpp
+++ b/source/Applewin.cpp
@@ -473,7 +473,7 @@ void GetProgramDirectory(void)
 	GetModuleFileName((HINSTANCE)0, g_sProgramDir, MAX_PATH);
 	g_sProgramDir[MAX_PATH-1] = 0;
 
-	int loop = _tcslen(g_sProgramDir);
+	int loop = (int)_tcslen(g_sProgramDir);
 	while (loop--)
 	{
 		if ((g_sProgramDir[loop] == TEXT('\\')) || (g_sProgramDir[loop] == TEXT(':')))
@@ -756,7 +756,7 @@ bool SetCurrentImageDir(const char* pszImageDir)
 {
 	strcpy(g_sCurrentDir, pszImageDir);
 
-	int nLen = strlen( g_sCurrentDir );
+	int nLen = (int)strlen( g_sCurrentDir );
 	if ((nLen > 0) && (g_sCurrentDir[ nLen - 1 ] != '\\'))
 	{
 		g_sCurrentDir[ nLen + 0 ] = '\\';
@@ -843,7 +843,7 @@ void RegisterExtensions(void)
 	pValueName = "DiskImage\\shell\\open\\command";
 	res = RegSetValue(HKEY_CLASSES_ROOT,
 				pValueName,
-				REG_SZ,command,_tcslen(command)+1);
+				REG_SZ,command, (DWORD)_tcslen(command)+1);
 	if (res != NOERROR) LogFileOutput("RegSetValue(%s) failed (0x%08X)\n", pValueName, res);
 
 	pValueName = "DiskImage\\shell\\open\\ddeexec";
@@ -855,14 +855,14 @@ void RegisterExtensions(void)
 	pValueName = "DiskImage\\shell\\open\\ddeexec\\application";
 	res = RegSetValue(HKEY_CLASSES_ROOT,
 				pValueName,
-				REG_SZ,"applewin",_tcslen("applewin")+1);
+				REG_SZ,"applewin", (DWORD)_tcslen("applewin")+1);
 //				REG_SZ,szCommandTmp,_tcslen(szCommandTmp)+1);
 	if (res != NOERROR) LogFileOutput("RegSetValue(%s) failed (0x%08X)\n", pValueName, res);
 
 	pValueName = "DiskImage\\shell\\open\\ddeexec\\topic";
 	res = RegSetValue(HKEY_CLASSES_ROOT,
 				pValueName,
-				REG_SZ,"system",_tcslen("system")+1);
+				REG_SZ,"system", (DWORD)_tcslen("system")+1);
 	if (res != NOERROR) LogFileOutput("RegSetValue(%s) failed (0x%08X)\n", pValueName, res);
 }
 
@@ -1686,7 +1686,7 @@ int APIENTRY WinMain(HINSTANCE passinstance, HINSTANCE, LPSTR lpCmdLine, int)
 		if (szSnapshotName)
 		{
 			std::string strPathname(szSnapshotName);
-			int nIdx = strPathname.find_last_of('\\');
+			int nIdx = (int)strPathname.find_last_of('\\');
 			if (nIdx >= 0 && nIdx+1 < (int)strPathname.length())
 			{
 				std::string strPath = strPathname.substr(0, nIdx+1);

--- a/source/Configuration/About.cpp
+++ b/source/Configuration/About.cpp
@@ -35,7 +35,7 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 You should have received a copy of the GNU General Public License along with this program; if not, write to the Free Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.";
 
 
-static BOOL CALLBACK DlgProcAbout(HWND hWnd, UINT message, WPARAM wparam, LPARAM lparam)
+static INT_PTR CALLBACK DlgProcAbout(HWND hWnd, UINT message, WPARAM wparam, LPARAM lparam)
 {
 	switch (message)
 	{

--- a/source/Configuration/PageAdvanced.cpp
+++ b/source/Configuration/PageAdvanced.cpp
@@ -158,7 +158,7 @@ void CPageAdvanced::DlgOK(HWND hWnd)
 		memset(szFilename, 0, sizeof(szFilename));
 		* (USHORT*) szFilename = sizeof(szFilename);
 
-		UINT nLineLength = SendDlgItemMessage(hWnd, IDC_SAVESTATE_FILENAME, EM_LINELENGTH, 0, 0);
+		UINT nLineLength = (UINT)SendDlgItemMessage(hWnd, IDC_SAVESTATE_FILENAME, EM_LINELENGTH, 0, 0);
 
 		SendDlgItemMessage(hWnd, IDC_SAVESTATE_FILENAME, EM_GETLINE, 0, (LPARAM)szFilename);
 
@@ -174,7 +174,7 @@ void CPageAdvanced::DlgOK(HWND hWnd)
 		memset(szFilename, 0, sizeof(szFilename));
 		* (USHORT*) szFilename = sizeof(szFilename);
 
-		UINT nLineLength = SendDlgItemMessage(hWnd, IDC_PRINTER_DUMP_FILENAME, EM_LINELENGTH, 0, 0);
+		UINT nLineLength = (UINT)SendDlgItemMessage(hWnd, IDC_PRINTER_DUMP_FILENAME, EM_LINELENGTH, 0, 0);
 
 		SendDlgItemMessage(hWnd, IDC_PRINTER_DUMP_FILENAME, EM_GETLINE, 0, (LPARAM)szFilename);
 

--- a/source/Configuration/PageAdvanced.cpp
+++ b/source/Configuration/PageAdvanced.cpp
@@ -62,11 +62,11 @@ BOOL CPageAdvanced::DlgProcInternal(HWND hWnd, UINT message, WPARAM wparam, LPAR
 				InitOptions(hWnd);
 				break;
 			case PSN_KILLACTIVE:
-				SetWindowLong(hWnd, DWL_MSGRESULT, FALSE);			// Changes are valid
+				SetWindowLong(hWnd, DWLP_MSGRESULT, FALSE);			// Changes are valid
 				break;
 			case PSN_APPLY:
 				DlgOK(hWnd);
-				SetWindowLong(hWnd, DWL_MSGRESULT, PSNRET_NOERROR);	// Changes are valid
+				SetWindowLong(hWnd, DWLP_MSGRESULT, PSNRET_NOERROR);	// Changes are valid
 				break;
 			case PSN_QUERYCANCEL:
 				// Can use this to ask user to confirm cancel

--- a/source/Configuration/PageConfig.cpp
+++ b/source/Configuration/PageConfig.cpp
@@ -42,7 +42,7 @@ const TCHAR CPageConfig::m_ComputerChoices[] =
 				TEXT("Enhanced Apple //e\0")
 				TEXT("Clone\0");
 
-BOOL CALLBACK CPageConfig::DlgProc(HWND hWnd, UINT message, WPARAM wparam, LPARAM lparam)
+INT_PTR CALLBACK CPageConfig::DlgProc(HWND hWnd, UINT message, WPARAM wparam, LPARAM lparam)
 {
 	// Switch from static func to our instance
 	return CPageConfig::ms_this->DlgProcInternal(hWnd, message, wparam, lparam);
@@ -67,12 +67,12 @@ BOOL CPageConfig::DlgProcInternal(HWND hWnd, UINT message, WPARAM wparam, LPARAM
 				// About to stop being active page
 				{
 					DWORD NewComputerMenuItem = (DWORD) SendDlgItemMessage(hWnd, IDC_COMPUTER, CB_GETCURSEL, 0, 0);
-					SetWindowLong(hWnd, DWL_MSGRESULT, FALSE);		// Changes are valid
+					SetWindowLong(hWnd, DWLP_MSGRESULT, FALSE);		// Changes are valid
 				}
 				break;
 			case PSN_APPLY:
 				DlgOK(hWnd);
-				SetWindowLong(hWnd, DWL_MSGRESULT, PSNRET_NOERROR);	// Changes are valid
+				SetWindowLong(hWnd, DWLP_MSGRESULT, PSNRET_NOERROR);	// Changes are valid
 				break;
 			case PSN_QUERYCANCEL:
 				// Can use this to ask user to confirm cancel

--- a/source/Configuration/PageConfig.cpp
+++ b/source/Configuration/PageConfig.cpp
@@ -344,7 +344,7 @@ void CPageConfig::DlgOK(HWND hWnd)
 	if (IsDlgButtonChecked(hWnd, IDC_AUTHENTIC_SPEED))
 		g_dwSpeed = SPEED_NORMAL;
 	else
-		g_dwSpeed = SendDlgItemMessage(hWnd, IDC_SLIDER_CPU_SPEED,TBM_GETPOS, 0, 0);
+		g_dwSpeed = (DWORD)SendDlgItemMessage(hWnd, IDC_SLIDER_CPU_SPEED,TBM_GETPOS, 0, 0);
 
 	SetCurrentCLK6502();
 

--- a/source/Configuration/PageConfig.h
+++ b/source/Configuration/PageConfig.h
@@ -16,7 +16,7 @@ public:
 	}
 	virtual ~CPageConfig(){}
 
-	static BOOL CALLBACK DlgProc(HWND hWnd, UINT message, WPARAM wparam, LPARAM lparam);
+	static INT_PTR CALLBACK DlgProc(HWND hWnd, UINT message, WPARAM wparam, LPARAM lparam);
 
 protected:
 	// IPropertySheetPage

--- a/source/Configuration/PageConfigTfe.cpp
+++ b/source/Configuration/PageConfigTfe.cpp
@@ -56,7 +56,7 @@ uilib_dialog_group CPageConfigTfe::ms_rightgroup[] =
 	{0, 0}
 };
 
-BOOL CALLBACK CPageConfigTfe::DlgProc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam)
+INT_PTR CALLBACK CPageConfigTfe::DlgProc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam)
 {
 	// Switch from static func to our instance
 	return CPageConfigTfe::ms_this->DlgProcInternal(hwnd, msg, wparam, lparam);

--- a/source/Configuration/PageConfigTfe.cpp
+++ b/source/Configuration/PageConfigTfe.cpp
@@ -171,7 +171,7 @@ int CPageConfigTfe::gray_ungray_items(HWND hwnd)
 		char *pname = NULL;
 		char *pdescription = NULL;
 
-		number = SendMessage(GetDlgItem(hwnd, IDC_TFE_SETTINGS_INTERFACE), CB_GETCURSEL, 0, 0);
+		number = (int)SendMessage(GetDlgItem(hwnd, IDC_TFE_SETTINGS_INTERFACE), CB_GETCURSEL, 0, 0);
 
 		if (get_tfename(number, &pname, &pdescription))
 		{
@@ -284,7 +284,7 @@ void CPageConfigTfe::save_tfe_dialog(HWND hwnd)
 	{
 		RegSaveString(TEXT("Configuration"), TEXT("Uthernet Interface"), 1, buffer);
 
-		active_value = SendMessage(GetDlgItem(hwnd, IDC_TFE_SETTINGS_ENABLE), CB_GETCURSEL, 0, 0);
+		active_value = (int)SendMessage(GetDlgItem(hwnd, IDC_TFE_SETTINGS_ENABLE), CB_GETCURSEL, 0, 0);
 
 		tfe_enabled = active_value >= 1 ? 1 : 0;
 		REGSAVE(TEXT("Uthernet Active")  ,tfe_enabled);

--- a/source/Configuration/PageConfigTfe.h
+++ b/source/Configuration/PageConfigTfe.h
@@ -12,7 +12,7 @@ public:
 	}
 	virtual ~CPageConfigTfe(){}
 
-	static BOOL CALLBACK DlgProc(HWND window, UINT message, WPARAM wparam, LPARAM lparam);
+	static INT_PTR CALLBACK DlgProc(HWND window, UINT message, WPARAM wparam, LPARAM lparam);
 
 protected:
 	// IPropertySheetPage

--- a/source/Configuration/PageDisk.cpp
+++ b/source/Configuration/PageDisk.cpp
@@ -67,11 +67,11 @@ BOOL CPageDisk::DlgProcInternal(HWND hWnd, UINT message, WPARAM wparam, LPARAM l
 				InitOptions(hWnd);
 				break;
 			case PSN_KILLACTIVE:
-				SetWindowLong(hWnd, DWL_MSGRESULT, FALSE);			// Changes are valid
+				SetWindowLong(hWnd, DWLP_MSGRESULT, FALSE);			// Changes are valid
 				break;
 			case PSN_APPLY:
 				DlgOK(hWnd);
-				SetWindowLong(hWnd, DWL_MSGRESULT, PSNRET_NOERROR);	// Changes are valid
+				SetWindowLong(hWnd, DWLP_MSGRESULT, PSNRET_NOERROR);	// Changes are valid
 				break;
 			case PSN_QUERYCANCEL:
 				// Can use this to ask user to confirm cancel

--- a/source/Configuration/PageInput.cpp
+++ b/source/Configuration/PageInput.cpp
@@ -85,11 +85,11 @@ BOOL CPageInput::DlgProcInternal(HWND hWnd, UINT message, WPARAM wparam, LPARAM 
 				InitOptions(hWnd);
 				break;
 			case PSN_KILLACTIVE:
-				SetWindowLong(hWnd, DWL_MSGRESULT, FALSE);			// Changes are valid
+				SetWindowLong(hWnd, DWLP_MSGRESULT, FALSE);			// Changes are valid
 				break;
 			case PSN_APPLY:
 				DlgOK(hWnd);
-				SetWindowLong(hWnd, DWL_MSGRESULT, PSNRET_NOERROR);	// Changes are valid
+				SetWindowLong(hWnd, DWLP_MSGRESULT, PSNRET_NOERROR);	// Changes are valid
 				break;
 			case PSN_QUERYCANCEL:
 				// Can use this to ask user to confirm cancel

--- a/source/Configuration/PageInput.cpp
+++ b/source/Configuration/PageInput.cpp
@@ -211,10 +211,10 @@ BOOL CPageInput::DlgProcInternal(HWND hWnd, UINT message, WPARAM wparam, LPARAM 
 
 void CPageInput::DlgOK(HWND hWnd)
 {
-	UINT uNewJoyType0 = SendDlgItemMessage(hWnd, IDC_JOYSTICK0, CB_GETCURSEL, 0, 0);
+	UINT uNewJoyType0 = (UINT)SendDlgItemMessage(hWnd, IDC_JOYSTICK0, CB_GETCURSEL, 0, 0);
 	if (uNewJoyType0 >= J0C_MAX) uNewJoyType0 = 0;	// GH#434
 
-	UINT uNewJoyType1 = SendDlgItemMessage(hWnd, IDC_JOYSTICK1, CB_GETCURSEL, 0, 0);
+	UINT uNewJoyType1 = (UINT)SendDlgItemMessage(hWnd, IDC_JOYSTICK1, CB_GETCURSEL, 0, 0);
 	if (uNewJoyType1 >= J1C_MAX) uNewJoyType1 = 0;	// GH#434
 
 	const bool bIsSlot4Mouse = m_PropertySheetHelper.GetConfigNew().m_Slot[4] == CT_MouseInterface;
@@ -386,7 +386,7 @@ void CPageInput::InitCPMChoices(HWND hWnd)
 
 	if (bIsSlot4Empty || bIsSlot4CPM)
 	{
-		const UINT uStrLen = strlen(m_szCPMSlotChoice_Slot4)+1;
+		const UINT uStrLen = (UINT)strlen(m_szCPMSlotChoice_Slot4)+1;
 		memcpy(&m_szCPMSlotChoices[uStringOffset], m_szCPMSlotChoice_Slot4, uStrLen);
 		uStringOffset += uStrLen;
 
@@ -395,7 +395,7 @@ void CPageInput::InitCPMChoices(HWND hWnd)
 
 	if (bIsSlot5Empty || bIsSlot5CPM)
 	{
-		const UINT uStrLen = strlen(m_szCPMSlotChoice_Slot5)+1;
+		const UINT uStrLen = (UINT)strlen(m_szCPMSlotChoice_Slot5)+1;
 		memcpy(&m_szCPMSlotChoices[uStringOffset], m_szCPMSlotChoice_Slot5, uStrLen);
 		uStringOffset += uStrLen;
 
@@ -404,7 +404,7 @@ void CPageInput::InitCPMChoices(HWND hWnd)
 
 	if (uStringOffset)
 	{
-		const UINT uStrLen = strlen(m_szCPMSlotChoice_Unplugged)+1;
+		const UINT uStrLen = (UINT)strlen(m_szCPMSlotChoice_Unplugged)+1;
 		memcpy(&m_szCPMSlotChoices[uStringOffset], m_szCPMSlotChoice_Unplugged, uStrLen);
 		uStringOffset += uStrLen;
 
@@ -412,7 +412,7 @@ void CPageInput::InitCPMChoices(HWND hWnd)
 	}
 	else
 	{
-		const UINT uStrLen = strlen(m_szCPMSlotChoice_Unavailable)+1;
+		const UINT uStrLen = (UINT)strlen(m_szCPMSlotChoice_Unavailable)+1;
 		memcpy(&m_szCPMSlotChoices[uStringOffset], m_szCPMSlotChoice_Unavailable, uStrLen);
 		uStringOffset += uStrLen;
 

--- a/source/Configuration/PageSound.cpp
+++ b/source/Configuration/PageSound.cpp
@@ -60,11 +60,11 @@ BOOL CPageSound::DlgProcInternal(HWND hWnd, UINT message, WPARAM wparam, LPARAM 
 				InitOptions(hWnd);
 				break;
 			case PSN_KILLACTIVE:
-				SetWindowLong(hWnd, DWL_MSGRESULT, FALSE);			// Changes are valid
+				SetWindowLong(hWnd, DWLP_MSGRESULT, FALSE);			// Changes are valid
 				break;
 			case PSN_APPLY:
 				DlgOK(hWnd);
-				SetWindowLong(hWnd, DWL_MSGRESULT, PSNRET_NOERROR);	// Changes are valid
+				SetWindowLong(hWnd, DWLP_MSGRESULT, PSNRET_NOERROR);	// Changes are valid
 				break;
 			case PSN_QUERYCANCEL:
 				// Can use this to ask user to confirm cancel

--- a/source/Configuration/PageSound.cpp
+++ b/source/Configuration/PageSound.cpp
@@ -134,8 +134,8 @@ void CPageSound::DlgOK(HWND hWnd)
 {
 	const SoundType_e newSoundType = (SoundType_e) SendDlgItemMessage(hWnd, IDC_SOUNDTYPE, CB_GETCURSEL, 0, 0);
 
-	const DWORD dwSpkrVolume = SendDlgItemMessage(hWnd, IDC_SPKR_VOLUME, TBM_GETPOS, 0, 0);
-	const DWORD dwMBVolume = SendDlgItemMessage(hWnd, IDC_MB_VOLUME, TBM_GETPOS, 0, 0);
+	const DWORD dwSpkrVolume = (DWORD)SendDlgItemMessage(hWnd, IDC_SPKR_VOLUME, TBM_GETPOS, 0, 0);
+	const DWORD dwMBVolume = (DWORD)SendDlgItemMessage(hWnd, IDC_MB_VOLUME, TBM_GETPOS, 0, 0);
 
 	if (SpkrSetEmulationType(hWnd, newSoundType))
 	{

--- a/source/Configuration/PropertySheetHelper.cpp
+++ b/source/Configuration/PropertySheetHelper.cpp
@@ -272,10 +272,10 @@ int CPropertySheetHelper::SaveStateSelectImage(HWND hWindow, TCHAR* pszTitle, bo
 			const char szAWS_EXT1[] = ".aws";
 			const char szAWS_EXT2[] = ".yaml";
 			const char szAWS_EXT3[] = ".aws.yaml";
-			const UINT uStrLenFile  = strlen(&szFilename[ofn.nFileOffset]);
-			const UINT uStrLenExt1  = strlen(szAWS_EXT1);
-			const UINT uStrLenExt2  = strlen(szAWS_EXT2);
-			const UINT uStrLenExt3  = strlen(szAWS_EXT3);
+			const UINT uStrLenFile  = (UINT)strlen(&szFilename[ofn.nFileOffset]);
+			const UINT uStrLenExt1  = (UINT)strlen(szAWS_EXT1);
+			const UINT uStrLenExt2  = (UINT)strlen(szAWS_EXT2);
+			const UINT uStrLenExt3  = (UINT)strlen(szAWS_EXT3);
 			if (uStrLenFile <= uStrLenExt1)
 			{
 				strcpy(&szFilename[ofn.nFileOffset+uStrLenFile], szAWS_EXT3);					// "file" += ".aws.yaml"

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -3334,7 +3334,7 @@ Update_t CmdCursorLineUp (int nArgs)
 			}
 		} while (iTop < MAX_LOOK_AHEAD);
 
-		int nCandidates = aTopCandidates.size();
+		int nCandidates = (int)aTopCandidates.size();
 		if (nCandidates)
 		{
 			int iBest = NO_6502_TARGET;
@@ -4381,7 +4381,7 @@ Update_t CmdMemoryLoad (int nArgs)
 	const KnownFileType_t *pFileType = NULL;
 
 	char *pFileName = g_aArgs[ 1 ].sArg;
-	int   nLen = strlen( pFileName );
+	int   nLen = (int)strlen( pFileName );
 	char *pEnd = pFileName + nLen - 1;
 	while( pEnd > pFileName )
 	{
@@ -4925,7 +4925,7 @@ size_t Util_GetDebuggerText( char* &pText_ )
 	}
 
 	*pEnd = 0;
-	g_nTextScreen = pEnd - pBeg;
+	g_nTextScreen = (int)(pEnd - pBeg);
 	
 	pText_ = pBeg;
 	return g_nTextScreen;
@@ -4976,7 +4976,7 @@ size_t Util_GetTextScreen ( char* &pText_ )
 	}
 	*pEnd = 0;
 
-	g_nTextScreen = pEnd - pBeg;
+	g_nTextScreen = (int)(pEnd - pBeg);
 	
 	pText_ = pBeg;
 	return g_nTextScreen;
@@ -5032,7 +5032,7 @@ Update_t CmdNTSC (int nArgs)
 #endif
 
 	char *pFileName = (nArgs > 1) ? g_aArgs[ 2 ].sArg : "";
-	int   nLen = strlen( pFileName );
+	int   nLen = (int)strlen( pFileName );
 	char *pEnd = pFileName + nLen - 1;
 	while( pEnd > pFileName )
 	{
@@ -5078,9 +5078,9 @@ Update_t CmdNTSC (int nArgs)
 						ConsoleBufferPush( pPrefixText );	// TODO: Add a ": " separator
 
 #if _DEBUG
-						sprintf( text, "Filename.length.1: %d\n", len1 );
+						sprintf( text, "Filename.length.1: %d\n", (int)len1 );
 						OutputDebugString( text );
-						sprintf( text, "Filename.length.2: %d\n", len2 );
+						sprintf( text, "Filename.length.2: %d\n", (int)len2 );
 						OutputDebugString( text );
 						OutputDebugString( sPaletteFilePath );
 #endif
@@ -5693,7 +5693,7 @@ int _SearchMemoryFind(
 
 		WORD nAddress2 = nAddress;
 
-		int nMemBlocks = vMemorySearchValues.size();
+		int nMemBlocks = (int)vMemorySearchValues.size();
 		for (int iBlock = 0; iBlock < nMemBlocks; iBlock++, nAddress2++ )
 		{
 			MemorySearch_t ms = vMemorySearchValues.at( iBlock );
@@ -5785,7 +5785,7 @@ Update_t _SearchMemoryDisplay (int nArgs)
 {
 	const UINT nBuf = CONSOLE_WIDTH * 2;
 
-	int nFound = g_vMemorySearchResults.size() - 1;
+	int nFound = (int)g_vMemorySearchResults.size() - 1;
 
 	int nLen = 0; // temp
 	int nLineLen = 0; // string length of matches for this line, for word-wrap
@@ -6238,7 +6238,7 @@ Update_t CmdOutputPrint (int nArgs)
 		if (g_aArgs[ iArg ].bType & TYPE_QUOTED_2)
 		{
 			int iChar;
-			int nChar = _tcslen( g_aArgs[ iArg ].sArg );
+			int nChar = (int)_tcslen( g_aArgs[ iArg ].sArg );
 			for( iChar = 0; iChar < nChar; iChar++ )
 			{
 				TCHAR c = g_aArgs[ iArg ].sArg[ iChar ];
@@ -6329,7 +6329,7 @@ Update_t CmdOutputPrintf (int nArgs)
 		if (g_aArgs[ iArg ].bType & TYPE_QUOTED_2)
 		{
 			int iChar;
-			int nChar = _tcslen( g_aArgs[ iArg ].sArg );
+			int nChar = (int)_tcslen( g_aArgs[ iArg ].sArg );
 			for( iChar = 0; iChar < nChar; iChar++ )
 			{
 				TCHAR c = g_aArgs[ iArg ].sArg[ iChar ];
@@ -6487,7 +6487,7 @@ Update_t CmdOutputRun (int nArgs)
 		for( int iLine = 0; iLine < nLine; iLine++ )
 		{
 			script.GetLine( iLine, g_pConsoleInput, CONSOLE_WIDTH-2 );
-			g_nConsoleInputChars = _tcslen( g_pConsoleInput );
+			g_nConsoleInputChars = (int)_tcslen( g_pConsoleInput );
 			bUpdateDisplay |= DebuggerProcessCommand( false );
 		}
 	}
@@ -6638,7 +6638,7 @@ bool ParseAssemblyListing( bool bBytesToMemory, bool bAddSymbols )
 					// start
 					pStart = pEnd + 1;
 					pEnd = const_cast<char*>( SkipUntilWhiteSpace( pStart ));
-					int nLen = (pEnd - pStart);
+					int nLen = (int)(pEnd - pStart);
 					if (nLen != 2)
 					{
 						break;
@@ -6681,7 +6681,7 @@ bool ParseAssemblyListing( bool bBytesToMemory, bool bAddSymbols )
 					pLabelEnd++;
 					pLabelStart++;
 					
-					int nLen = pLabelEnd - pLabelStart;
+					int nLen = (int)(pLabelEnd - pLabelStart);
 					nLen = MIN( nLen, MAX_SYMBOLS_LEN );
 					strncpy( sName, pLabelStart, nLen );
 					sName[ nLen - 1 ] = 0;
@@ -7652,7 +7652,7 @@ Update_t CmdZeroPagePointer (int nArgs)
 int FindParam( LPTSTR pLookupName, Match_e eMatch, int & iParam_, int iParamBegin, int iParamEnd )
 {
 	int nFound = 0;
-	int nLen     = _tcslen( pLookupName );
+	int nLen     = (int)_tcslen( pLookupName );
 	int iParam = 0;
 
 	if (! nLen)
@@ -7718,7 +7718,7 @@ int FindCommand( LPTSTR pName, CmdFuncPtr_t & pFunction_, int * iCommand_ )
 	g_vPotentialCommands.erase( g_vPotentialCommands.begin(), g_vPotentialCommands.end() );
 
 	int nFound   = 0;
-	int nLen     = _tcslen( pName );
+	int nLen     = (int)_tcslen( pName );
 	int iCommand = 0;
 
 	if (! nLen)
@@ -7787,12 +7787,12 @@ void DisplayAmbigiousCommands( int nFound )
 		char sPotentialCommands[ CONSOLE_WIDTH ];
 		sprintf( sPotentialCommands, "%s ", CHC_COMMAND );
 
-		int iWidth = strlen( sPotentialCommands );
+		int iWidth = (int)strlen( sPotentialCommands );
 		while ((iCommand < nFound) && (iWidth < g_nConsoleDisplayWidth))
 		{
 			int   nCommand = g_vPotentialCommands[ iCommand ];
 			char *pName = g_aCommands[ nCommand ].m_sName;
-			int   nLen = strlen( pName );
+			int   nLen = (int)strlen( pName );
 
 			if ((iWidth + nLen) >= (CONSOLE_WIDTH - 1))
 				break;
@@ -7888,7 +7888,7 @@ Update_t ExecuteCommand (int nArgs)
 					// with:    comamnd addr
 					pArg[1] = pArg[0];
 					strcpy( pArg->sArg, g_aCommands[ g_iCommand ].m_sName );
-					pArg->nArgLen = strlen( pArg->sArg );
+					pArg->nArgLen = (int)strlen( pArg->sArg );
 
 					pArg++;
 					pArg->nValue = nAddress;
@@ -7907,7 +7907,7 @@ Update_t ExecuteCommand (int nArgs)
 					pArg[1] = pArg[0];
 
 					strcpy( pArg->sArg, g_aCommands[ g_iCommand ].m_sName );
-					pArg->nArgLen = strlen( pArg->sArg );
+					pArg->nArgLen = (int)strlen( pArg->sArg );
 
 //					nCookMask &= ~ (1 << TOKEN_COLON);
 //					nArgs++;
@@ -9059,7 +9059,7 @@ void DebugInitialize ()
 		char *pHelp = g_aCommands[ iCmd ].pHelpSummary;
 		if (pHelp)
 		{
-			int nLen = _tcslen( pHelp ) + 2;
+			int nLen = (int)_tcslen( pHelp ) + 2;
 			if (nLen > (CONSOLE_WIDTH-1))
 			{
 				ConsoleBufferPushFormat( sText, TEXT("Warning: %s help is %d chars"),

--- a/source/Debugger/Debugger_Assembler.cpp
+++ b/source/Debugger/Debugger_Assembler.cpp
@@ -879,7 +879,7 @@ int AssemblerHashMnemonic ( const TCHAR * pMnemonic )
 	const int    NUM_MSK_BITS =  5; //  4 ->  5 prime
 	const Hash_t BIT_MSK_HIGH = ((1 << NUM_MSK_BITS) - 1) << NUM_LOW_BITS;
 
-	int nLen = strlen( pMnemonic );
+	int nLen = (int)strlen( pMnemonic );
 
 #if DEBUG_ASSEMBLER
 	static int nMaxLen = 0;
@@ -1030,7 +1030,7 @@ bool AssemblerPokeOpcodeAddress( const WORD nBaseAddress )
 	int nTargetValue = m_nAsmTargetValue;
 
 	int iOpcode;
-	int nOpcodes = m_vAsmOpcodes.size();
+	int nOpcodes = (int)m_vAsmOpcodes.size();
 
 	for( iOpcode = 0; iOpcode < nOpcodes; iOpcode++ )
 	{
@@ -1044,7 +1044,7 @@ bool AssemblerPokeOpcodeAddress( const WORD nBaseAddress )
 
 			if (m_bDelayedTargetsDirty)
 			{			
-				int nDelayedTargets = m_vDelayedTargets.size();
+				int nDelayedTargets = (int)m_vDelayedTargets.size();
 				DelayedTarget_t *pTarget = & m_vDelayedTargets.at( nDelayedTargets - 1 );
 
 				pTarget->m_nOpcode = nOpcode;
@@ -1397,7 +1397,7 @@ bool AssemblerUpdateAddressingMode()
 //===========================================================================
 int AssemblerDelayedTargetsSize()
 {
-	int nSize = m_vDelayedTargets.size();
+	int nSize = (int)m_vDelayedTargets.size();
 	return nSize;
 }
 
@@ -1507,7 +1507,7 @@ bool Assemble( int iArg, int nArgs, WORD nAddress )
 		}
 	}
 
-	int nOpcodes = m_vAsmOpcodes.size();
+	int nOpcodes = (int)m_vAsmOpcodes.size();
 	if (! nOpcodes)
 	{
 		// Check for assembler directive

--- a/source/Debugger/Debugger_Console.cpp
+++ b/source/Debugger/Debugger_Console.cpp
@@ -100,7 +100,7 @@ int ConsoleLineLength( const conchar_t * pText )
 		{
 			pSrc++;
 		}
-		nLen = pSrc - pText;
+		nLen = (int)(pSrc - pText);
 	}
 	return nLen;
 }
@@ -429,7 +429,7 @@ void ConsoleDisplayPause ()
 			g_aConsoleInput,
 			"...press SPACE continue, ESC skip..."
 		);
-		g_nConsolePromptLen = strlen( g_pConsoleInput ) + 1;
+		g_nConsolePromptLen = (int)strlen( g_pConsoleInput ) + 1;
 #endif
 		g_nConsoleInputChars = 0;
 		g_bConsoleBufferPaused = true;
@@ -527,7 +527,7 @@ void ConsoleInputReset ()
 #if CONSOLE_INPUT_CHAR16
 	int nLen = ConsoleLineLength( g_aConsoleInput );
 #else
-	int nLen = strlen( g_aConsoleInput );
+	int nLen = (int)strlen( g_aConsoleInput );
 #endif
 
 	g_pConsoleInput = &g_aConsoleInput[ g_nConsolePromptLen ];

--- a/source/Debugger/Debugger_DisassemblerData.cpp
+++ b/source/Debugger/Debugger_DisassemblerData.cpp
@@ -201,7 +201,7 @@ Update_t CmdDisasmDataList (int nArgs)
 	{
 		if (pData->iDirective != _NOP_REMOVED)
 		{
-			int nLen = strlen( pData->sSymbol );
+			int nLen = (int)strlen( pData->sSymbol );
 
 			char sText[CONSOLE_WIDTH * 2];
 			// <smbol> <type> <start>:<end>
@@ -462,7 +462,7 @@ Update_t CmdDisasmDataDefString ( int nArgs )
 DisasmData_t* Disassembly_Enumerate( DisasmData_t *pCurrent )
 {
 	DisasmData_t *pData = NULL; // bIsNopcode = false
-	int nDataTargets = g_aDisassemblerData.size();
+	int nDataTargets = (int)g_aDisassemblerData.size();
 
 	if( nDataTargets )
 	{
@@ -486,7 +486,7 @@ DisasmData_t* Disassembly_Enumerate( DisasmData_t *pCurrent )
 DisasmData_t* Disassembly_IsDataAddress ( WORD nAddress )
 {
 	DisasmData_t *pData = NULL; // bIsNopcode = false
-	int nDataTargets = g_aDisassemblerData.size();
+	int nDataTargets = (int)g_aDisassemblerData.size();
 
 	if( nDataTargets )
 	{
@@ -535,7 +535,7 @@ void Disassembly_DelData( DisasmData_t tData)
 	WORD nAddress = tData.nStartAddress;
 
 	DisasmData_t *pData = NULL; // bIsNopcode = false
-	int nDataTargets = g_aDisassemblerData.size();
+	int nDataTargets = (int)g_aDisassemblerData.size();
 
 	if( nDataTargets )
 	{

--- a/source/Debugger/Debugger_Display.cpp
+++ b/source/Debugger/Debugger_Display.cpp
@@ -810,7 +810,7 @@ int PrintText ( const char * pText, RECT & rRect )
 		MessageBox( g_hFrameWindow, "pText = NULL!", "DrawText()", MB_OK );
 #endif
 
-	int nLen = strlen( pText );
+	int nLen = (int)strlen( pText );
 
 #if !DEBUG_FONT_NO_BACKGROUND_TEXT
 	FillRect( GetDebuggerMemDC(), &rRect, g_hConsoleBrushBG );
@@ -1595,7 +1595,7 @@ int GetDisassemblyLine ( WORD nBaseAddress, DisasmLine_t & line_ )
 		strcpy( line_.sMnemonic, g_aOpcodes[ line_.iOpcode ].sMnemonic );
 	}
 
-	int nSpaces = strlen( line_.sOpCodes );
+	int nSpaces = (int)strlen( line_.sOpCodes );
     while (nSpaces < (int)nMinBytesLen)
 	{
 		strcat( line_.sOpCodes, " " );
@@ -2077,7 +2077,7 @@ WORD DrawDisassemblyLine ( int iLine, const WORD nBaseAddress )
 	}
 
 	char *pTarget = line.sTarget;
-	int nLen = strlen( pTarget );
+	int nLen = (int)strlen( pTarget );
 
 	if (*pTarget == '$') // BUG? if ASC #:# starts with '$' ? // && (iOpcode != OPCODE_NOP)
 	{
@@ -2130,7 +2130,7 @@ WORD DrawDisassemblyLine ( int iLine, const WORD nBaseAddress )
 		if (line.nTargetOffset != 0)
 			nOverflow++;
 
-		nOverflow += strlen( line.sTargetOffset );
+		nOverflow += (int)strlen( line.sTargetOffset );
 	}
 
 	if (line.bTargetIndirect || line.bTargetX || line.bTargetY)
@@ -2153,15 +2153,15 @@ WORD DrawDisassemblyLine ( int iLine, const WORD nBaseAddress )
 
 	if (bDisasmFormatFlags & DISASM_FORMAT_TARGET_POINTER)
 	{
-		nOverflow += strlen( line.sTargetPointer ); // '####'
-		nOverflow ++  ;                             //     ':'
-		nOverflow += 2;                             //      '##'
-		nOverflow ++  ;                             //         ' '
+		nOverflow += (int)strlen( line.sTargetPointer ); // '####'
+		nOverflow ++  ;                                  //     ':'
+		nOverflow += 2;                                  //      '##'
+		nOverflow ++  ;                                  //         ' '
 	}
 
 	if (bDisasmFormatFlags & DISASM_FORMAT_CHAR)
 	{
-		nOverflow += strlen( line.sImmediate );
+		nOverflow += (int)strlen( line.sImmediate );
 	}
 
 	if (nLen >=  (nMaxLen - nOverflow))
@@ -3408,8 +3408,8 @@ void DrawZeroPagePointers ( int line )
 			const char* pSymbol2 = GetSymbol(nZPAddr2, 2);		// 2:8-bit value (if symbol not found)
 			const char* pSymbol1 = GetSymbol(nZPAddr1, 2);		// 2:8-bit value (if symbol not found)
 
-			int nLen1 = strlen( pSymbol1 );
-			int nLen2 = strlen( pSymbol2 );
+			int nLen1 = (int)strlen( pSymbol1 );
+			int nLen2 = (int)strlen( pSymbol2 );
 
 
 //			if ((nLen1 == 1) && (nLen2 == 1))
@@ -3770,7 +3770,7 @@ void DrawSubWindow_Source2 (Update_t bUpdate)
 	char sTitle[ CONSOLE_WIDTH ];
 	char sText [ CONSOLE_WIDTH ];
 	strcpy ( sTitle, "   Source: " );
-	int maxSizeToCopy = g_nConsoleDisplayWidth - strlen(sTitle) - 1;
+	int maxSizeToCopy = g_nConsoleDisplayWidth - (int)strlen(sTitle) - 1;
 	strncpy( sText , g_aSourceFileName, maxSizeToCopy );
 	sText[ maxSizeToCopy - 1 ] = 0;
 	strcat ( sTitle, sText );

--- a/source/Debugger/Debugger_Help.cpp
+++ b/source/Debugger/Debugger_Help.cpp
@@ -57,8 +57,8 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 //===========================================================================
 bool TestStringCat ( TCHAR * pDst, LPCSTR pSrc, const int nDstSize )
 {
-	int nLenDst = _tcslen( pDst );
-	int nLenSrc = _tcslen( pSrc );
+	int nLenDst = (int)_tcslen( pDst );
+	int nLenSrc = (int)_tcslen( pSrc );
 	int nSpcDst = nDstSize - nLenDst;
 	int nChars  = MIN( nLenSrc, nSpcDst );
 
@@ -76,8 +76,8 @@ bool TestStringCat ( TCHAR * pDst, LPCSTR pSrc, const int nDstSize )
 //===========================================================================
 bool TryStringCat ( TCHAR * pDst, LPCSTR pSrc, const int nDstSize )
 {
-	int nLenDst = _tcslen( pDst );
-	int nLenSrc = _tcslen( pSrc );
+	int nLenDst = (int)_tcslen( pDst );
+	int nLenSrc = (int)_tcslen( pSrc );
 	int nSpcDst = nDstSize - nLenDst;
 	int nChars  = MIN( nLenSrc, nSpcDst );
 
@@ -96,8 +96,8 @@ bool TryStringCat ( TCHAR * pDst, LPCSTR pSrc, const int nDstSize )
 //===========================================================================
 int StringCat ( TCHAR * pDst, LPCSTR pSrc, const int nDstSize )
 {
-	int nLenDst = _tcslen( pDst );
-	int nLenSrc = _tcslen( pSrc );
+	int nLenDst = (int)_tcslen( pDst );
+	int nLenSrc = (int)_tcslen( pSrc );
 	int nSpcDst = nDstSize - nLenDst;
 	int nChars  = MIN( nLenSrc, nSpcDst );
 
@@ -301,7 +301,7 @@ void _ColorizeHeader(
 {
 	int nLen;
 	
-	nLen = strlen( CHC_USAGE );
+	nLen = (int)strlen( CHC_USAGE );
 	strcpy( pDst, CHC_USAGE );
 	pDst += nLen;
 
@@ -311,14 +311,14 @@ void _ColorizeHeader(
 
 	pSrc += nHeaderLen;
 
-	nLen = strlen( CHC_ARG_SEP );
+	nLen = (int)strlen( CHC_ARG_SEP );
 	strcpy( pDst, CHC_ARG_SEP );
 	pDst += nLen;
 
 	*pDst = ':';
 	pDst++;
 
-	nLen = strlen( CHC_DEFAULT );
+	nLen = (int)strlen( CHC_DEFAULT );
 	strcpy( pDst, CHC_DEFAULT );
 	pDst += nLen;
 }
@@ -340,14 +340,14 @@ void _ColorizeOperator(
 {
 	int nLen;
 	
-	nLen = strlen( pOperator );
+	nLen = (int)strlen( pOperator );
 	strcpy( pDst, pOperator );
 	pDst += nLen;
 
 	*pDst = *pSrc;
 	pDst++;
 
-	nLen = strlen( CHC_DEFAULT );
+	nLen = (int)strlen( CHC_DEFAULT );
 	strcpy( pDst, CHC_DEFAULT );
 	pDst += nLen;
 
@@ -1498,7 +1498,7 @@ Update_t CmdHelpList (int nArgs)
 
 	char sText[ nBuf ] = "";
 	
-	int nLenLine = strlen( sText );
+	int nLenLine = (int)strlen( sText );
 	int y = 0;
 	int nLinesScrolled = 0;
 
@@ -1515,7 +1515,7 @@ Update_t CmdHelpList (int nArgs)
 		}
 		std::sort( g_vSortedCommands.begin(), g_vSortedCommands.end(), commands_functor_compare() );
 	}
-	int nCommands = g_vSortedCommands.size();
+	int nCommands = (int)g_vSortedCommands.size();
 
 	int nLen = 0;
 //		Colorize( sText, "Commands: " );
@@ -1534,7 +1534,7 @@ Update_t CmdHelpList (int nArgs)
 		if (! pCommand->pFunction)
 			continue; // not implemented function
 
-		int nLenCmd = strlen( pName );
+		int nLenCmd = (int)strlen( pName );
 		if ((nLen + nLenCmd) < (nMaxWidth))
 		{
 			        StringCat( sText, CHC_COMMAND, nBuf );

--- a/source/Debugger/Debugger_Parser.cpp
+++ b/source/Debugger/Debugger_Parser.cpp
@@ -104,7 +104,7 @@ int _Arg_1( int nValue )
 //===========================================================================
 int _Arg_1( LPTSTR pName )
 {
-	int nLen = _tcslen( g_aArgs[1].sArg );
+	int nLen = (int)_tcslen( g_aArgs[1].sArg );
 	if (nLen < MAX_ARG_LEN)
 	{
 		_tcscpy( g_aArgs[1].sArg, pName );
@@ -303,7 +303,7 @@ int	ArgsGet ( TCHAR * pInput )
 
 			if (pEnd)
 			{
-				nBuf = pEnd - pSrc;
+				nBuf = (int)(pEnd - pSrc);
 			}
 
 			if (nBuf > 0)
@@ -663,7 +663,7 @@ int ArgsCook ( const int nArgs )
 					pArg->nValue   = 0; // nAddressRHS;
 					pArg->bSymbol = false;
 
-					int nPointers = g_vMemorySearchResults.size();
+					int nPointers = (int)g_vMemorySearchResults.size();
 					if ((nPointers) &&
 						(nAddressRHS < nPointers))
 					{
@@ -869,7 +869,7 @@ const TCHAR * FindTokenOrAlphaNumeric ( const TCHAR *pSrc, const TokenTable_t *a
 //===========================================================================
 void TextConvertTabsToSpaces( TCHAR *pDeTabified_, LPCTSTR pText, const int nDstSize, int nTabStop )
 {
-	int nLen = _tcslen( pText );
+	int nLen = (int)_tcslen( pText );
 
 	int TAB_SPACING = 8;
 	int TAB_SPACING_1 = 16;
@@ -943,7 +943,7 @@ void TextConvertTabsToSpaces( TCHAR *pDeTabified_, LPCTSTR pText, const int nDst
 //===========================================================================
 int RemoveWhiteSpaceReverse ( TCHAR *pSrc )
 {
-	int   nLen = _tcslen( pSrc );
+	int   nLen = (int)_tcslen( pSrc );
 	char *pDst = pSrc + nLen;
 	while (nLen--)
 	{

--- a/source/Debugger/Debugger_Symbols.cpp
+++ b/source/Debugger/Debugger_Symbols.cpp
@@ -283,7 +283,7 @@ void _CmdSymbolsInfoHeader( int iTable, char * pText, int nDisplaySize /* = 0 */
 {
 	// Common case is to use/calc the table size
 	bool bActive = (g_bDisplaySymbolTables & (1 << iTable)) ? true : false;
-	int nSymbols  = nDisplaySize ? nDisplaySize : g_aSymbols[ iTable ].size();
+	int nSymbols  = nDisplaySize ? nDisplaySize : (int)g_aSymbols[ iTable ].size();
 
 	// Short Desc: `MAIN`: `1000`
 	// // 2.6.2.19 Color for name of symbol table: _CmdPrintSymbol() "SYM HOME" _CmdSymbolsInfoHeader "SYM"
@@ -490,7 +490,7 @@ Update_t _CmdSymbolsListTables (int nArgs, int bSymbolTables )
 			{
 				if( bTable & bSymbolTables )
 				{
-					int nSymbols = g_aSymbols[iTable].size();
+					int nSymbols = (int)g_aSymbols[iTable].size();
 					if (nSymbols)
 					{
 						SymbolTable_t :: iterator  iSymbol = g_aSymbols[iTable].begin();
@@ -622,7 +622,7 @@ int ParseSymbolTable( TCHAR *pPathFileName, SymbolTable_Index_e eSymbolTableWrit
 				p = strstr(szLine, ";");		// Optional
 				if(p) *p = 0;
 				p = strstr(szLine, " ");		// 1st space between name & value
-				int nLen = p - szLine;
+				int nLen = (int)(p - szLine);
 				if (nLen > MAX_SYMBOLS_LEN)
 				{
 					memset(&szLine[MAX_SYMBOLS_LEN], ' ', nLen-MAX_SYMBOLS_LEN);	// sscanf fails for nAddress if string too long
@@ -641,7 +641,7 @@ int ParseSymbolTable( TCHAR *pPathFileName, SymbolTable_Index_e eSymbolTableWrit
 			int  iTable;
 
 			// 2.9.0.11 Bug #479
-			int nLen = strlen( sName );
+			int nLen = (int)strlen( sName );
 			if (nLen > nMaxLen)
 			{
 				ConsolePrintFormat( sText, " %sWarn.: %s%s (%d > %d)"

--- a/source/Debugger/Util_MemoryTextFile.cpp
+++ b/source/Debugger/Util_MemoryTextFile.cpp
@@ -104,7 +104,7 @@ void MemoryTextFile_t::GetLinePointers()
 
 			// DOS/Win "Text" mode converts LF CR (0D 0A) to CR (0D)
 			// but just in case, the file is read in binary.
-			int nEOL = pStartNextLine - pEnd;
+			int nEOL = (int)(pStartNextLine - pEnd);
 			while (nEOL-- > 1)
 			{
 				*pEnd++ = ' ';

--- a/source/Debugger/Util_MemoryTextFile.h
+++ b/source/Debugger/Util_MemoryTextFile.h
@@ -33,7 +33,7 @@ inline	int  GetNumLines()
 			if (m_bDirty)
 				GetLinePointers();
 
-			return m_vLines.size();
+			return (int)m_vLines.size();
 		}
 
 inline	char *GetLine( const int iLine ) const

--- a/source/DiskImage.cpp
+++ b/source/DiskImage.cpp
@@ -301,7 +301,7 @@ void GetImageTitle(LPCTSTR pPathname, TCHAR* pImageName, TCHAR* pFullName)
 	}
 
 	if ((!found) && (loop > 2))
-		CharLowerBuff(imagetitle+1, _tcslen(imagetitle+1));
+		CharLowerBuff(imagetitle+1, (DWORD)_tcslen(imagetitle+1));
 
 	// pFullName = <FILENAME.EXT>
 	_tcsncpy( pFullName, imagetitle, MAX_DISK_FULL_NAME );

--- a/source/DiskImageHelper.cpp
+++ b/source/DiskImageHelper.cpp
@@ -541,7 +541,7 @@ DWORD CImageBase::NibblizeTrack(LPBYTE trackimagebuffer, SectorOrder_e SectorOrd
 		sector++;
 	}
 
-	return imageptr-trackimagebuffer;
+	return (DWORD)(imageptr-trackimagebuffer);
 }
 
 //-------------------------------------
@@ -1350,7 +1350,7 @@ void CImageHelperBase::GetCharLowerExt(TCHAR* pszExt, LPCTSTR pszImageFilename, 
 	_tcsncpy(pszExt, pImageFileExt, uExtSize);
 	pszExt[uExtSize - 1] = 0;
 
-	CharLowerBuff(pszExt, _tcslen(pszExt));
+	CharLowerBuff(pszExt, (DWORD)_tcslen(pszExt));
 }
 
 void CImageHelperBase::GetCharLowerExt2(TCHAR* pszExt, LPCTSTR pszImageFilename, const UINT uExtSize)

--- a/source/DiskImageHelper.h
+++ b/source/DiskImageHelper.h
@@ -315,7 +315,7 @@ protected:
 	void GetCharLowerExt2(TCHAR* pszExt, LPCTSTR pszImageFilename, const UINT uExtSize);
 	void SetImageInfo(ImageInfo* pImageInfo, FileType_e eFileGZip, DWORD dwOffset, CImageBase* pImageType, DWORD dwSize);
 
-	UINT GetNumImages(void) { return m_vecImageTypes.size(); };
+	UINT GetNumImages(void) { return (UINT)m_vecImageTypes.size(); };
 	CImageBase* GetImage(UINT uIndex) { _ASSERT(uIndex<GetNumImages()); return m_vecImageTypes[uIndex]; }
 	CImageBase* GetImage(eImageType Type)
 	{

--- a/source/Frame.cpp
+++ b/source/Frame.cpp
@@ -515,7 +515,7 @@ static void DrawButton (HDC passdc, int number) {
 	LPCTSTR pszBaseName = sg_Disk2Card.GetBaseName(number-BTN_DRIVE1);
     ExtTextOut(dc,x+offset+22,rect.top,ETO_CLIPPED,&rect,
                pszBaseName,
-               MIN(8,_tcslen(pszBaseName)),
+               (UINT)MIN(8, _tcslen(pszBaseName)),
                NULL);
   }
   if (!passdc)
@@ -858,7 +858,7 @@ void FrameDrawDiskStatus( HDC passdc )
 			sprintf( text, "%s/%s    ", g_sTrackDrive2, g_sSectorDrive2 );
 
 		SetTextColor(dc, g_aDiskFullScreenColorsLED[ DISK_STATUS_READ ] );
-		TextOut(dc,x+dx,y-12,text, strlen(text) ); // original: y+2; y-12 puts status in the Configuration Button Icon
+		TextOut(dc,x+dx,y-12,text, (int)strlen(text)); // original: y+2; y-12 puts status in the Configuration Button Icon
 	}
 	else
 	{
@@ -875,14 +875,14 @@ void FrameDrawDiskStatus( HDC passdc )
 		SetBkMode(dc,TRANSPARENT);
 
 		sprintf( text, "T%s", g_sTrackDrive1 );
-		TextOut(dc,x+6, y+32, text, strlen(text) );
+		TextOut(dc,x+6, y+32, text, (int)strlen(text) );
 		sprintf( text, "S%s", g_sSectorDrive1 );
-		TextOut(dc,x+6, y+42, text, strlen(text) );
+		TextOut(dc,x+6, y+42, text, (int)strlen(text) );
 
 		sprintf( text, "T%s", g_sTrackDrive2 );
-		TextOut(dc,x+26,y+32, text, strlen(text) );
+		TextOut(dc,x+26,y+32, text, (int)strlen(text) );
 		sprintf( text, "S%s", g_sSectorDrive2 );
-		TextOut(dc,x+26,y+42, text, strlen(text) );
+		TextOut(dc,x+26,y+42, text, (int)strlen(text) );
 	}
 }
 
@@ -956,14 +956,14 @@ static void DrawStatusArea (HDC passdc, int drawflags)
 			if (pCurrentAppModeText && pNewAppModeText != pCurrentAppModeText)
 			{
 				SetTextColor(dc, RGB(0,0,0));
-				TextOut(dc, x+BUTTONCX/2, y+13, pCurrentAppModeText, strlen(pCurrentAppModeText));
+				TextOut(dc, x+BUTTONCX/2, y+13, pCurrentAppModeText, (int)strlen(pCurrentAppModeText));
 				pCurrentAppModeText = NULL;
 			}
 
 			if (pNewAppModeText)
 			{
 				SetTextColor(dc, RGB(255,255,255));
-				TextOut(dc, x+BUTTONCX/2, y+13, pNewAppModeText, strlen(pNewAppModeText));
+				TextOut(dc, x+BUTTONCX/2, y+13, pNewAppModeText, (int)strlen(pNewAppModeText));
 				pCurrentAppModeText = pNewAppModeText;
 			}
 		}
@@ -1260,7 +1260,7 @@ LRESULT CALLBACK FrameWndProc (
 		if ((wparam >= VK_F1) && (wparam <= VK_F8) && (buttondown == -1))
 		{
 			SetUsingCursor(FALSE);
-			buttondown = wparam-VK_F1;
+			buttondown = (int)(wparam-VK_F1);
 			if (g_bIsFullScreen && (buttonover != -1)) {
 				if (buttonover != buttondown)
 				EraseButton(buttonover);
@@ -1400,7 +1400,7 @@ LRESULT CALLBACK FrameWndProc (
 		}
 		else if (g_nAppMode == MODE_DEBUG)
 		{		
-			DebuggerProcessKey(wparam); // Debugger already active, re-direct key to debugger
+			DebuggerProcessKey((int)wparam); // Debugger already active, re-direct key to debugger
 		}
 		break;
 
@@ -1430,10 +1430,10 @@ LRESULT CALLBACK FrameWndProc (
 		{
 			buttondown = -1;
 			if (g_bIsFullScreen)
-				EraseButton(wparam-VK_F1);
+				EraseButton((int)(wparam-VK_F1));
 			else
-				DrawButton((HDC)0,wparam-VK_F1);
-			ProcessButtonClick(wparam-VK_F1, true);
+				DrawButton((HDC)0,(int)(wparam-VK_F1));
+			ProcessButtonClick((int)(wparam-VK_F1), true);
 		}
 		else
 		{
@@ -1653,7 +1653,7 @@ LRESULT CALLBACK FrameWndProc (
       if(((LPNMTTDISPINFO)lparam)->hdr.hwndFrom == tooltipwindow &&
          ((LPNMTTDISPINFO)lparam)->hdr.code == TTN_GETDISPINFO)
         ((LPNMTTDISPINFO)lparam)->lpszText =
-          (LPTSTR)sg_Disk2Card.GetFullDiskFilename(((LPNMTTDISPINFO)lparam)->hdr.idFrom);
+          (LPTSTR)sg_Disk2Card.GetFullDiskFilename((int)((LPNMTTDISPINFO)lparam)->hdr.idFrom);
       break;
 
     case WM_PAINT:

--- a/source/Keyboard.cpp
+++ b/source/Keyboard.cpp
@@ -140,11 +140,11 @@ void KeybQueueKeypress (WPARAM key, Keystroke_e bASCII)
 			if (g_bCapsLock && (key >= 'a') && (key <='z'))
 			{
 				P8Shift = true;
-				keycode = key - 32;
+				keycode = (BYTE)(key - 32);
 			}
 			else
 			{
-				keycode = key;
+				keycode = (BYTE)key;
 			}			
 
 			//The latter line should be applied for Pravtes 8A/C only, but not for Pravets 82/M !!!			
@@ -152,7 +152,7 @@ void KeybQueueKeypress (WPARAM key, Keystroke_e bASCII)
 			{
 				P8Shift = true;
 				if (g_Apple2Type == A2TYPE_PRAVETS8A) 
-					keycode = key + 32;
+					keycode = (BYTE)(key + 32);
 			}
 
 			//Remap some keys for Pravets82/M
@@ -259,9 +259,9 @@ void KeybQueueKeypress (WPARAM key, Keystroke_e bASCII)
 				}
 				if (key > 0x7F) return;	// Get out
 				if ((key >= 'a') && (key <= 'z') && (g_bCapsLock))
-					keycode = key - ('a'-'A');
+					keycode = (BYTE)(key - ('a'-'A'));
 				else
-					keycode = key;
+					keycode = (BYTE)key;
 			}
 		}
 		else
@@ -272,9 +272,9 @@ void KeybQueueKeypress (WPARAM key, Keystroke_e bASCII)
 			else
 			{
 				if (key >= '`')
-					keycode = key - 32;
+					keycode = (BYTE)(key - 32);
 				else
-					keycode = key;
+					keycode = (BYTE)key;
 			}
 		}
 	} 
@@ -459,7 +459,7 @@ void KeybAnyKeyDown(UINT message, WPARAM wparam, bool bIsExtended)
 
 	if (IsVirtualKeyAnAppleIIKey(wparam))
 	{
-		UINT offset = wparam >> 6;
+		UINT offset = (UINT)(wparam >> 6);
 		UINT bit    = wparam & 0x3f;
 		UINT idx    = !bIsExtended ? 0 : 1;
 

--- a/source/Mockingboard.cpp
+++ b/source/Mockingboard.cpp
@@ -1190,13 +1190,13 @@ static bool MB_DSInit()
 									FALSE,	// bManualReset (FALSE = auto-reset)
 									FALSE,	// bInitialState (FALSE = non-signaled)
 									NULL);	// lpName
-	LogFileOutput("MB_DSInit: CreateEvent(), g_hSSI263Event[0]=0x%08X\n", (UINT32)g_hSSI263Event[0]);
+	LogFileOutput("MB_DSInit: CreateEvent(), g_hSSI263Event[0]=0x%016p\n", g_hSSI263Event[0]);
 
 	g_hSSI263Event[1] = CreateEvent(NULL,	// lpEventAttributes
 									FALSE,	// bManualReset (FALSE = auto-reset)
 									FALSE,	// bInitialState (FALSE = non-signaled)
 									NULL);	// lpName
-	LogFileOutput("MB_DSInit: CreateEvent(), g_hSSI263Event[1]=0x%08X\n", (UINT32)g_hSSI263Event[1]);
+	LogFileOutput("MB_DSInit: CreateEvent(), g_hSSI263Event[1]=0x%016p\n", g_hSSI263Event[1]);
 
 	if((g_hSSI263Event[0] == NULL) || (g_hSSI263Event[1] == NULL))
 	{
@@ -1298,7 +1298,7 @@ static bool MB_DSInit()
 								NULL,			// lpParameter
 								0,				// dwCreationFlags : 0 = Run immediately
 								&dwThreadId);	// lpThreadId
-	LogFileOutput("MB_DSInit: CreateThread(), g_hThread=0x%08X\n", (UINT32)g_hThread);
+	LogFileOutput("MB_DSInit: CreateThread(), g_hThread=0x%016p\n", g_hThread);
 
 	BOOL bRes2 = SetThreadPriority(g_hThread, THREAD_PRIORITY_TIME_CRITICAL);
 	LogFileOutput("MB_DSInit: SetThreadPriority(), bRes=%d\n", bRes2 ? 1 : 0);

--- a/source/ParallelPrinter.cpp
+++ b/source/ParallelPrinter.cpp
@@ -246,7 +246,7 @@ void Printer_SetFilename(char* prtFilename)
 
 		// NB. _tcsncat_s() terminates program if buffer is too small! So continue to use manual buffer check & _tcsncat()
 
-		int nLen = sizeof(g_szPrintFilename) - strlen(g_szPrintFilename) - (sizeof(DEFAULT_PRINT_FILENAME)-1) - 1;
+		int nLen = (int)(sizeof(g_szPrintFilename) - strlen(g_szPrintFilename) - (sizeof(DEFAULT_PRINT_FILENAME)-1) - 1);
 		if (nLen < 0)
 		{
 			MessageBox(g_hFrameWindow, "Printer - SetFilename(): folder too deep", "Warning", MB_ICONWARNING | MB_OK);

--- a/source/Registry.cpp
+++ b/source/Registry.cpp
@@ -86,7 +86,7 @@ void RegSaveString (LPCTSTR section, LPCTSTR key, BOOL peruser, LPCTSTR buffer) 
                   0,
                   REG_SZ,
                   (CONST BYTE *)buffer,
-                  (_tcslen(buffer)+1)*sizeof(TCHAR));
+                  (DWORD)(_tcslen(buffer)+1)*sizeof(TCHAR));
     RegCloseKey(keyhandle);
   }
 }

--- a/source/SaveState.cpp
+++ b/source/SaveState.cpp
@@ -93,7 +93,7 @@ void Snapshot_SetFilename(std::string strPathname)
 	std::string strFilename = strPathname;	// Set default, as maybe there's no path
 	g_strSaveStatePath.clear();
 
-	int nIdx = strPathname.find_last_of('\\');
+	int nIdx = (int)strPathname.find_last_of('\\');
 	if (nIdx >= 0 && nIdx+1 < (int)strPathname.length())
 	{
 		strFilename = &strPathname[nIdx+1];

--- a/source/SerialComms.cpp
+++ b/source/SerialComms.cpp
@@ -1275,7 +1275,7 @@ void CSuperSerialCard::ScanCOMPorts()
 	//
 
 	m_vecSerialPortsItems.push_back(SERIALPORTITEM_INVALID_COM_PORT);	// "TCP"
-	m_uTCPChoiceItemIdx = m_vecSerialPortsItems.size()-1;
+	m_uTCPChoiceItemIdx = (UINT)(m_vecSerialPortsItems.size()-1);
 }
 
 char* CSuperSerialCard::GetSerialPortChoices()

--- a/source/SerialComms.h
+++ b/source/SerialComms.h
@@ -75,7 +75,7 @@ private:
 	static DWORD WINAPI	CommThread(LPVOID lpParameter);
 	bool	CommThInit();
 	void	CommThUninit();
-	UINT	GetNumSerialPortChoices() { return m_vecSerialPortsItems.size(); }
+	UINT	GetNumSerialPortChoices() { return (UINT)m_vecSerialPortsItems.size(); }
 	void	ScanCOMPorts();
 	void	SaveSnapshotDIPSW(class YamlSaveHelper& yamlSaveHelper, std::string key, SSC_DIPSW& dipsw);
 	void	LoadSnapshotDIPSW(class YamlLoadHelper& yamlLoadHelper, std::string key, SSC_DIPSW& dipsw);

--- a/source/Tfe/Tfe.cpp
+++ b/source/Tfe/Tfe.cpp
@@ -505,7 +505,7 @@ int tfe_activate_i(void)
 
 #ifdef TFE_DEBUG_INIT
     if(g_fh) fprintf(g_fh, "tfe_activate: Allocated memory successfully.\n");
-    if(g_fh) fprintf(g_fh, "\ttfe at $%08X, tfe_packetpage at $%08X\n", uintptr_t(tfe), uintptr_t(tfe_packetpage) );
+    if(g_fh) fprintf(g_fh, "\ttfe at $%016p, tfe_packetpage at $%016p\n", tfe, tfe_packetpage );
 #endif
 
 #ifdef DOS_TFE
@@ -1361,7 +1361,7 @@ int set_tfe_enabled(void *v, void *param)
 {
     if (!tfe_cannot_use) {
 
-        if (!(int)v) {
+        if (!v) {
             /* TFE should be deactived */
             if (tfe_enabled) {
                 tfe_enabled = 0;

--- a/source/Tfe/Uilib.cpp
+++ b/source/Tfe/Uilib.cpp
@@ -55,7 +55,7 @@ void uilib_get_general_window_extents(HWND hwnd, int *xsize, int *ysize)
     SIZE  size;
 
     hFont = (HFONT)SendMessage(hwnd, WM_GETFONT, 0, 0);
-    strlen = SendMessage(hwnd, WM_GETTEXTLENGTH, 0, 0);
+    strlen = (int)SendMessage(hwnd, WM_GETTEXTLENGTH, 0, 0);
 	/* RGJ added cast for AppleWin */
     buffer = (char *) malloc(strlen + 1);
 	if (buffer == NULL)	// TC: add null check for AppleWin

--- a/source/Video.cpp
+++ b/source/Video.cpp
@@ -448,23 +448,23 @@ void VideoDisplayLogo ()
 	TextOut(hFrameDC,                       \
 		scale*540+x+xoff,scale*358+y+yoff,  \
 		szVersion,                          \
-		strlen(szVersion));
+		(int)strlen(szVersion));
 
 	if (GetDeviceCaps(hFrameDC,PLANES) * GetDeviceCaps(hFrameDC,BITSPIXEL) <= 4) {
-		DRAWVERSION( 2, 2,RGB(0x00,0x00,0x00));
-		DRAWVERSION( 1, 1,RGB(0x00,0x00,0x00));
-		DRAWVERSION( 0, 0,RGB(0xFF,0x00,0xFF));
+		DRAWVERSION( 2, 2, RGB(0x00,0x00,0x00));
+		DRAWVERSION( 1, 1, RGB(0x00,0x00,0x00));
+		DRAWVERSION( 0, 0, RGB(0xFF,0x00,0xFF));
 	} else {
-		DRAWVERSION( 1, 1,PALETTERGB(0x30,0x30,0x70));
-		DRAWVERSION(-1,-1,PALETTERGB(0xC0,0x70,0xE0));
-		DRAWVERSION( 0, 0,PALETTERGB(0x70,0x30,0xE0));
+		DRAWVERSION( 1, 1, PALETTERGB(0x30,0x30,0x70));
+		DRAWVERSION(-1,-1, PALETTERGB(0xC0,0x70,0xE0));
+		DRAWVERSION( 0, 0, PALETTERGB(0x70,0x30,0xE0));
 	}
 
 #if _DEBUG
 	sprintf( szVersion, "DEBUG" );
-	DRAWVERSION( 2, -358*scale,RGB(0x00,0x00,0x00));
-	DRAWVERSION( 1, -357*scale,RGB(0x00,0x00,0x00));
-	DRAWVERSION( 0, -356*scale,RGB(0xFF,0x00,0xFF));
+	DRAWVERSION( 2, -358*scale, RGB(0x00,0x00,0x00));
+	DRAWVERSION( 1, -357*scale, RGB(0x00,0x00,0x00));
+	DRAWVERSION( 0, -356*scale, RGB(0xFF,0x00,0xFF));
 #endif
 
 #undef  DRAWVERSION

--- a/zlib/gzread.c
+++ b/zlib/gzread.c
@@ -321,7 +321,7 @@ local z_size_t gz_read(state, buf, len)
         /* set n to the maximum amount of len that fits in an unsigned int */
         n = -1;
         if (n > len)
-            n = len;
+            n = (unsigned)len;
 
         /* first just try copying data from the output buffer */
         if (state->x.have) {
@@ -402,7 +402,7 @@ int ZEXPORT gzread(file, buf, len)
     }
 
     /* read len or fewer bytes to buf */
-    len = gz_read(state, buf, len);
+    len = (unsigned)gz_read(state, buf, len);
 
     /* check for an error */
     if (len == 0 && state->err != Z_OK && state->err != Z_BUF_ERROR)
@@ -474,7 +474,7 @@ int ZEXPORT gzgetc(file)
     }
 
     /* nothing there -- try gz_read() */
-    ret = gz_read(state, buf, 1);
+    ret = (int)gz_read(state, buf, 1);
     return ret < 1 ? -1 : buf[0];
 }
 

--- a/zlib/gzwrite.c
+++ b/zlib/gzwrite.c
@@ -214,7 +214,7 @@ local z_size_t gz_write(state, buf, len)
                               state->in);
             copy = state->size - have;
             if (copy > len)
-                copy = len;
+                copy = (unsigned)len;
             memcpy(state->in + have, buf, copy);
             state->strm.avail_in += copy;
             state->x.pos += copy;
@@ -234,7 +234,7 @@ local z_size_t gz_write(state, buf, len)
         do {
             unsigned n = (unsigned)-1;
             if (n > len)
-                n = len;
+                n = (unsigned)len;
             state->strm.avail_in = n;
             state->x.pos += n;
             if (gz_comp(state, Z_NO_FLUSH) == -1)
@@ -373,7 +373,7 @@ int ZEXPORT gzputs(file, str)
 
     /* write string */
     len = strlen(str);
-    ret = gz_write(state, str, len);
+    ret = (int)gz_write(state, str, len);
     return ret == 0 && len != 0 ? -1 : ret;
 }
 


### PR DESCRIPTION
This change adds 64-bit support to AppleWin.
1. It adds a 64-bit Visual Studio configuration for AppleWin.
2. It corrects several lines of code that were incompatible with 64-bit compiles.
3. It corrects a larger number of warnings that were generated by the 64-bit compiler.

This change builds on top of an earlier pull request, https://github.com/AppleWin/AppleWin/pull/682, which added the ability to generate Visual Studio solutions and projects.
