### PR TITLE
Video7 SL7 RGB extra modes

### DIFF
--- a/source/Applewin.cpp
+++ b/source/Applewin.cpp
@@ -1333,6 +1333,7 @@ struct CmdLine
 		newVideoRefreshRate = VR_NONE;
 		clockMultiplier = 0.0;	// 0 => not set from cmd-line
 		model = A2TYPE_MAX;
+		rgb_card = RGB_Videocard_e::Apple;
 
 		for (UINT i = 0; i < NUM_SLOTS; i++)
 		{
@@ -1367,6 +1368,9 @@ struct CmdLine
 	VideoRefreshRate_e newVideoRefreshRate;
 	double clockMultiplier;
 	eApple2Type model;
+	RGB_Videocard_e rgb_card;
+	int rgb_card_foreground_color;
+	int rgb_card_background_color;
 	std::string strCurrentDir;
 };
 
@@ -1798,6 +1802,37 @@ static bool ProcessCmdLine(LPSTR lpCmdLine)
 		{
 			g_cmdLine.newVideoRefreshRate = VR_60HZ;
 		}
+		else if (strcmp(lpCmdLine, "-rgb-card-type") == 0)
+		{
+			// RGB video card valide types are: "apple", "sl7", "eve", "feline"
+			lpCmdLine = GetCurrArg(lpNextArg);
+			lpNextArg = GetNextArg(lpNextArg);
+
+			if (strcmp(lpCmdLine, "apple") == 0)
+				g_cmdLine.rgb_card = RGB_Videocard_e::Apple;
+			else if (strcmp(lpCmdLine, "sl7") == 0)
+				g_cmdLine.rgb_card = RGB_Videocard_e::Video7_SL7;
+			else if (strcmp(lpCmdLine, "eve") == 0)
+				g_cmdLine.rgb_card = RGB_Videocard_e::LeChatMauve_EVE;
+			else if (strcmp(lpCmdLine, "feline") == 0)
+				g_cmdLine.rgb_card = RGB_Videocard_e::LeChatMauve_Feline;
+			else
+				LogFileOutput("-rgb-card-type: unsupported type: %s\n", lpCmdLine);
+		}
+		else if (strcmp(lpCmdLine, "-rgb-card-foreground") == 0)
+		{
+			// Default hardware-defined Text foreground color, for some RGB cards only
+			lpCmdLine = GetCurrArg(lpNextArg);
+			lpNextArg = GetNextArg(lpNextArg);
+			g_cmdLine.rgb_card_foreground_color = atoi(lpCmdLine);
+		}
+		else if (strcmp(lpCmdLine, "-rgb-card-background") == 0)
+		{
+			// Default hardware-defined Text background color, for some RGB cards only
+			lpCmdLine = GetCurrArg(lpNextArg);
+			lpNextArg = GetNextArg(lpNextArg);
+			g_cmdLine.rgb_card_background_color = atoi(lpCmdLine);
+		}
 		else if (strcmp(lpCmdLine, "-power-on") == 0)
 		{
 			g_cmdLine.bBoot = true;
@@ -1943,6 +1978,8 @@ static void RepeatInitialization(void)
 
 		if (g_cmdLine.model != A2TYPE_MAX)
 			SetApple2Type(g_cmdLine.model);
+
+		RGB_SetVideocard(g_cmdLine.rgb_card, g_cmdLine.rgb_card_foreground_color, g_cmdLine.rgb_card_background_color);
 
 		if (g_cmdLine.newVideoType >= 0)
 		{

--- a/source/Applewin.cpp
+++ b/source/Applewin.cpp
@@ -1333,7 +1333,9 @@ struct CmdLine
 		newVideoRefreshRate = VR_NONE;
 		clockMultiplier = 0.0;	// 0 => not set from cmd-line
 		model = A2TYPE_MAX;
-		rgb_card = RGB_Videocard_e::Apple;
+		rgbCard = RGB_Videocard_e::Apple;
+		rgbCardForegroundColor = 15;
+		rgbCardBackgroundColor = 0;
 
 		for (UINT i = 0; i < NUM_SLOTS; i++)
 		{
@@ -1368,9 +1370,9 @@ struct CmdLine
 	VideoRefreshRate_e newVideoRefreshRate;
 	double clockMultiplier;
 	eApple2Type model;
-	RGB_Videocard_e rgb_card;
-	int rgb_card_foreground_color;
-	int rgb_card_background_color;
+	RGB_Videocard_e rgbCard;
+	int rgbCardForegroundColor;
+	int rgbCardBackgroundColor;
 	std::string strCurrentDir;
 };
 
@@ -1809,13 +1811,13 @@ static bool ProcessCmdLine(LPSTR lpCmdLine)
 			lpNextArg = GetNextArg(lpNextArg);
 
 			if (strcmp(lpCmdLine, "apple") == 0)
-				g_cmdLine.rgb_card = RGB_Videocard_e::Apple;
+				g_cmdLine.rgbCard = RGB_Videocard_e::Apple;
 			else if (strcmp(lpCmdLine, "sl7") == 0)
-				g_cmdLine.rgb_card = RGB_Videocard_e::Video7_SL7;
+				g_cmdLine.rgbCard = RGB_Videocard_e::Video7_SL7;
 			else if (strcmp(lpCmdLine, "eve") == 0)
-				g_cmdLine.rgb_card = RGB_Videocard_e::LeChatMauve_EVE;
+				g_cmdLine.rgbCard = RGB_Videocard_e::LeChatMauve_EVE;
 			else if (strcmp(lpCmdLine, "feline") == 0)
-				g_cmdLine.rgb_card = RGB_Videocard_e::LeChatMauve_Feline;
+				g_cmdLine.rgbCard = RGB_Videocard_e::LeChatMauve_Feline;
 			else
 				LogFileOutput("-rgb-card-type: unsupported type: %s\n", lpCmdLine);
 		}
@@ -1824,14 +1826,14 @@ static bool ProcessCmdLine(LPSTR lpCmdLine)
 			// Default hardware-defined Text foreground color, for some RGB cards only
 			lpCmdLine = GetCurrArg(lpNextArg);
 			lpNextArg = GetNextArg(lpNextArg);
-			g_cmdLine.rgb_card_foreground_color = atoi(lpCmdLine);
+			g_cmdLine.rgbCardForegroundColor = atoi(lpCmdLine);
 		}
 		else if (strcmp(lpCmdLine, "-rgb-card-background") == 0)
 		{
 			// Default hardware-defined Text background color, for some RGB cards only
 			lpCmdLine = GetCurrArg(lpNextArg);
 			lpNextArg = GetNextArg(lpNextArg);
-			g_cmdLine.rgb_card_background_color = atoi(lpCmdLine);
+			g_cmdLine.rgbCardBackgroundColor = atoi(lpCmdLine);
 		}
 		else if (strcmp(lpCmdLine, "-power-on") == 0)
 		{
@@ -1979,7 +1981,7 @@ static void RepeatInitialization(void)
 		if (g_cmdLine.model != A2TYPE_MAX)
 			SetApple2Type(g_cmdLine.model);
 
-		RGB_SetVideocard(g_cmdLine.rgb_card, g_cmdLine.rgb_card_foreground_color, g_cmdLine.rgb_card_background_color);
+		RGB_SetVideocard(g_cmdLine.rgbCard, g_cmdLine.rgbCardForegroundColor, g_cmdLine.rgbCardBackgroundColor);
 
 		if (g_cmdLine.newVideoType >= 0)
 		{

--- a/source/NTSC.cpp
+++ b/source/NTSC.cpp
@@ -1666,7 +1666,6 @@ void updateScreenText40RGB(long cycles6502)
 				uint8_t* pMain = MemGetMainPtr(addr);
 				uint8_t  m = pMain[0];
 				uint8_t  c = getCharSetBits(m);
-				//uint16_t bits = g_aPixelDoubleMaskHGR[c & 0x7F]; // Optimization: hgrbits second 128 entries are mirror of first 128
 
 				if (0 == g_nVideoCharSet && 0x40 == (m & 0xC0)) // Flash only if mousetext not active
 					c ^= g_nTextFlashMask;
@@ -1761,10 +1760,7 @@ void updateScreenText80RGB(long cycles6502)
 				g_pVideoAddress += 7;
 
 				uint16_t bits = (main << 7) | (aux & 0x7f);
-				//if (g_eVideoType != VT_COLOR_MONITOR_RGB)			// No extra 14M bit needed for VT_COLOR_MONITOR_RGB
-				//	bits = (bits << 1) | g_nLastColumnPixelNTSC;	// GH#555: Align TEXT80 chars with DHGR
 
-				//updatePixels(bits);
 				g_nLastColumnPixelNTSC = (bits >> 14) & 1;
 			}
 		}

