### PR TITLE
Support for PAL killing color-burst during TEXT video mode

### DIFF
--- a/source/NTSC.cpp
+++ b/source/NTSC.cpp
@@ -411,7 +411,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 	INLINE void      updateFramebufferMonitorSingleScanline( uint16_t signal, bgra_t *pTable );
 	INLINE void      updateFramebufferMonitorDoubleScanline( uint16_t signal, bgra_t *pTable );
 	INLINE void      updatePixels( uint16_t bits );
-	INLINE void      updatePixelsText(uint16_t bits);
 	INLINE void      updateVideoScannerHorzEOL();
 	INLINE void      updateVideoScannerAddress();
 	INLINE uint16_t  getVideoScannerAddressTXT();


### PR DESCRIPTION
PR for #763.

Attention paid to "NTSC Monitor" mode when MIXED (lines 160-191 are TEXT) or demos that switch video modes mid-scanline.

Tested with:
- https://github.com/AppleWin/AppleWin-Test/blob/master/v2/Tests-Various.dsk
- FT's ANSI STORY & TRIBU demos