### PR TITLE
Memory fix

### DIFF
--- a/source/DiskImage.cpp
+++ b/source/DiskImage.cpp
@@ -57,7 +57,7 @@ ImageError_e ImageOpen(	const std::string & pszImageFilename,
 	if (*ppImageInfo == NULL)
 		return eIMAGE_ERROR_BAD_POINTER;
 
-	ZeroMemory(*ppImageInfo, sizeof(ImageInfo));
+	new (*ppImageInfo) ImageInfo();
 	ImageInfo* pImageInfo = *ppImageInfo;
 	pImageInfo->bWriteProtected = *pWriteProtected;
 	if (bExpectFloppy)	pImageInfo->pImageHelper = &sg_DiskImageHelper;

--- a/source/DiskImage.cpp
+++ b/source/DiskImage.cpp
@@ -53,11 +53,8 @@ ImageError_e ImageOpen(	const std::string & pszImageFilename,
 		return eIMAGE_ERROR_BAD_POINTER;
 
 	// CREATE A RECORD FOR THE FILE
-	*ppImageInfo = (ImageInfo*) VirtualAlloc(NULL, sizeof(ImageInfo), MEM_COMMIT, PAGE_READWRITE);
-	if (*ppImageInfo == NULL)
-		return eIMAGE_ERROR_BAD_POINTER;
+	*ppImageInfo = new ImageInfo();
 
-	new (*ppImageInfo) ImageInfo();
 	ImageInfo* pImageInfo = *ppImageInfo;
 	pImageInfo->bWriteProtected = *pWriteProtected;
 	if (bExpectFloppy)	pImageInfo->pImageHelper = &sg_DiskImageHelper;
@@ -116,7 +113,7 @@ void ImageClose(ImageInfo* const pImageInfo, const bool bOpenError /*=false*/)
 
 	pImageInfo->pImageHelper->Close(pImageInfo, bDeleteFile);
 
-	VirtualFree(pImageInfo, 0, MEM_RELEASE);
+	delete pImageInfo;
 }
 
 //===========================================================================

--- a/source/DiskImageHelper.cpp
+++ b/source/DiskImageHelper.cpp
@@ -38,6 +38,25 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "DiskImageHelper.h"
 #include "Memory.h"
 
+ImageInfo::ImageInfo()
+{
+	// this is not a POD as it contains c++ strings
+	// simply zeroing is not going to work
+	pImageType = NULL;
+	pImageHelper = NULL;
+	FileType = eFileNormal;
+	hFile = INVALID_HANDLE_VALUE;
+	uOffset = 0;
+	bWriteProtected = false;
+	uImageSize = 0;
+	ZeroMemory(&zipFileInfo, sizeof(zipFileInfo));
+	uNumEntriesInZip = 0;
+	ZeroMemory(&ValidTrack, sizeof(ValidTrack));
+	uNumTracks = 0;
+	pImageBuffer = NULL;
+	pTrackMap = NULL;
+	optimalBitTiming = 0;
+}
 
 /* DO logical order  0 1 2 3 4 5 6 7 8 9 A B C D E F */
 /*    physical order 0 D B 9 7 5 3 1 E C A 8 6 4 2 F */
@@ -1704,7 +1723,7 @@ void CImageHelperBase::Close(ImageInfo* pImageInfo, const bool bDeleteFile)
 		DeleteFile(pImageInfo->szFilename.c_str());
 	}
 
-	pImageInfo->szFilename[0] = 0;
+	pImageInfo->szFilename.clear();
 
 	delete [] pImageInfo->pImageBuffer;
 	pImageInfo->pImageBuffer = NULL;

--- a/source/DiskImageHelper.cpp
+++ b/source/DiskImageHelper.cpp
@@ -1077,7 +1077,7 @@ public:
 			m_pWOZEmptyTrack[i] = n;
 		}
 	}
-	virtual ~CWOZEmptyTrack(void) { delete m_pWOZEmptyTrack; }
+	virtual ~CWOZEmptyTrack(void) { delete [] m_pWOZEmptyTrack; }
 
 	void ReadEmptyTrack(LPBYTE pTrackImageBuffer, int* pNibbles, UINT* pBitCount)
 	{

--- a/source/DiskImageHelper.h
+++ b/source/DiskImageHelper.h
@@ -37,6 +37,8 @@ struct ImageInfo
 	BYTE*			pImageBuffer;
 	BYTE*			pTrackMap;	// WOZ only
 	BYTE			optimalBitTiming;	// WOZ only
+
+	ImageInfo();
 };
 
 //-------------------------------------


### PR DESCRIPTION
ImageInfo must be initialised by calling its c++ constructor (as it contains std::string).

In VS it seems to work (by chance?), in g++ it fails.
C++ standard requires the constructor anyway.
