### PR TITLE
RGB extramodes: SL7 fixes, DHIRES fixes, Feline support

### DIFF
--- a/source/Applewin.cpp
+++ b/source/Applewin.cpp
@@ -1333,6 +1333,7 @@ struct CmdLine
 		newVideoRefreshRate = VR_NONE;
 		clockMultiplier = 0.0;	// 0 => not set from cmd-line
 		model = A2TYPE_MAX;
+		rgb_card = RGB_Videocard_e::Apple;
 
 		for (UINT i = 0; i < NUM_SLOTS; i++)
 		{
@@ -1367,6 +1368,9 @@ struct CmdLine
 	VideoRefreshRate_e newVideoRefreshRate;
 	double clockMultiplier;
 	eApple2Type model;
+	RGB_Videocard_e rgb_card;
+	int rgb_card_foreground_color;
+	int rgb_card_background_color;
 	std::string strCurrentDir;
 };
 
@@ -1798,6 +1802,37 @@ static bool ProcessCmdLine(LPSTR lpCmdLine)
 		{
 			g_cmdLine.newVideoRefreshRate = VR_60HZ;
 		}
+		else if (strcmp(lpCmdLine, "-rgb-card-type") == 0)
+		{
+			// RGB video card valide types are: "apple", "sl7", "eve", "feline"
+			lpCmdLine = GetCurrArg(lpNextArg);
+			lpNextArg = GetNextArg(lpNextArg);
+
+			if (strcmp(lpCmdLine, "apple") == 0)
+				g_cmdLine.rgb_card = RGB_Videocard_e::Apple;
+			else if (strcmp(lpCmdLine, "sl7") == 0)
+				g_cmdLine.rgb_card = RGB_Videocard_e::Video7_SL7;
+			else if (strcmp(lpCmdLine, "eve") == 0)
+				g_cmdLine.rgb_card = RGB_Videocard_e::LeChatMauve_EVE;
+			else if (strcmp(lpCmdLine, "feline") == 0)
+				g_cmdLine.rgb_card = RGB_Videocard_e::LeChatMauve_Feline;
+			else
+				LogFileOutput("-rgb-card-type: unsupported type: %s\n", lpCmdLine);
+		}
+		else if (strcmp(lpCmdLine, "-rgb-card-foreground") == 0)
+		{
+			// Default hardware-defined Text foreground color, for some RGB cards only
+			lpCmdLine = GetCurrArg(lpNextArg);
+			lpNextArg = GetNextArg(lpNextArg);
+			g_cmdLine.rgb_card_foreground_color = atoi(lpCmdLine);
+		}
+		else if (strcmp(lpCmdLine, "-rgb-card-background") == 0)
+		{
+			// Default hardware-defined Text background color, for some RGB cards only
+			lpCmdLine = GetCurrArg(lpNextArg);
+			lpNextArg = GetNextArg(lpNextArg);
+			g_cmdLine.rgb_card_background_color = atoi(lpCmdLine);
+		}
 		else if (strcmp(lpCmdLine, "-power-on") == 0)
 		{
 			g_cmdLine.bBoot = true;
@@ -1943,6 +1978,8 @@ static void RepeatInitialization(void)
 
 		if (g_cmdLine.model != A2TYPE_MAX)
 			SetApple2Type(g_cmdLine.model);
+
+		RGB_SetVideocard(g_cmdLine.rgb_card, g_cmdLine.rgb_card_foreground_color, g_cmdLine.rgb_card_background_color);
 
 		if (g_cmdLine.newVideoType >= 0)
 		{

--- a/source/Applewin.cpp
+++ b/source/Applewin.cpp
@@ -1333,7 +1333,9 @@ struct CmdLine
 		newVideoRefreshRate = VR_NONE;
 		clockMultiplier = 0.0;	// 0 => not set from cmd-line
 		model = A2TYPE_MAX;
-		rgb_card = RGB_Videocard_e::Apple;
+		rgbCard = RGB_Videocard_e::Apple;
+		rgbCardForegroundColor = 15;
+		rgbCardBackgroundColor = 0;
 
 		for (UINT i = 0; i < NUM_SLOTS; i++)
 		{
@@ -1368,9 +1370,9 @@ struct CmdLine
 	VideoRefreshRate_e newVideoRefreshRate;
 	double clockMultiplier;
 	eApple2Type model;
-	RGB_Videocard_e rgb_card;
-	int rgb_card_foreground_color;
-	int rgb_card_background_color;
+	RGB_Videocard_e rgbCard;
+	int rgbCardForegroundColor;
+	int rgbCardBackgroundColor;
 	std::string strCurrentDir;
 };
 
@@ -1809,13 +1811,13 @@ static bool ProcessCmdLine(LPSTR lpCmdLine)
 			lpNextArg = GetNextArg(lpNextArg);
 
 			if (strcmp(lpCmdLine, "apple") == 0)
-				g_cmdLine.rgb_card = RGB_Videocard_e::Apple;
+				g_cmdLine.rgbCard = RGB_Videocard_e::Apple;
 			else if (strcmp(lpCmdLine, "sl7") == 0)
-				g_cmdLine.rgb_card = RGB_Videocard_e::Video7_SL7;
+				g_cmdLine.rgbCard = RGB_Videocard_e::Video7_SL7;
 			else if (strcmp(lpCmdLine, "eve") == 0)
-				g_cmdLine.rgb_card = RGB_Videocard_e::LeChatMauve_EVE;
+				g_cmdLine.rgbCard = RGB_Videocard_e::LeChatMauve_EVE;
 			else if (strcmp(lpCmdLine, "feline") == 0)
-				g_cmdLine.rgb_card = RGB_Videocard_e::LeChatMauve_Feline;
+				g_cmdLine.rgbCard = RGB_Videocard_e::LeChatMauve_Feline;
 			else
 				LogFileOutput("-rgb-card-type: unsupported type: %s\n", lpCmdLine);
 		}
@@ -1824,14 +1826,14 @@ static bool ProcessCmdLine(LPSTR lpCmdLine)
 			// Default hardware-defined Text foreground color, for some RGB cards only
 			lpCmdLine = GetCurrArg(lpNextArg);
 			lpNextArg = GetNextArg(lpNextArg);
-			g_cmdLine.rgb_card_foreground_color = atoi(lpCmdLine);
+			g_cmdLine.rgbCardForegroundColor = atoi(lpCmdLine);
 		}
 		else if (strcmp(lpCmdLine, "-rgb-card-background") == 0)
 		{
 			// Default hardware-defined Text background color, for some RGB cards only
 			lpCmdLine = GetCurrArg(lpNextArg);
 			lpNextArg = GetNextArg(lpNextArg);
-			g_cmdLine.rgb_card_background_color = atoi(lpCmdLine);
+			g_cmdLine.rgbCardBackgroundColor = atoi(lpCmdLine);
 		}
 		else if (strcmp(lpCmdLine, "-power-on") == 0)
 		{
@@ -1979,7 +1981,7 @@ static void RepeatInitialization(void)
 		if (g_cmdLine.model != A2TYPE_MAX)
 			SetApple2Type(g_cmdLine.model);
 
-		RGB_SetVideocard(g_cmdLine.rgb_card, g_cmdLine.rgb_card_foreground_color, g_cmdLine.rgb_card_background_color);
+		RGB_SetVideocard(g_cmdLine.rgbCard, g_cmdLine.rgbCardForegroundColor, g_cmdLine.rgbCardBackgroundColor);
 
 		if (g_cmdLine.newVideoType >= 0)
 		{

--- a/source/NTSC.cpp
+++ b/source/NTSC.cpp
@@ -1670,7 +1670,7 @@ void updateScreenText40RGB(long cycles6502)
 				if (0 == g_nVideoCharSet && 0x40 == (m & 0xC0)) // Flash only if mousetext not active
 					c ^= g_nTextFlashMask;
 
-				UpdateText40ColorCell(g_nVideoClockHorz - VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress, c);
+				UpdateText40ColorCell(g_nVideoClockHorz - VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress, c, m);
 				g_pVideoAddress += 14;
 
 			}
@@ -1754,9 +1754,9 @@ void updateScreenText80RGB(long cycles6502)
 				if ((0 == g_nVideoCharSet) && 0x40 == (a & 0xC0)) // Flash only if mousetext not active
 					aux ^= g_nTextFlashMask;
 
-				UpdateText80ColorCell(g_nVideoClockHorz - VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress, (uint8_t)aux);
+				UpdateText80ColorCell(g_nVideoClockHorz - VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress, (uint8_t)aux, a);
 				g_pVideoAddress += 7;
-				UpdateText80ColorCell(g_nVideoClockHorz - VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress, (uint8_t)main);
+				UpdateText80ColorCell(g_nVideoClockHorz - VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress, (uint8_t)main, m);
 				g_pVideoAddress += 7;
 
 				uint16_t bits = (main << 7) | (aux & 0x7f);

--- a/source/NTSC.cpp
+++ b/source/NTSC.cpp
@@ -1280,27 +1280,6 @@ void updateScreenDoubleHires80Simplified (long cycles6502 ) // wsUpdateVideoDblH
 					UpdateDHiResCell(g_nVideoClockHorz - VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress, RGB_IsMixMode(), RGB_IsMixModeInvertBit7());
 					g_pVideoAddress += 14;
 				}