--- a/source/NTSC.cpp
+++ b/source/NTSC.cpp
@@ -1754,9 +1754,9 @@ void updateScreenText80RGB(long cycles6502)
 				if ((0 == g_nVideoCharSet) && 0x40 == (a & 0xC0)) // Flash only if mousetext not active
 					aux ^= g_nTextFlashMask;
 
-				UpdateText80ColorCell(g_nVideoClockHorz - VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress, aux);
+				UpdateText80ColorCell(g_nVideoClockHorz - VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress, (uint8_t)aux);
 				g_pVideoAddress += 7;
-				UpdateText80ColorCell(g_nVideoClockHorz - VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress, main);
+				UpdateText80ColorCell(g_nVideoClockHorz - VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress, (uint8_t)main);
 				g_pVideoAddress += 7;
 
 				uint16_t bits = (main << 7) | (aux & 0x7f);

--- a/source/NTSC.cpp
+++ b/source/NTSC.cpp
@@ -8,7 +8,7 @@ AppleWin is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
-lecha
+
 AppleWin is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/source/NTSC.cpp
+++ b/source/NTSC.cpp
@@ -1925,7 +1925,7 @@ void NTSC_SetVideoMode( uint32_t uVideoModeFlags, bool bDelay/*=false*/ )
 	}
 
 	if (g_eVideoType == VT_COLOR_MONITOR_RGB
-		&& RGB_GetVideocard() == RGB_Video7_SL7
+		&& RGB_GetVideocard() == RGB_Videocard_e::Video7_SL7
 		&& (!(uVideoModeFlags & VF_DHIRES) ^ !(!(uVideoModeFlags & VF_TEXT) && (uVideoModeFlags & VF_DHIRES) && (uVideoModeFlags & VF_80COL))))
 	{
 		RGB_EnableTextFB(); // F/B text only shows in 40col mode anyway

--- a/source/NTSC.cpp
+++ b/source/NTSC.cpp
@@ -1837,7 +1837,7 @@ void NTSC_SetVideoMode( uint32_t uVideoModeFlags, bool bDelay/*=false*/ )
 
 	if (g_eVideoType == VT_COLOR_MONITOR_RGB
 		&& RGB_GetVideocard() == RGB_Video7_SL7
-		&& !((uVideoModeFlags & VF_DHIRES) && (uVideoModeFlags & VF_TEXT) && !(uVideoModeFlags & VF_DHIRES) && !(uVideoModeFlags & VF_80COL)))
+		&& (!(uVideoModeFlags & VF_DHIRES) ^ !(!(uVideoModeFlags & VF_TEXT) && (uVideoModeFlags & VF_DHIRES) && (uVideoModeFlags & VF_80COL))))
 	{
 		// ----- Video-7 SL7 extra modes ----- (from the videocard manual)
 		//  AN3 TEXT HIRES 80COL

--- a/source/NTSC.cpp
+++ b/source/NTSC.cpp
@@ -441,6 +441,8 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 	static void updateScreenSingleLores40( long cycles6502 );
 	static void updateScreenText40       ( long cycles6502 );
 	static void updateScreenText80       ( long cycles6502 );
+	static void updateScreenText40RGB	 ( long cycles6502 );
+	static void updateScreenText80RGB    ( long cycles6502 );
 
 //===========================================================================
 static void set_csbits()
@@ -826,7 +828,8 @@ inline void updateVideoScannerAddress()
 	if (((g_pFuncUpdateGraphicsScreen == updateScreenDoubleHires80) ||
 		(g_pFuncUpdateGraphicsScreen == updateScreenDoubleLores80) ||
 		(g_pFuncUpdateGraphicsScreen == updateScreenText80) ||
-		(g_nVideoMixed && g_nVideoClockVert >= VIDEO_SCANNER_Y_MIXED && g_pFuncUpdateTextScreen == updateScreenText80))
+		(g_pFuncUpdateGraphicsScreen == updateScreenText80RGB) ||
+		(g_nVideoMixed && g_nVideoClockVert >= VIDEO_SCANNER_Y_MIXED && (g_pFuncUpdateTextScreen == updateScreenText80 || g_pFuncUpdateGraphicsScreen == updateScreenText80RGB)))
 		&& (g_eVideoType != VT_COLOR_MONITOR_RGB))	// Fix for "Ansi Story" (Turn the disk over) - Top row of TEXT80 is shifted by 1 pixel
 	{
 		g_pVideoAddress -= 1;
@@ -1899,7 +1902,8 @@ void NTSC_SetVideoMode( uint32_t uVideoModeFlags, bool bDelay/*=false*/ )
 
 			// Switching mid-line from graphics to TEXT
 			if (g_eVideoType == VT_COLOR_MONITOR_NTSC &&
-				g_pFuncUpdateGraphicsScreen != updateScreenText40 && g_pFuncUpdateGraphicsScreen != updateScreenText40RGB && g_pFuncUpdateGraphicsScreen != updateScreenText80)
+				g_pFuncUpdateGraphicsScreen != updateScreenText40 && g_pFuncUpdateGraphicsScreen != updateScreenText40RGB
+				&& g_pFuncUpdateGraphicsScreen != updateScreenText80 && g_pFuncUpdateGraphicsScreen != updateScreenText80RGB)
 			{
 				*(uint32_t*)&g_pVideoAddress[0] = 0;	// blank out any stale pixel data, eg. ANSI STORY (at end credits)
 				*(uint32_t*)&g_pVideoAddress[1] = 0;
@@ -1912,7 +1916,8 @@ void NTSC_SetVideoMode( uint32_t uVideoModeFlags, bool bDelay/*=false*/ )
 
 			// Switching mid-line from TEXT to graphics
 			if (g_eVideoType == VT_COLOR_MONITOR_NTSC &&
-				(g_pFuncUpdateGraphicsScreen == updateScreenText40 || g_pFuncUpdateGraphicsScreen == updateScreenText40RGB || g_pFuncUpdateGraphicsScreen == updateScreenText80))
+				(g_pFuncUpdateGraphicsScreen == updateScreenText40 || g_pFuncUpdateGraphicsScreen == updateScreenText40RGB
+					|| g_pFuncUpdateGraphicsScreen == updateScreenText80 || g_pFuncUpdateGraphicsScreen == updateScreenText80RGB))
 			{
 				g_pVideoAddress -= 2;	// eg. FT's TRIBU demo & ANSI STORY (at "turn the disk over!")
 			}
