### PR TITLE
Fix random crash upon start up.

### DIFF
--- a/source/Debugger/Debugger_Symbols.cpp
+++ b/source/Debugger/Debugger_Symbols.cpp
@@ -622,10 +622,13 @@ int ParseSymbolTable(const std::string & pPathFileName, SymbolTable_Index_e eSym
 				p = strstr(szLine, ";");		// Optional
 				if(p) *p = 0;
 				p = strstr(szLine, " ");		// 1st space between name & value
-				int nLen = p - szLine;
-				if (nLen > MAX_SYMBOLS_LEN)
+				if (p)
 				{
-					memset(&szLine[MAX_SYMBOLS_LEN], ' ', nLen-MAX_SYMBOLS_LEN);	// sscanf fails for nAddress if string too long
+					int nLen = p - szLine;
+					if (nLen > MAX_SYMBOLS_LEN)
+					{
+						memset(&szLine[MAX_SYMBOLS_LEN], ' ', nLen - MAX_SYMBOLS_LEN);	// sscanf fails for nAddress if string too long
+					}
 				}
 				sscanf(szLine, sFormat2, sName, &nAddress);
 			}


### PR DESCRIPTION
Unchecked null result of strstr() may cause random crashes. Well, strstr() returns null (at least so it seems) for all empty lines in the *.SYM files, but not crashing all the times somehow.