### PR TITLE
Allow use of an INI-file instead of the Registry

### DIFF
--- a/help/CommandLine.html
+++ b/help/CommandLine.html
@@ -11,6 +11,8 @@
 		<p style="FONT-WEIGHT: bold">AppleWin can be driven from the command line as 
 			follows:
 		</p>
+		-conf &lt;pathname&gt;<br>
+		Use an INI file for configuration instead of the Registry.<br>
 		-d1 &lt;pathname&gt;<br>
 		Start with a floppy disk in slot 6 drive-1 (and auto power-on the Apple II).<br>
 		NB. -s6d1 has the meaning same as -d1.<br><br>

--- a/source/Applewin.cpp
+++ b/source/Applewin.cpp
@@ -85,6 +85,8 @@ static bool g_bSysClkOK = false;
 std::string g_sProgramDir; // Directory of where AppleWin executable resides
 std::string g_sDebugDir; // TODO: Not currently used
 std::string g_sScreenShotDir; // TODO: Not currently used
+std::string g_sConfigFile; // INI file to use instead of Registry
+
 bool      g_bCapturePrintScreenKey = true;
 static bool g_bHookSystemKey = true;
 static bool g_bHookAltTab = false;
@@ -1385,6 +1387,17 @@ static bool ProcessCmdLine(LPSTR lpCmdLine)
 		else if (strcmp(lpCmdLine, "-noreg") == 0)
 		{
 			g_bRegisterFileTypes = false;
+		}
+		else if (strcmp(lpCmdLine, "-conf") == 0)
+		{
+			lpCmdLine = GetCurrArg(lpNextArg);
+			lpNextArg = GetNextArg(lpNextArg);
+			char buf[MAX_PATH];
+			DWORD res = GetFullPathName(lpCmdLine, MAX_PATH, buf, NULL);
+			if (res == 0)
+				LogFileOutput("Failed to open configuration file: %s\n", lpCmdLine);
+			else
+				g_sConfigFile = buf;
 		}
 		else if (strcmp(lpCmdLine, "-d1") == 0)
 		{

--- a/source/Registry.cpp
+++ b/source/Registry.cpp
@@ -28,10 +28,30 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include "StdAfx.h"
 
+extern std::string g_sConfigFile;
+
+namespace _ini {
+	//===========================================================================
+	BOOL RegLoadString(LPCTSTR section, LPCTSTR key, BOOL peruser, LPTSTR buffer, DWORD chars)
+	{
+		DWORD n = GetPrivateProfileString(section, key, NULL, buffer, chars, g_sConfigFile.c_str());
+		return n > 0;
+	}
+
+	//===========================================================================
+	void RegSaveString(LPCTSTR section, LPCTSTR key, BOOL peruser, const std::string& buffer)
+	{
+		BOOL updated = WritePrivateProfileString(section, key, buffer.c_str(), g_sConfigFile.c_str());
+		_ASSERT(updated || GetLastError() == 0);
+	}
+}
 
 //===========================================================================
 BOOL RegLoadString (LPCTSTR section, LPCTSTR key, BOOL peruser, LPTSTR buffer, DWORD chars)
 {
+	if (!g_sConfigFile.empty())
+		return _ini::RegLoadString(section, key, peruser, buffer, chars);
+
 	TCHAR fullkeyname[256];
 	StringCbPrintf(fullkeyname, 256, TEXT("Software\\AppleWin\\CurrentVersion\\%s"), section);
 
@@ -88,6 +108,9 @@ BOOL RegLoadValue (LPCTSTR section, LPCTSTR key, BOOL peruser, DWORD* value, DWO
 
 //===========================================================================
 void RegSaveString (LPCTSTR section, LPCTSTR key, BOOL peruser, const std::string & buffer) {
+	if (!g_sConfigFile.empty())
+		return _ini::RegSaveString(section, key, peruser, buffer);
+
 	TCHAR fullkeyname[256];
 	StringCbPrintf(fullkeyname, 256, TEXT("Software\\AppleWin\\CurrentVersion\\%s"), section);
 
@@ -122,3 +145,4 @@ void RegSaveValue (LPCTSTR section, LPCTSTR key, BOOL peruser, DWORD value) {
 	StringCbPrintf(buffer, 32, "%d", value);
 	RegSaveString(section, key, peruser, buffer);
 }
+


### PR DESCRIPTION
This change adds the `-conf` switch which, if specified, will use an INI-file instead of the Windows Registry.

This affects AppleWin/AppleWin#709 and AppleWin/AppleWin#446.

## Testing
I tested this using VS2019 on Windows 10.

1. Open PowerShell and navigate to the folder containing `AppleWin.exe`.
2. Run `AppleWin.exe -conf config.ini`, where `config.ini` is a non-existing file.
3. Close AppleWin.
4. Note the creation of `config.ini`. Also note that no values in the Registry should be changed (this is easy to test if you remove the AppleWin group first so you can see that nothing is created).
5. Run `AppleWin.exe` normally (without `-conf`). Change some settings. Notice that the Registry is used and the `config.ini` is unaffected.