@@ -1966,7 +1971,12 @@ void NTSC_SetVideoMode( uint32_t uVideoModeFlags, bool bDelay/*=false*/ )
 	else if (uVideoModeFlags & VF_TEXT)
 	{
 		if (uVideoModeFlags & VF_80COL)
-			g_pFuncUpdateGraphicsScreen = updateScreenText80;
+		{
+			if (g_eVideoType == VT_COLOR_MONITOR_RGB)
+				g_pFuncUpdateGraphicsScreen = updateScreenText80RGB;
+			else
+				g_pFuncUpdateGraphicsScreen = updateScreenText80;
+		}
 		else if (g_eVideoType == VT_COLOR_MONITOR_RGB)
 			g_pFuncUpdateGraphicsScreen = updateScreenText40RGB;
 		else

--- a/source/NTSC.cpp
+++ b/source/NTSC.cpp
@@ -1920,9 +1920,16 @@ void NTSC_SetVideoMode( uint32_t uVideoModeFlags, bool bDelay/*=false*/ )
 		}
 	}
 
+	// Video7_SL7 extra RGB modes handling
 	if (g_eVideoType == VT_COLOR_MONITOR_RGB
 		&& RGB_GetVideocard() == RGB_Videocard_e::Video7_SL7
-		&& (!(uVideoModeFlags & VF_DHIRES) ^ !(!(uVideoModeFlags & VF_TEXT) && (uVideoModeFlags & VF_DHIRES) && (uVideoModeFlags & VF_80COL))))
+		// Exclude following modes (fallback through regular NTSC rendering with RGB text)
+		// VF_DHIRES = 1  -> regular Apple IIe modes
+		// VF_DHIRES = 0 and VF_TEXT=0, VF_DHIRES=1, VF_80COL=1  -> DHIRES modes, setup by F1/F2
+		&& !(!(uVideoModeFlags & VF_DHIRES) ||
+			 ((uVideoModeFlags & VF_DHIRES) && !(uVideoModeFlags & VF_TEXT) && (uVideoModeFlags & VF_DHIRES) && (uVideoModeFlags & VF_80COL))
+			)
+		)
 	{
 		RGB_EnableTextFB(); // F/B text only shows in 40col mode anyway
 
@@ -1964,6 +1971,7 @@ void NTSC_SetVideoMode( uint32_t uVideoModeFlags, bool bDelay/*=false*/ )
 			g_pFuncUpdateTextScreen = updateScreenText40RGB;
 		}
 	}