-				//	
-				//	if (!RGB_IsMixMode() || (RGB_IsMixMode() && (a & m & 0x80)))
-				//{
-				//	UpdateDHiResCell(g_nVideoClockHorz-VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress, true, true);
-				//	g_pVideoAddress += 14;
-				//}
-				//else	// RGB_IsMixMode() && ((a ^ m) & 0x80)
-				//{
-				//	if (a & 0x80)	// RGB color, then monochrome
-				//	{
-				//		UpdateDHiResCell(g_nVideoClockHorz-VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress, true ,false);
-				//		g_pVideoAddress += 7;
-				//		update7MonoPixels(m);
-				//	}
-				//	else			// monochrome, then RGB color
-				//	{
-				//		update7MonoPixels(a);
-				//		UpdateDHiResCell(g_nVideoClockHorz-VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress, false, true);
-				//		g_pVideoAddress += 7;
-				//	}
-				//}
 			}
 		}
 		updateVideoScannerHorzEOLSimple();

--- a/source/NTSC.cpp
+++ b/source/NTSC.cpp
@@ -1270,31 +1270,37 @@ void updateScreenDoubleHires80Simplified (long cycles6502 ) // wsUpdateVideoDblH
 					int width = UpdateDHiRes160Cell(g_nVideoClockHorz-VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress);
 					g_pVideoAddress += width;
 				}
-				else if (RGB_Is560Mode() || (RGB_IsMixMode() && !((a | m) & 0x80)))
+				else if (RGB_Is560Mode())// || (RGB_IsMixMode() && !((a | m) & 0x80)))
 				{
 					update7MonoPixels(a);
 					update7MonoPixels(m);
 				}
-				else if (!RGB_IsMixMode() || (RGB_IsMixMode() && (a & m & 0x80)))
+				else
 				{
-					UpdateDHiResCell(g_nVideoClockHorz-VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress, true, true);
+					UpdateDHiResCell(g_nVideoClockHorz - VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress, RGB_IsMixMode(), RGB_IsMixModeInvertBit7());
 					g_pVideoAddress += 14;
 				}
-				else	// RGB_IsMixMode() && ((a ^ m) & 0x80)
-				{
-					if (a & 0x80)	// RGB color, then monochrome
-					{
-						UpdateDHiResCell(g_nVideoClockHorz-VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress, true ,false);
-						g_pVideoAddress += 7;
-						update7MonoPixels(m);
-					}
-					else			// monochrome, then RGB color
-					{
-						update7MonoPixels(a);
-						UpdateDHiResCell(g_nVideoClockHorz-VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress, false, true);
-						g_pVideoAddress += 7;
-					}
-				}
+				//	
+				//	if (!RGB_IsMixMode() || (RGB_IsMixMode() && (a & m & 0x80)))
+				//{
+				//	UpdateDHiResCell(g_nVideoClockHorz-VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress, true, true);
+				//	g_pVideoAddress += 14;
+				//}
+				//else	// RGB_IsMixMode() && ((a ^ m) & 0x80)
+				//{
+				//	if (a & 0x80)	// RGB color, then monochrome
+				//	{
+				//		UpdateDHiResCell(g_nVideoClockHorz-VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress, true ,false);
+				//		g_pVideoAddress += 7;
+				//		update7MonoPixels(m);
+				//	}
+				//	else			// monochrome, then RGB color
+				//	{
+				//		update7MonoPixels(a);
+				//		UpdateDHiResCell(g_nVideoClockHorz-VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress, false, true);
+				//		g_pVideoAddress += 7;
+				//	}
+				//}
 			}
 		}
 		updateVideoScannerHorzEOLSimple();

--- a/source/NTSC.cpp
+++ b/source/NTSC.cpp
@@ -1666,7 +1666,6 @@ void updateScreenText40RGB(long cycles6502)
 				uint8_t* pMain = MemGetMainPtr(addr);
 				uint8_t  m = pMain[0];
 				uint8_t  c = getCharSetBits(m);
-				//uint16_t bits = g_aPixelDoubleMaskHGR[c & 0x7F]; // Optimization: hgrbits second 128 entries are mirror of first 128
 
 				if (0 == g_nVideoCharSet && 0x40 == (m & 0xC0)) // Flash only if mousetext not active
 					c ^= g_nTextFlashMask;
