### PR TITLE
Fixed CmdCursorSetPC command

### DIFF
--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -3661,7 +3661,7 @@ Update_t CmdCursorPageUp4K (int nArgs)
 //===========================================================================
 Update_t CmdCursorSetPC( int nArgs) // TODO rename
 {
-	regs.pc = nArgs; // HACK:
+	regs.pc = g_nDisasmCurAddress; // set PC to current cursor address
 	return UPDATE_DISASM;
 }
 


### PR DESCRIPTION
Hitting "=" in the debugger is supposed to set PC to the _current cursor address_.
Setting PC to the _number_ of arguments made no sense anyway.