+	// Regular NTSC modes
 	else if (uVideoModeFlags & VF_TEXT)
 	{
 		if (uVideoModeFlags & VF_80COL)

--- a/source/NTSC.h
+++ b/source/NTSC.h
@@ -24,4 +24,3 @@
 	UINT NTSC_GetCyclesPerLine(void);
 	UINT NTSC_GetVideoLines(void);
 	bool NTSC_IsVisible(void);
-

--- a/source/NTSC.h
+++ b/source/NTSC.h
@@ -24,3 +24,4 @@
 	UINT NTSC_GetCyclesPerLine(void);
 	UINT NTSC_GetVideoLines(void);
 	bool NTSC_IsVisible(void);
+

--- a/source/RGBMonitor.cpp
+++ b/source/RGBMonitor.cpp
@@ -11,9 +11,9 @@
 
 // RGB videocards types
 
-static RGB_Videocard_e RGB_Videocard = RGB_Videocard_e::Video7_SL7;
+static RGB_Videocard_e RGB_Videocard = RGB_Videocard_e::Apple;
 static int nTextFBMode = 0; // F/B Text
-static int nRegularTextFG = 9; // Default TEXT color
+static int nRegularTextFG = 15; // Default TEXT color
 static int nRegularTextBG = 0; // Default TEXT background color
 
 const int HIRES_COLUMN_SUBUNIT_SIZE = 16;

--- a/source/RGBMonitor.cpp
+++ b/source/RGBMonitor.cpp
@@ -11,7 +11,7 @@
 
 // RGB videocards types
 
-static RGB_Videocard_e RGB_Videocard = RGB_Video7_SL7;
+static RGB_Videocard_e RGB_Videocard = RGB_Videocard_e::Video7_SL7;
 static int nTextFBMode = 0; // F/B Text
 static int nRegularTextFG = 9; // Default TEXT color
 static int nRegularTextBG = 0; // Default TEXT background color
@@ -955,9 +955,21 @@ RGB_Videocard_e RGB_GetVideocard(void)
 	return RGB_Videocard;
 }
 