@@ -1761,10 +1760,7 @@ void updateScreenText80RGB(long cycles6502)
 				g_pVideoAddress += 7;
 
 				uint16_t bits = (main << 7) | (aux & 0x7f);
-				//if (g_eVideoType != VT_COLOR_MONITOR_RGB)			// No extra 14M bit needed for VT_COLOR_MONITOR_RGB
-				//	bits = (bits << 1) | g_nLastColumnPixelNTSC;	// GH#555: Align TEXT80 chars with DHGR
 
-				//updatePixels(bits);
 				g_nLastColumnPixelNTSC = (bits >> 14) & 1;
 			}
 		}

--- a/source/NTSC.cpp
+++ b/source/NTSC.cpp
@@ -1754,9 +1754,9 @@ void updateScreenText80RGB(long cycles6502)
 				if ((0 == g_nVideoCharSet) && 0x40 == (a & 0xC0)) // Flash only if mousetext not active
 					aux ^= g_nTextFlashMask;
 
-				UpdateText80ColorCell(g_nVideoClockHorz - VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress, aux);
+				UpdateText80ColorCell(g_nVideoClockHorz - VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress, (uint8_t)aux);
 				g_pVideoAddress += 7;
-				UpdateText80ColorCell(g_nVideoClockHorz - VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress, main);
+				UpdateText80ColorCell(g_nVideoClockHorz - VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress, (uint8_t)main);
 				g_pVideoAddress += 7;
 
 				uint16_t bits = (main << 7) | (aux & 0x7f);

--- a/source/NTSC.cpp
+++ b/source/NTSC.cpp
@@ -8,7 +8,7 @@ AppleWin is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
-lecha
+
 AppleWin is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/source/NTSC.cpp
+++ b/source/NTSC.cpp
@@ -1925,7 +1925,7 @@ void NTSC_SetVideoMode( uint32_t uVideoModeFlags, bool bDelay/*=false*/ )
 	}
 
 	if (g_eVideoType == VT_COLOR_MONITOR_RGB
-		&& RGB_GetVideocard() == RGB_Video7_SL7
+		&& RGB_GetVideocard() == RGB_Videocard_e::Video7_SL7
 		&& (!(uVideoModeFlags & VF_DHIRES) ^ !(!(uVideoModeFlags & VF_TEXT) && (uVideoModeFlags & VF_DHIRES) && (uVideoModeFlags & VF_80COL))))
 	{
 		RGB_EnableTextFB(); // F/B text only shows in 40col mode anyway

--- a/source/NTSC.cpp
+++ b/source/NTSC.cpp
@@ -1837,7 +1837,7 @@ void NTSC_SetVideoMode( uint32_t uVideoModeFlags, bool bDelay/*=false*/ )
 
 	if (g_eVideoType == VT_COLOR_MONITOR_RGB
 		&& RGB_GetVideocard() == RGB_Video7_SL7
-		&& !((uVideoModeFlags & VF_DHIRES) && (uVideoModeFlags & VF_TEXT) && !(uVideoModeFlags & VF_DHIRES) && !(uVideoModeFlags & VF_80COL)))
+		&& (!(uVideoModeFlags & VF_DHIRES) ^ !(!(uVideoModeFlags & VF_TEXT) && (uVideoModeFlags & VF_DHIRES) && (uVideoModeFlags & VF_80COL))))
 	{
 		// ----- Video-7 SL7 extra modes ----- (from the videocard manual)
 		//  AN3 TEXT HIRES 80COL

--- a/source/NTSC.cpp
+++ b/source/NTSC.cpp
@@ -441,6 +441,8 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 	static void updateScreenSingleLores40( long cycles6502 );
 	static void updateScreenText40       ( long cycles6502 );
 	static void updateScreenText80       ( long cycles6502 );
+	static void updateScreenText40RGB	 ( long cycles6502 );
+	static void updateScreenText80RGB    ( long cycles6502 );
 
 //===========================================================================
 static void set_csbits()
@@ -826,7 +828,8 @@ inline void updateVideoScannerAddress()
 	if (((g_pFuncUpdateGraphicsScreen == updateScreenDoubleHires80) ||
 		(g_pFuncUpdateGraphicsScreen == updateScreenDoubleLores80) ||
 		(g_pFuncUpdateGraphicsScreen == updateScreenText80) ||
-		(g_nVideoMixed && g_nVideoClockVert >= VIDEO_SCANNER_Y_MIXED && g_pFuncUpdateTextScreen == updateScreenText80))
+		(g_pFuncUpdateGraphicsScreen == updateScreenText80RGB) ||
+		(g_nVideoMixed && g_nVideoClockVert >= VIDEO_SCANNER_Y_MIXED && (g_pFuncUpdateTextScreen == updateScreenText80 || g_pFuncUpdateGraphicsScreen == updateScreenText80RGB)))
 		&& (g_eVideoType != VT_COLOR_MONITOR_RGB))	// Fix for "Ansi Story" (Turn the disk over) - Top row of TEXT80 is shifted by 1 pixel
 	{
 		g_pVideoAddress -= 1;
@@ -1899,7 +1902,8 @@ void NTSC_SetVideoMode( uint32_t uVideoModeFlags, bool bDelay/*=false*/ )
 
 			// Switching mid-line from graphics to TEXT
 			if (g_eVideoType == VT_COLOR_MONITOR_NTSC &&
-				g_pFuncUpdateGraphicsScreen != updateScreenText40 && g_pFuncUpdateGraphicsScreen != updateScreenText40RGB && g_pFuncUpdateGraphicsScreen != updateScreenText80)
+				g_pFuncUpdateGraphicsScreen != updateScreenText40 && g_pFuncUpdateGraphicsScreen != updateScreenText40RGB
+				&& g_pFuncUpdateGraphicsScreen != updateScreenText80 && g_pFuncUpdateGraphicsScreen != updateScreenText80RGB)
 			{
 				*(uint32_t*)&g_pVideoAddress[0] = 0;	// blank out any stale pixel data, eg. ANSI STORY (at end credits)
 				*(uint32_t*)&g_pVideoAddress[1] = 0;
@@ -1912,7 +1916,8 @@ void NTSC_SetVideoMode( uint32_t uVideoModeFlags, bool bDelay/*=false*/ )
 
 			// Switching mid-line from TEXT to graphics
 			if (g_eVideoType == VT_COLOR_MONITOR_NTSC &&
-				(g_pFuncUpdateGraphicsScreen == updateScreenText40 || g_pFuncUpdateGraphicsScreen == updateScreenText40RGB || g_pFuncUpdateGraphicsScreen == updateScreenText80))
+				(g_pFuncUpdateGraphicsScreen == updateScreenText40 || g_pFuncUpdateGraphicsScreen == updateScreenText40RGB
+					|| g_pFuncUpdateGraphicsScreen == updateScreenText80 || g_pFuncUpdateGraphicsScreen == updateScreenText80RGB))
 			{
 				g_pVideoAddress -= 2;	// eg. FT's TRIBU demo & ANSI STORY (at "turn the disk over!")
 			}