-void RGB_SetVideocard(RGB_Videocard_e videocard)
+void RGB_SetVideocard(RGB_Videocard_e videocard, int text_foreground, int text_background)
 {
 	RGB_Videocard = videocard;
+
+	// black & white text
+	RGB_SetRegularTextFG(15);
+	RGB_SetRegularTextBG(0);
+
+	if (videocard == RGB_Videocard_e::Video7_SL7 &&
+		(text_foreground == 6 || text_foreground == 9 || text_foreground == 12 || text_foreground == 15))
+	{
+		// SL7: Only Blue, Amber (Orange), Green, White are supported by hardware switches
+		RGB_SetRegularTextFG(text_foreground);
+		RGB_SetRegularTextBG(0);
+	}
 }
 
 void RGB_SetRegularTextFG(int color)

--- a/source/RGBMonitor.cpp
+++ b/source/RGBMonitor.cpp
@@ -11,10 +11,10 @@
 
 // RGB videocards types
 
-static RGB_Videocard_e RGB_Videocard = RGB_Videocard_e::Apple;
-static int nTextFBMode = 0; // F/B Text
-static int nRegularTextFG = 15; // Default TEXT color
-static int nRegularTextBG = 0; // Default TEXT background color
+static RGB_Videocard_e g_RGBVideocard = RGB_Videocard_e::Apple;
+static int g_nTextFBMode = 0; // F/B Text
+static int g_nRegularTextFG = 15; // Default TEXT color
+static int g_nRegularTextBG = 0; // Default TEXT background color
 
 const int HIRES_COLUMN_SUBUNIT_SIZE = 16;
 const int HIRES_COLUMN_UNIT_SIZE = (HIRES_COLUMN_SUBUNIT_SIZE)*2;
@@ -710,9 +710,9 @@ void UpdateDLoResCell (int x, int y, uint16_t addr, bgra_t *pVideoAddress)
 // Default BG and FG are usually defined by hardware switches, defaults to black/white
 void UpdateText40ColorCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, uint8_t bits)
 {
-	uint8_t foreground = nRegularTextFG;
-	uint8_t background = nRegularTextBG;
-	if (nTextFBMode)
+	uint8_t foreground = g_nRegularTextFG;
+	uint8_t background = g_nRegularTextBG;
+	if (g_nTextFBMode)
 	{
 		const BYTE val = *MemGetAuxPtr(addr);  // RGB cards with F/B text use their own AUX memory!
 		foreground = val >> 4;
@@ -724,7 +724,7 @@ void UpdateText40ColorCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, u
 
 void UpdateText80ColorCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, uint8_t bits)
 {
-	UpdateDuochromeCell(2, 7, pVideoAddress, bits, nRegularTextFG, nRegularTextBG);
+	UpdateDuochromeCell(2, 7, pVideoAddress, bits, g_nRegularTextFG, g_nRegularTextBG);
 }
 
 //===========================================================================
@@ -951,12 +951,12 @@ void RGB_LoadSnapshot(YamlLoadHelper& yamlLoadHelper, UINT cardVersion)
 
 RGB_Videocard_e RGB_GetVideocard(void)
 {
-	return RGB_Videocard;
+	return g_RGBVideocard;
 }
 
 void RGB_SetVideocard(RGB_Videocard_e videocard, int text_foreground, int text_background)
 {
-	RGB_Videocard = videocard;
+	g_RGBVideocard = videocard;
 
 	// black & white text
 	RGB_SetRegularTextFG(15);
@@ -973,25 +973,25 @@ void RGB_SetVideocard(RGB_Videocard_e videocard, int text_foreground, int text_b
 
 void RGB_SetRegularTextFG(int color)
 {
-	 nRegularTextFG = color;
+	g_nRegularTextFG = color;
 }
 
 void RGB_SetRegularTextBG(int color)
 {
-	nRegularTextBG = color;
+	g_nRegularTextBG = color;
 }
 
 void RGB_EnableTextFB()
 {
-	nTextFBMode = 1;
+	g_nTextFBMode = 1;
 }
 
 void RGB_DisableTextFB()
 {
-	nTextFBMode = 0;
+	g_nTextFBMode = 0;
 }
 
 int RGB_IsTextFB()
 {
-	return nTextFBMode;
+	return g_nTextFBMode;
 }

--- a/source/RGBMonitor.cpp
+++ b/source/RGBMonitor.cpp
@@ -716,7 +716,6 @@ void UpdateText40ColorCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, u
 	{
 		const BYTE val = *MemGetAuxPtr(addr);  // RGB cards with F/B text use their own AUX memory!
 		foreground = val >> 4;
-		//foreground = (val >> 6) | ((val & 0x30) >> 2);
 		background = val & 0x0F;
 	}
 

--- a/source/RGBMonitor.cpp
+++ b/source/RGBMonitor.cpp
@@ -13,7 +13,7 @@
 
 static RGB_Videocard_e RGB_Videocard = RGB_Video7_SL7;
 static int nTextFBMode = 0; // F/B Text
-static int nRegularTextFG = 1; // Default TEXT color
+static int nRegularTextFG = 3; // Default TEXT color
 static int nRegularTextBG = 0; // Default TEXT background color
 
 const int HIRES_COLUMN_SUBUNIT_SIZE = 16;
@@ -707,11 +707,17 @@ void UpdateDLoResCell (int x, int y, uint16_t addr, bgra_t *pVideoAddress)
 
 //===========================================================================
 // Color TEXT (some RGB cards only)
-void UpdateText40DuochromeCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, uint8_t bits)
+// Default BG and FG are usually defined by hardware switches, defaults to black/white
+void UpdateText40ColorCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, uint8_t bits)
 {
-	const BYTE val = *MemGetAuxPtr(addr);
-	const uint8_t foreground = val >> 4;
-	const uint8_t background = val & 0x0F;
+	uint8_t foreground = nRegularTextFG;
+	uint8_t background = nRegularTextBG;
+	if (nTextFBMode)
+	{
+		const BYTE val = *MemGetAuxPtr(addr);  // RGB cards with F/B text use their own AUX memory!
+		foreground = val >> 4;
+		background = val & 0x0F;
+	}
 
 	UpdateDuochromeCell(2, pVideoAddress, bits, foreground, background);
 }

--- a/source/RGBMonitor.cpp
+++ b/source/RGBMonitor.cpp
@@ -13,7 +13,7 @@
 
 static RGB_Videocard_e RGB_Videocard = RGB_Video7_SL7;
 static int nTextFBMode = 0; // F/B Text
-static int nRegularTextFG = 3; // Default TEXT color
+static int nRegularTextFG = 9; // Default TEXT color
 static int nRegularTextBG = 0; // Default TEXT background color
 
 const int HIRES_COLUMN_SUBUNIT_SIZE = 16;

--- a/source/RGBMonitor.h
+++ b/source/RGBMonitor.h
@@ -1,8 +1,22 @@
+// Handling of RGB videocards
+
+typedef enum
+{
+	RGB_Apple,
+	RGB_Video7_SL7,
+	RGB_LeChatMauve_EVE,
+	RGB_LeChatMauve_Feline
+} RGB_Videocard_e;
+
+
 void UpdateHiResCell(int x, int y, uint16_t addr, bgra_t *pVideoAddress);
 void UpdateDHiResCell (int x, int y, uint16_t addr, bgra_t *pVideoAddress, bool updateAux, bool updateMain);
 int UpdateDHiRes160Cell (int x, int y, uint16_t addr, bgra_t *pVideoAddress);
 void UpdateLoResCell(int x, int y, uint16_t addr, bgra_t *pVideoAddress);
 void UpdateDLoResCell(int x, int y, uint16_t addr, bgra_t *pVideoAddress);
+void UpdateText40DuochromeCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, uint8_t bits);
+void UpdateHiResDuochromeCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress);
+void UpdateDuochromeCell(int h, bgra_t* pVideoAddress, uint8_t bits, uint8_t foreground, uint8_t background);
 
 const UINT kNumBaseColors = 16;
 typedef bgra_t (*baseColors_t)[kNumBaseColors];