@@ -1966,7 +1971,12 @@ void NTSC_SetVideoMode( uint32_t uVideoModeFlags, bool bDelay/*=false*/ )
 	else if (uVideoModeFlags & VF_TEXT)
 	{
 		if (uVideoModeFlags & VF_80COL)
-			g_pFuncUpdateGraphicsScreen = updateScreenText80;
+		{
+			if (g_eVideoType == VT_COLOR_MONITOR_RGB)
+				g_pFuncUpdateGraphicsScreen = updateScreenText80RGB;
+			else
+				g_pFuncUpdateGraphicsScreen = updateScreenText80;
+		}
 		else if (g_eVideoType == VT_COLOR_MONITOR_RGB)
 			g_pFuncUpdateGraphicsScreen = updateScreenText40RGB;
 		else

--- a/source/NTSC.cpp
+++ b/source/NTSC.cpp
@@ -1920,9 +1920,16 @@ void NTSC_SetVideoMode( uint32_t uVideoModeFlags, bool bDelay/*=false*/ )
 		}
 	}
 
+	// Video7_SL7 extra RGB modes handling
 	if (g_eVideoType == VT_COLOR_MONITOR_RGB
 		&& RGB_GetVideocard() == RGB_Videocard_e::Video7_SL7
-		&& (!(uVideoModeFlags & VF_DHIRES) ^ !(!(uVideoModeFlags & VF_TEXT) && (uVideoModeFlags & VF_DHIRES) && (uVideoModeFlags & VF_80COL))))
+		// Exclude following modes (fallback through regular NTSC rendering with RGB text)
+		// VF_DHIRES = 1  -> regular Apple IIe modes
+		// VF_DHIRES = 0 and VF_TEXT=0, VF_DHIRES=1, VF_80COL=1  -> DHIRES modes, setup by F1/F2
+		&& !(!(uVideoModeFlags & VF_DHIRES) ||
+			 ((uVideoModeFlags & VF_DHIRES) && !(uVideoModeFlags & VF_TEXT) && (uVideoModeFlags & VF_DHIRES) && (uVideoModeFlags & VF_80COL))
+			)
+		)
 	{
 		RGB_EnableTextFB(); // F/B text only shows in 40col mode anyway
 
@@ -1964,6 +1971,7 @@ void NTSC_SetVideoMode( uint32_t uVideoModeFlags, bool bDelay/*=false*/ )
 			g_pFuncUpdateTextScreen = updateScreenText40RGB;
 		}
 	}
+	// Regular NTSC modes
 	else if (uVideoModeFlags & VF_TEXT)
 	{
 		if (uVideoModeFlags & VF_80COL)

--- a/source/NTSC.h
+++ b/source/NTSC.h
@@ -24,4 +24,3 @@
 	UINT NTSC_GetCyclesPerLine(void);
 	UINT NTSC_GetVideoLines(void);
 	bool NTSC_IsVisible(void);
-

--- a/source/NTSC.h
+++ b/source/NTSC.h
@@ -24,3 +24,4 @@
 	UINT NTSC_GetCyclesPerLine(void);
 	UINT NTSC_GetVideoLines(void);
 	bool NTSC_IsVisible(void);
+

--- a/source/RGBMonitor.cpp
+++ b/source/RGBMonitor.cpp
@@ -11,9 +11,9 @@
 
 // RGB videocards types
 
-static RGB_Videocard_e RGB_Videocard = RGB_Videocard_e::Video7_SL7;
+static RGB_Videocard_e RGB_Videocard = RGB_Videocard_e::Apple;
 static int nTextFBMode = 0; // F/B Text
-static int nRegularTextFG = 9; // Default TEXT color
+static int nRegularTextFG = 15; // Default TEXT color
 static int nRegularTextBG = 0; // Default TEXT background color
 
 const int HIRES_COLUMN_SUBUNIT_SIZE = 16;

--- a/source/RGBMonitor.cpp
+++ b/source/RGBMonitor.cpp
@@ -11,7 +11,7 @@
 
 // RGB videocards types
 
-static RGB_Videocard_e RGB_Videocard = RGB_Video7_SL7;
+static RGB_Videocard_e RGB_Videocard = RGB_Videocard_e::Video7_SL7;
 static int nTextFBMode = 0; // F/B Text
 static int nRegularTextFG = 9; // Default TEXT color
 static int nRegularTextBG = 0; // Default TEXT background color
@@ -955,9 +955,21 @@ RGB_Videocard_e RGB_GetVideocard(void)
 	return RGB_Videocard;
 }
 
-void RGB_SetVideocard(RGB_Videocard_e videocard)
+void RGB_SetVideocard(RGB_Videocard_e videocard, int text_foreground, int text_background)
 {
 	RGB_Videocard = videocard;
+
+	// black & white text
+	RGB_SetRegularTextFG(15);
+	RGB_SetRegularTextBG(0);
+
+	if (videocard == RGB_Videocard_e::Video7_SL7 &&
+		(text_foreground == 6 || text_foreground == 9 || text_foreground == 12 || text_foreground == 15))
+	{
+		// SL7: Only Blue, Amber (Orange), Green, White are supported by hardware switches
+		RGB_SetRegularTextFG(text_foreground);
+		RGB_SetRegularTextBG(0);
+	}
 }
 
 void RGB_SetRegularTextFG(int color)

--- a/source/RGBMonitor.cpp
+++ b/source/RGBMonitor.cpp
@@ -11,10 +11,10 @@
 
 // RGB videocards types
 
-static RGB_Videocard_e RGB_Videocard = RGB_Videocard_e::Apple;
-static int nTextFBMode = 0; // F/B Text
-static int nRegularTextFG = 15; // Default TEXT color
-static int nRegularTextBG = 0; // Default TEXT background color
+static RGB_Videocard_e g_RGBVideocard = RGB_Videocard_e::Apple;
+static int g_nTextFBMode = 0; // F/B Text
+static int g_nRegularTextFG = 15; // Default TEXT color
+static int g_nRegularTextBG = 0; // Default TEXT background color
 
 const int HIRES_COLUMN_SUBUNIT_SIZE = 16;
 const int HIRES_COLUMN_UNIT_SIZE = (HIRES_COLUMN_SUBUNIT_SIZE)*2;
@@ -710,9 +710,9 @@ void UpdateDLoResCell (int x, int y, uint16_t addr, bgra_t *pVideoAddress)
 // Default BG and FG are usually defined by hardware switches, defaults to black/white
 void UpdateText40ColorCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, uint8_t bits)
 {
-	uint8_t foreground = nRegularTextFG;
-	uint8_t background = nRegularTextBG;
-	if (nTextFBMode)
+	uint8_t foreground = g_nRegularTextFG;
+	uint8_t background = g_nRegularTextBG;
+	if (g_nTextFBMode)
 	{
 		const BYTE val = *MemGetAuxPtr(addr);  // RGB cards with F/B text use their own AUX memory!
 		foreground = val >> 4;
@@ -724,7 +724,7 @@ void UpdateText40ColorCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, u
 
 void UpdateText80ColorCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, uint8_t bits)
 {
-	UpdateDuochromeCell(2, 7, pVideoAddress, bits, nRegularTextFG, nRegularTextBG);
+	UpdateDuochromeCell(2, 7, pVideoAddress, bits, g_nRegularTextFG, g_nRegularTextBG);
 }
 
 //===========================================================================
@@ -951,12 +951,12 @@ void RGB_LoadSnapshot(YamlLoadHelper& yamlLoadHelper, UINT cardVersion)
 
 RGB_Videocard_e RGB_GetVideocard(void)
 {
-	return RGB_Videocard;
+	return g_RGBVideocard;
 }
 
 void RGB_SetVideocard(RGB_Videocard_e videocard, int text_foreground, int text_background)
 {
-	RGB_Videocard = videocard;
+	g_RGBVideocard = videocard;
 
 	// black & white text
 	RGB_SetRegularTextFG(15);
@@ -973,25 +973,25 @@ void RGB_SetVideocard(RGB_Videocard_e videocard, int text_foreground, int text_b
 
 void RGB_SetRegularTextFG(int color)
 {
-	 nRegularTextFG = color;
+	g_nRegularTextFG = color;
 }
 
 void RGB_SetRegularTextBG(int color)
 {
-	nRegularTextBG = color;
+	g_nRegularTextBG = color;
 }
 
 void RGB_EnableTextFB()
 {
-	nTextFBMode = 1;
+	g_nTextFBMode = 1;
 }
 
 void RGB_DisableTextFB()
 {
-	nTextFBMode = 0;
+	g_nTextFBMode = 0;
 }
 
 int RGB_IsTextFB()
 {
-	return nTextFBMode;
+	return g_nTextFBMode;
 }

--- a/source/RGBMonitor.cpp
+++ b/source/RGBMonitor.cpp
@@ -128,6 +128,7 @@ static RGBQUAD PalIndex2RGB[] =
 	SETRGBCOLOR(/*HGR_BLACK, */ 0x00,0x00,0x00), // For TV emulation HGR Video Mode
 	SETRGBCOLOR(/*HGR_WHITE, */ 0xFF,0xFF,0xFF),
 #else
+// Note: this is a placeholder. This palette is overwritten by VideoInitializeOriginal()
 	SETRGBCOLOR(/*HGR_BLACK, */ 0x00,0x00,0x00), // For TV emulation HGR Video Mode
 	SETRGBCOLOR(/*HGR_WHITE, */ 0xFF,0xFF,0xFF),
 	SETRGBCOLOR(/*BLUE,      */ 0x0D,0xA1,0xFF), // FC Linards Tweaked 0x00,0x00,0xFF -> 0x0D,0xA1,0xFF
@@ -145,6 +146,7 @@ static RGBQUAD PalIndex2RGB[] =
 	SETRGBCOLOR(/*HGR_PINK,  */ 0xFF,0x32,0xB5), // 0xD0,0x40,0xA0 -> 0xFF,0x32,0xB5
 
 // lores & dhires
+// Note: this is a placeholder. This palette is overwritten by VideoInitializeOriginal()
 	SETRGBCOLOR(/*BLACK,*/      0x00,0x00,0x00), // 0
 	SETRGBCOLOR(/*DEEP_RED,*/   0x9D,0x09,0x66), // 0xD0,0x00,0x30 -> Linards Tweaked 0x9D,0x09,0x66
 	SETRGBCOLOR(/*DARK_BLUE,*/  0x2A,0x2A,0xE5), // 4 // Linards Tweaked 0x00,0x00,0x80 -> 0x2A,0x2A,0xE5
@@ -160,6 +162,29 @@ static RGBQUAD PalIndex2RGB[] =
 	SETRGBCOLOR(/*GREEN,*/      0x38,0xCB,0x00), // FA Linards Tweaked 0x00,0xFF,0x00 -> 0x38,0xCB,0x00
 	SETRGBCOLOR(/*YELLOW,*/     0xD5,0xD5,0x1A), // FB Linards Tweaked 0xFF,0xFF,0x00 -> 0xD5,0xD5,0x1A
 	SETRGBCOLOR(/*AQUA,*/       0x62,0xF6,0x99), // 0x40,0xFF,0x90 -> Linards Tweaked 0x62,0xF6,0x99
+	SETRGBCOLOR(/*WHITE,*/      0xFF,0xFF,0xFF),
+};
+
+// Le Chat Mauve Feline's palette
+// extracted from a white-balanced RGB video capture
+static RGBQUAD PalIndex2RGB_Feline[] =
+{
+	// Feline test
+	SETRGBCOLOR(/*BLACK,*/      0x00,0x00,0x00),
+	SETRGBCOLOR(/*DEEP_RED,*/   0xAC,0x12,0x4C),
+	SETRGBCOLOR(/*DARK_BLUE,*/  0x00,0x07,0x83),
+	SETRGBCOLOR(/*MAGENTA,*/    0xAA,0x1A,0xD1),
+	SETRGBCOLOR(/*DARK_GREEN,*/ 0x00,0x83,0x2F),
+	SETRGBCOLOR(/*DARK_GRAY,*/  0x9F,0x97,0x7E),
+	SETRGBCOLOR(/*BLUE,*/       0x00,0x8A,0xB5),
+	SETRGBCOLOR(/*LIGHT_BLUE,*/ 0x9F,0x9E,0xFF),
+	SETRGBCOLOR(/*BROWN,*/      0x7A,0x5F,0x00),
+	SETRGBCOLOR(/*ORANGE,*/     0xFF,0x72,0x47),
+	SETRGBCOLOR(/*LIGHT_GRAY,*/ 0x78,0x68,0x7F),
+	SETRGBCOLOR(/*PINK,*/       0xFF,0x7A,0xCF),
+	SETRGBCOLOR(/*GREEN,*/      0x6F,0xE6,0x2C),
+	SETRGBCOLOR(/*YELLOW,*/     0xFF,0xF6,0x7B),
+	SETRGBCOLOR(/*AQUA,*/       0x6C,0xEE,0xB2),
 	SETRGBCOLOR(/*WHITE,*/      0xFF,0xFF,0xFF),
 };
 
@@ -815,7 +840,14 @@ void VideoInitializeOriginal(baseColors_t pBaseNtscColors)
 	// CREATE THE SOURCE IMAGE AND DRAW INTO THE SOURCE BIT BUFFER
 	V_CreateDIBSections();
 
-	memcpy(&PalIndex2RGB[BLACK], *pBaseNtscColors, sizeof(RGBQUAD)*kNumBaseColors);
+	if (g_RGBVideocard == RGB_Videocard_e::LeChatMauve_Feline)
+	{
+		memcpy(&PalIndex2RGB[BLACK], &PalIndex2RGB_Feline[0], sizeof(RGBQUAD) * kNumBaseColors);
+	}
+	else
+	{
+		memcpy(&PalIndex2RGB[BLACK], *pBaseNtscColors, sizeof(RGBQUAD) * kNumBaseColors);
+	}
 	PalIndex2RGB[HGR_BLUE]   = PalIndex2RGB[BLUE];
 	PalIndex2RGB[HGR_ORANGE] = PalIndex2RGB[ORANGE];
 	PalIndex2RGB[HGR_GREEN]  = PalIndex2RGB[GREEN];
@@ -874,12 +906,14 @@ void RGB_SetVideoMode(WORD address)
 
 bool RGB_Is140Mode(void)	// Extended 80-Column Text/AppleColor Card's Mode 2
 {
-	return g_rgbMode == 0;
+	// Feline falls back to this mode instead of 160
+	return g_rgbMode == 0 || (g_RGBVideocard == RGB_Videocard_e::LeChatMauve_Feline && g_rgbMode == 1);
 }
 
 bool RGB_Is160Mode(void)	// Extended 80-Column Text/AppleColor Card: N/A
 {
-	return g_rgbMode == 1;
+	// Unsupported by Feline
+	return g_rgbMode == 1 && (g_RGBVideocard != RGB_Videocard_e::LeChatMauve_Feline);
 }
 
 bool RGB_IsMixMode(void)	// Extended 80-Column Text/AppleColor Card's Mode 3

--- a/source/RGBMonitor.cpp
+++ b/source/RGBMonitor.cpp
@@ -637,7 +637,8 @@ void UpdateDHiResCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, bool i
 		byteval4 = ~byteval4;
 	}
 
-	// To be checked on real hardware
+	// In RGB, DHGR mixed mode switch between color and BW only every 4 bits, based on bit 7 of the last read byte
+	// each case is handled below.
 	// Note: Color mode is a real 140x192 RGB mode with no color fringe (ref. patent US4631692, "THE 140x192 VIDEO MODE")
 
 	UINT32* pDst = (UINT32*)pVideoAddress;
@@ -744,20 +745,17 @@ void UpdateDHiResCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, bool i
 
 	// Second line
 	UINT32* pSrc = (UINT32*)pVideoAddress ;
-	pDst = pSrc + GetFrameBufferWidth();
-	for (int i = 0; i < 14; i++)
-		*(pDst+i) = *(pSrc+i);
-
-	// TODO: handle scanlines
-	//if (bIsHalfScanLines && !(h & 1))
-	//{
-	//	// 50% Half Scan Line clears every odd scanline (and SHIFT+PrintScreen saves only the even rows)
-	//	std::fill(pDst, pDst + 14, 0);
-	//	const UINT frameBufferWidth = GetFrameBufferWidth();
-	//}
-	//else
-	//{
-
+	pDst = pSrc - GetFrameBufferWidth();
+	if (bIsHalfScanLines)
+	{
+		// Scanlines
+		std::fill(pDst, pDst + 14, 0);
+	}
+	else
+	{
+		for (int i = 0; i < 14; i++)
+			*(pDst + i) = *(pSrc + i);
+	}
 }
 
 #if 1