@@ -19,3 +33,11 @@ void RGB_SetInvertBit7(bool state);
 
 void RGB_SaveSnapshot(class YamlSaveHelper& yamlSaveHelper);
 void RGB_LoadSnapshot(class YamlLoadHelper& yamlLoadHelper, UINT cardVersion);
+
+RGB_Videocard_e RGB_GetVideocard(void);
+void RGB_SetVideocard(RGB_Videocard_e videocard);
+void RGB_SetRegularTextFG(int color);
+void RGB_SetRegularTextBG(int color);
+void RGB_EnableTextFB();
+void RGB_DisableTextFB();
+int RGB_IsTextFB();

--- a/source/RGBMonitor.h
+++ b/source/RGBMonitor.h
@@ -15,8 +15,9 @@ int UpdateDHiRes160Cell (int x, int y, uint16_t addr, bgra_t *pVideoAddress);
 void UpdateLoResCell(int x, int y, uint16_t addr, bgra_t *pVideoAddress);
 void UpdateDLoResCell(int x, int y, uint16_t addr, bgra_t *pVideoAddress);
 void UpdateText40ColorCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, uint8_t bits);
+void UpdateText80ColorCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, uint8_t bits);
 void UpdateHiResDuochromeCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress);
-void UpdateDuochromeCell(int h, bgra_t* pVideoAddress, uint8_t bits, uint8_t foreground, uint8_t background);
+void UpdateDuochromeCell(int h, int w, bgra_t* pVideoAddress, uint8_t bits, uint8_t foreground, uint8_t background);
 
 const UINT kNumBaseColors = 16;
 typedef bgra_t (*baseColors_t)[kNumBaseColors];

--- a/source/RGBMonitor.h
+++ b/source/RGBMonitor.h
@@ -1,6 +1,6 @@
 // Handling of RGB videocards
 