--- a/source/RGBMonitor.cpp
+++ b/source/RGBMonitor.cpp
@@ -733,7 +733,7 @@ void UpdateDLoResCell (int x, int y, uint16_t addr, bgra_t *pVideoAddress)
 //===========================================================================
 // Color TEXT (some RGB cards only)
 // Default BG and FG are usually defined by hardware switches, defaults to black/white
-void UpdateText40ColorCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, uint8_t bits)
+void UpdateText40ColorCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, uint8_t bits, uint8_t character)
 {
 	uint8_t foreground = g_nRegularTextFG;
 	uint8_t background = g_nRegularTextBG;
@@ -743,13 +743,25 @@ void UpdateText40ColorCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, u
 		foreground = val >> 4;
 		background = val & 0x0F;
 	}
+	else if (g_RGBVideocard == RGB_Videocard_e::Video7_SL7 && character < 0x80)
+	{
+		// in regular 40COL mode, the SL7 videocard renders inverse characters as B&W
+		foreground = 15;
+		background = 0;
+	}
 
 	UpdateDuochromeCell(2, 14, pVideoAddress, bits, foreground, background);
 }
 
-void UpdateText80ColorCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, uint8_t bits)
+void UpdateText80ColorCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, uint8_t bits, uint8_t character)
 {
-	UpdateDuochromeCell(2, 7, pVideoAddress, bits, g_nRegularTextFG, g_nRegularTextBG);
+	if (g_RGBVideocard == RGB_Videocard_e::Video7_SL7 && character < 0x80)
+	{
+		// in all 80COL modes, the SL7 videocard renders inverse characters as B&W
+		UpdateDuochromeCell(2, 7, pVideoAddress, bits, 15, 0);
+	}
+	else
+		UpdateDuochromeCell(2, 7, pVideoAddress, bits, g_nRegularTextFG, g_nRegularTextBG);
 }
 
 //===========================================================================

--- a/source/RGBMonitor.cpp
+++ b/source/RGBMonitor.cpp
@@ -716,7 +716,6 @@ void UpdateText40ColorCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, u
 	{
 		const BYTE val = *MemGetAuxPtr(addr);  // RGB cards with F/B text use their own AUX memory!
 		foreground = val >> 4;
-		//foreground = (val >> 6) | ((val & 0x30) >> 2);
 		background = val & 0x0F;
 	}
 

--- a/source/RGBMonitor.cpp
+++ b/source/RGBMonitor.cpp
@@ -1066,11 +1066,11 @@ static bool g_rgbInvertBit7 = false;
 void RGB_SetVideoMode(WORD address)
 {
 
-	//if ((address & ~1) == 0x0C)			// 0x0C or 0x0D? (80COL)
-	//{
-	//	g_rgbSet80COL = true;
-	//	return;
-	//}
+	if ((address & ~1) == 0x0C)			// 0x0C or 0x0D? (80COL)
+	{
+		g_rgbSet80COL = true;
+		return;
+	}
 
 	if ((address & ~1) != 0x5E)			// 0x5E or 0x5F? (DHIRES)
 		return;
@@ -1085,38 +1085,22 @@ void RGB_SetVideoMode(WORD address)
 
 	// From Video7 patent and Le Chat Mauve manuals (under patent of Video7), no precondition is needed.
 
+	// In Prince of Persia, in the game demo, the RGB card switches to BW DHIRES after the HGR animation with Jaffar.
+	// It's actually the same on real hardware (tested on IIc RGB adapter).
+
 	if (address == 0x5F)
 	{
-		if (g_rgbPrevAN3Addr == 0x5E)// && g_rgbSet80COL)
+		if ((g_rgbPrevAN3Addr == 0x5E) && g_rgbSet80COL)
 		{
 			g_rgbFlags = (g_rgbFlags << 1) & 3;
 			g_rgbFlags |= ((g_uVideoMode & VF_80COL) ? 0 : 1);	// clock in !80COL
 			g_rgbMode = g_rgbFlags;								// latch F2,F1
 		}
 
-		//To test with Prince of Persia:
-		//g_rgbSet80COL = false;
+		g_rgbSet80COL = false;
 	}
 
 	g_rgbPrevAN3Addr = address;
-
-	//if ((g_uVideoMode & VF_MIXED) || (g_rgbSet80COL && address == 0x5F))
-	//{
-	//	g_rgbMode = 0;
-	//	g_rgbPrevAN3Addr = 0;
-	//	g_rgbSet80COL = false;
-	//	return;
-	//}
-
-	//if (address == 0x5F && g_rgbPrevAN3Addr == 0x5E)	// Check for AN3 clock transition
-	//{
-	//	g_rgbFlags = (g_rgbFlags<<1) & 3;
-	//	g_rgbFlags |= ((g_uVideoMode & VF_80COL) ? 0 : 1);	// clock in !80COL
-	//	g_rgbMode = g_rgbFlags;								// latch F2,F1
-	//}
-
-	//g_rgbPrevAN3Addr = address;
-	//g_rgbSet80COL = false;
 }
 
 bool RGB_Is140Mode(void)	// Extended 80-Column Text/AppleColor Card's Mode 2

--- a/source/RGBMonitor.cpp
+++ b/source/RGBMonitor.cpp
@@ -13,7 +13,7 @@
 
 static RGB_Videocard_e RGB_Videocard = RGB_Video7_SL7;
 static int nTextFBMode = 0; // F/B Text
-static int nRegularTextFG = 1; // Default TEXT color
+static int nRegularTextFG = 3; // Default TEXT color
 static int nRegularTextBG = 0; // Default TEXT background color
 
 const int HIRES_COLUMN_SUBUNIT_SIZE = 16;
@@ -707,11 +707,17 @@ void UpdateDLoResCell (int x, int y, uint16_t addr, bgra_t *pVideoAddress)
 
 //===========================================================================
 // Color TEXT (some RGB cards only)
-void UpdateText40DuochromeCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, uint8_t bits)
+// Default BG and FG are usually defined by hardware switches, defaults to black/white
+void UpdateText40ColorCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, uint8_t bits)
 {
-	const BYTE val = *MemGetAuxPtr(addr);
-	const uint8_t foreground = val >> 4;
-	const uint8_t background = val & 0x0F;
+	uint8_t foreground = nRegularTextFG;
+	uint8_t background = nRegularTextBG;
+	if (nTextFBMode)
+	{
+		const BYTE val = *MemGetAuxPtr(addr);  // RGB cards with F/B text use their own AUX memory!
+		foreground = val >> 4;
+		background = val & 0x0F;
+	}
 
 	UpdateDuochromeCell(2, pVideoAddress, bits, foreground, background);
 }

--- a/source/RGBMonitor.cpp
+++ b/source/RGBMonitor.cpp
@@ -13,7 +13,7 @@
 
 static RGB_Videocard_e RGB_Videocard = RGB_Video7_SL7;
 static int nTextFBMode = 0; // F/B Text
-static int nRegularTextFG = 3; // Default TEXT color
+static int nRegularTextFG = 9; // Default TEXT color
 static int nRegularTextBG = 0; // Default TEXT background color
 
 const int HIRES_COLUMN_SUBUNIT_SIZE = 16;

--- a/source/RGBMonitor.h
+++ b/source/RGBMonitor.h
@@ -1,8 +1,22 @@
+// Handling of RGB videocards
+
+typedef enum
+{
+	RGB_Apple,
+	RGB_Video7_SL7,
+	RGB_LeChatMauve_EVE,
+	RGB_LeChatMauve_Feline
+} RGB_Videocard_e;
+
+
 void UpdateHiResCell(int x, int y, uint16_t addr, bgra_t *pVideoAddress);
 void UpdateDHiResCell (int x, int y, uint16_t addr, bgra_t *pVideoAddress, bool updateAux, bool updateMain);
 int UpdateDHiRes160Cell (int x, int y, uint16_t addr, bgra_t *pVideoAddress);
 void UpdateLoResCell(int x, int y, uint16_t addr, bgra_t *pVideoAddress);
 void UpdateDLoResCell(int x, int y, uint16_t addr, bgra_t *pVideoAddress);
+void UpdateText40DuochromeCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, uint8_t bits);
+void UpdateHiResDuochromeCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress);
+void UpdateDuochromeCell(int h, bgra_t* pVideoAddress, uint8_t bits, uint8_t foreground, uint8_t background);
 
 const UINT kNumBaseColors = 16;
 typedef bgra_t (*baseColors_t)[kNumBaseColors];
@@ -19,3 +33,11 @@ void RGB_SetInvertBit7(bool state);
 
 void RGB_SaveSnapshot(class YamlSaveHelper& yamlSaveHelper);
 void RGB_LoadSnapshot(class YamlLoadHelper& yamlLoadHelper, UINT cardVersion);
+
+RGB_Videocard_e RGB_GetVideocard(void);
+void RGB_SetVideocard(RGB_Videocard_e videocard);
+void RGB_SetRegularTextFG(int color);
+void RGB_SetRegularTextBG(int color);
+void RGB_EnableTextFB();
+void RGB_DisableTextFB();
+int RGB_IsTextFB();

--- a/source/RGBMonitor.h
+++ b/source/RGBMonitor.h
@@ -15,8 +15,9 @@ int UpdateDHiRes160Cell (int x, int y, uint16_t addr, bgra_t *pVideoAddress);
 void UpdateLoResCell(int x, int y, uint16_t addr, bgra_t *pVideoAddress);
 void UpdateDLoResCell(int x, int y, uint16_t addr, bgra_t *pVideoAddress);
 void UpdateText40ColorCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, uint8_t bits);
+void UpdateText80ColorCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, uint8_t bits);
 void UpdateHiResDuochromeCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress);
-void UpdateDuochromeCell(int h, bgra_t* pVideoAddress, uint8_t bits, uint8_t foreground, uint8_t background);
+void UpdateDuochromeCell(int h, int w, bgra_t* pVideoAddress, uint8_t bits, uint8_t foreground, uint8_t background);
 
 const UINT kNumBaseColors = 16;
 typedef bgra_t (*baseColors_t)[kNumBaseColors];

--- a/source/RGBMonitor.h
+++ b/source/RGBMonitor.h
@@ -1,6 +1,6 @@
 // Handling of RGB videocards
 