-enum class RGB_Videocard_e
+enum RGB_Videocard_e
 {
 	Apple,
 	Video7_SL7,

--- a/source/RGBMonitor.h
+++ b/source/RGBMonitor.h
@@ -1,12 +1,12 @@
 // Handling of RGB videocards
 
-typedef enum
+enum class RGB_Videocard_e
 {
-	RGB_Apple,
-	RGB_Video7_SL7,
-	RGB_LeChatMauve_EVE,
-	RGB_LeChatMauve_Feline
-} RGB_Videocard_e;
+	Apple,
+	Video7_SL7,
+	LeChatMauve_EVE,
+	LeChatMauve_Feline
+};
 
 
 void UpdateHiResCell(int x, int y, uint16_t addr, bgra_t *pVideoAddress);
@@ -36,7 +36,7 @@ void RGB_SaveSnapshot(class YamlSaveHelper& yamlSaveHelper);
 void RGB_LoadSnapshot(class YamlLoadHelper& yamlLoadHelper, UINT cardVersion);
 
 RGB_Videocard_e RGB_GetVideocard(void);
-void RGB_SetVideocard(RGB_Videocard_e videocard);
+void RGB_SetVideocard(RGB_Videocard_e videocard, int text_foreground = -1, int text_background = -1);
 void RGB_SetRegularTextFG(int color);
 void RGB_SetRegularTextBG(int color);
 void RGB_EnableTextFB();

--- a/source/RGBMonitor.h
+++ b/source/RGBMonitor.h
@@ -14,7 +14,7 @@ void UpdateDHiResCell (int x, int y, uint16_t addr, bgra_t *pVideoAddress, bool 
 int UpdateDHiRes160Cell (int x, int y, uint16_t addr, bgra_t *pVideoAddress);
 void UpdateLoResCell(int x, int y, uint16_t addr, bgra_t *pVideoAddress);
 void UpdateDLoResCell(int x, int y, uint16_t addr, bgra_t *pVideoAddress);
-void UpdateText40DuochromeCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, uint8_t bits);
+void UpdateText40ColorCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, uint8_t bits);
 void UpdateHiResDuochromeCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress);
 void UpdateDuochromeCell(int h, bgra_t* pVideoAddress, uint8_t bits, uint8_t foreground, uint8_t background);
 


### PR DESCRIPTION
Added support for extra RGB modes of some video cards. (#819)

Currently only Apple RGB and Video7 SL7 are supported.

The RGB videocard can be defined through command-line:
`-rgb-card-type: apple (default), sl7, eve, feline`

The default text color can be modified when SL7 is selected. On the actual card this was defined by dip switches.
`-rgb-card-foreground <color>`
<color> can be 6 (blue), 9 (amber), 12 (green) and white (15)

Video7 SL7 extra modes (from the manual), modes 7 to 11. The others are the usual Apple RGB modes:
![image](https://user-images.githubusercontent.com/17545417/91236581-9576d800-e738-11ea-9c01-55ad92864916.png)

Note that mode 11 is actually incompatible with Apple RGB and other cards, which renders it as a B&W Hires.

In `NTSC` and `RGBMonitor`, some new functions were defined to handle RGB text and duochrome (F/B) 7-pixels cells. When the RGB monitor is selected, the text render does not use the regular NTSC functions anymore to be able to render color text anytime if needed.

Screenshots from the Video7 demo disk:

![image](https://user-images.githubusercontent.com/17545417/91236803-3e253780-e739-11ea-821d-ae39a8d727f9.png)
Amber text (hardware switches)


![image](https://user-images.githubusercontent.com/17545417/91236871-6c0a7c00-e739-11ea-81f2-2fd3386c1f7c.png)
HGR + amber text

![image](https://user-images.githubusercontent.com/17545417/91236907-7af12e80-e739-11ea-89c2-c08a91b24b3e.png)
DGR + amber text

![image](https://user-images.githubusercontent.com/17545417/91237112-0cf93700-e73a-11ea-8f60-a7eb74c3e60e.png)
F/B Text - Colors are defined in the matching AUX pages

![image](https://user-images.githubusercontent.com/17545417/91237166-2c905f80-e73a-11ea-84d0-b36174c3f73e.png)
GR + F/B Text

![image](https://user-images.githubusercontent.com/17545417/91237180-37e38b00-e73a-11ea-8704-f844e8c5b956.png)
F/B Hires - Again, colors are defined in AUX for each 7-pixels cell.