-enum class RGB_Videocard_e
+enum RGB_Videocard_e
 {
 	Apple,
 	Video7_SL7,

--- a/source/RGBMonitor.h
+++ b/source/RGBMonitor.h
@@ -14,8 +14,8 @@ void UpdateDHiResCell (int x, int y, uint16_t addr, bgra_t *pVideoAddress, bool 
 int UpdateDHiRes160Cell (int x, int y, uint16_t addr, bgra_t *pVideoAddress);
 void UpdateLoResCell(int x, int y, uint16_t addr, bgra_t *pVideoAddress);
 void UpdateDLoResCell(int x, int y, uint16_t addr, bgra_t *pVideoAddress);
-void UpdateText40ColorCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, uint8_t bits);
-void UpdateText80ColorCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, uint8_t bits);
+void UpdateText40ColorCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, uint8_t bits, uint8_t character);
+void UpdateText80ColorCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, uint8_t bits, uint8_t character);
 void UpdateHiResDuochromeCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress);
 void UpdateDuochromeCell(int h, int w, bgra_t* pVideoAddress, uint8_t bits, uint8_t foreground, uint8_t background);
 

--- a/source/RGBMonitor.h
+++ b/source/RGBMonitor.h
@@ -1,12 +1,12 @@
 // Handling of RGB videocards
 
-typedef enum
+enum class RGB_Videocard_e
 {
-	RGB_Apple,
-	RGB_Video7_SL7,
-	RGB_LeChatMauve_EVE,
-	RGB_LeChatMauve_Feline
-} RGB_Videocard_e;
+	Apple,
+	Video7_SL7,
+	LeChatMauve_EVE,
+	LeChatMauve_Feline
+};
 
 
 void UpdateHiResCell(int x, int y, uint16_t addr, bgra_t *pVideoAddress);
@@ -36,7 +36,7 @@ void RGB_SaveSnapshot(class YamlSaveHelper& yamlSaveHelper);
 void RGB_LoadSnapshot(class YamlLoadHelper& yamlLoadHelper, UINT cardVersion);
 
 RGB_Videocard_e RGB_GetVideocard(void);
-void RGB_SetVideocard(RGB_Videocard_e videocard);
+void RGB_SetVideocard(RGB_Videocard_e videocard, int text_foreground = -1, int text_background = -1);
 void RGB_SetRegularTextFG(int color);
 void RGB_SetRegularTextBG(int color);
 void RGB_EnableTextFB();

--- a/source/RGBMonitor.h
+++ b/source/RGBMonitor.h
@@ -14,7 +14,7 @@ void UpdateDHiResCell (int x, int y, uint16_t addr, bgra_t *pVideoAddress, bool 
 int UpdateDHiRes160Cell (int x, int y, uint16_t addr, bgra_t *pVideoAddress);
 void UpdateLoResCell(int x, int y, uint16_t addr, bgra_t *pVideoAddress);
 void UpdateDLoResCell(int x, int y, uint16_t addr, bgra_t *pVideoAddress);
-void UpdateText40DuochromeCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, uint8_t bits);
+void UpdateText40ColorCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, uint8_t bits);
 void UpdateHiResDuochromeCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress);
 void UpdateDuochromeCell(int h, bgra_t* pVideoAddress, uint8_t bits, uint8_t foreground, uint8_t background);
 


### PR DESCRIPTION
I used the same branch to continue my work on RGB extramodes, I hope this doesn't make the PR invalid?

Anyway, here's the new features/fixes:

- Fixed the SL7 color text features

In all regular text modes, when a default color is selected, all characters that are <0x80 shows in black and white. This was specified in the manual as "Inverse text always show in black and white"

The matching `UpdateText` functions now take the character value to handle this.

![image](https://user-images.githubusercontent.com/17545417/92338793-ebda0400-f0b2-11ea-9dd1-78e42977202e.png)

- Support for Le Chat Mauve Féline/IIc adapter (under Video7 patent)

Enabled with `-rgb-card-type feline`

It has the same features of the Apple RGB card except that the 160 DHIRES mode is not implemented.

The palette is different from the regular AW palette, so I added it directly into the code and it replaces the code-generated palette in that exact case. One of the main differences is that DARK_GREY and LIGHT_GREY are different colors. The colors were sampled from a white-balanced video capture done with my OSSC.

However, I will try to make more captures of other Féline and IIc adapters to further validate it.

Regular:
![image](https://user-images.githubusercontent.com/17545417/92339016-40ca4a00-f0b4-11ea-9375-41c22c67a39c.png)

Féline:
![image](https://user-images.githubusercontent.com/17545417/92338813-11ffa400-f0b3-11ea-9467-0eeeaa33ef90.png)


- DHIRES color & mixed mode rewrite

The current AW implementation of DHIRES in RGB seemed dubious to me, so I analyzed the Video7 patent and the output of my IIc in RGB.
I rewrote it, but it was not as straightforward that I first thought.

1. Color mode is a real 140x192 mode with no color fringe (Video7 patent, shows that way on real hardware)

![image](https://user-images.githubusercontent.com/17545417/92338878-63a82e80-f0b3-11ea-939a-44aeca954f94.png)

2. Mixed mode works with 4-bits cells that are organized in packs of 7 cells over 4 bytes:
Bit 7 defines if the 7 bits of that byte are color of B&W;
BW pixels are 1 bit wide, color pixels are usually 4 bits wide;
If a 4-bits color cell falls into a BW byte, then it immediatly reverts to the BW mode and the color pixel is less than 4 bits wide;
If a 4-bits BW cell falls into a Color byte, then the last BW pixel is repeated until the next color cell starts.

This was once again validated on my IIc adapter. The last one was tricky to understand. Some mixed DHGR pictures bundled with the drawing software "Extasie" didn't initially show correctly because of this. For instance on the "Elephant" picture, the left side of the Elephant shows 1-bit wide color pixels while the right side shows a column of repeated 1-bit BW pixels.

IIc:
![image](https://user-images.githubusercontent.com/17545417/92338966-f9dc5480-f0b3-11ea-99a7-9b0bf8917d43.png)
AppleWin (feline card):
![image](https://user-images.githubusercontent.com/17545417/92338998-2001f480-f0b4-11ea-937a-d7940181f226.png)

- DHIRES modes setup cleanup

The precondition tests that were present prevented Extasie to enter the mixed DHGR mode.

The Video7 patent doesn't state any precondition to enable the various DHGR modes through the hidden F1/F2 registers. However 80COL needs to be written to be detected, and its detection is reset when the card detects a C05E->C05F toggle (as previously implemented in AW).

This behavior triggers a bug in the game introduction of Prince of Persia: once it reverts to DHGR after the HGR animation with Jaffar, every following DHGR screen will show in BW (560) mode only. It's the same on real hardware.

IIc:
![image](https://user-images.githubusercontent.com/17545417/92339109-b7674780-f0b4-11ea-83cf-0037b03a0e1c.png)


