### PR TITLE
RGB Videocards

### DIFF
--- a/source/Applewin.cpp
+++ b/source/Applewin.cpp
@@ -1751,6 +1751,10 @@ static bool ProcessCmdLine(LPSTR lpCmdLine)
 		{
 			g_cmdLine.newVideoType = VT_COLOR_MONITOR_RGB;
 		}
+		else if (strcmp(lpCmdLine, "-video-mode=rgb-videocard") == 0)
+		{
+			g_cmdLine.newVideoType = VT_COLOR_VIDEOCARD_RGB;
+		}
 		else if (strcmp(lpCmdLine, "-video-mode=composite-monitor") == 0)	// GH#763
 		{
 			g_cmdLine.newVideoType = VT_COLOR_MONITOR_NTSC;

--- a/source/Applewin.cpp
+++ b/source/Applewin.cpp
@@ -2045,6 +2045,9 @@ static void RepeatInitialization(void)
 		FrameCreateWindow();	// g_hFrameWindow is now valid
 		LogFileOutput("Main: FrameCreateWindow() - post\n");
 
+		// Init palette color
+		VideoSwitchVideocardPalette(RGB_GetVideocard(), GetVideoType());
+
 		// Allow the 4 hardcoded slots to be configurated as empty
 		// NB. this state is not persisted to the Registry/conf.ini (just as '-s7 empty' isn't)
 		// TODO: support bSlotEmpty[] for slots: 0,4,5

--- a/source/Configuration/PageConfig.cpp
+++ b/source/Configuration/PageConfig.cpp
@@ -149,7 +149,7 @@ BOOL CPageConfig::DlgProcInternal(HWND hWnd, UINT message, WPARAM wparam, LPARAM
 			if(HIWORD(wparam) == CBN_SELCHANGE)
 			{
 				const VideoType_e newVideoType = (VideoType_e) SendDlgItemMessage(hWnd, IDC_VIDEOTYPE, CB_GETCURSEL, 0, 0);
-				EnableWindow(GetDlgItem(hWnd, IDC_CHECK_VERTICAL_BLEND), (newVideoType == VT_COLOR_MONITOR_RGB || newVideoType == VT_COLOR_VIDEOCARD_RGB) ? TRUE : FALSE);
+				EnableWindow(GetDlgItem(hWnd, IDC_CHECK_VERTICAL_BLEND), (newVideoType == VT_COLOR_MONITOR_RGB) ? TRUE : FALSE);
 			}
 			break;
 
@@ -204,7 +204,7 @@ BOOL CPageConfig::DlgProcInternal(HWND hWnd, UINT message, WPARAM wparam, LPARAM
 			CheckDlgButton(hWnd, IDC_CHECK_FS_SHOW_SUBUNIT_STATUS, GetFullScreenShowSubunitStatus() ? BST_CHECKED : BST_UNCHECKED);
 
 			CheckDlgButton(hWnd, IDC_CHECK_VERTICAL_BLEND, IsVideoStyle(VS_COLOR_VERTICAL_BLEND) ? BST_CHECKED : BST_UNCHECKED);
-			EnableWindow(GetDlgItem(hWnd, IDC_CHECK_VERTICAL_BLEND), (GetVideoType() == VT_COLOR_MONITOR_RGB || GetVideoType() == VT_COLOR_VIDEOCARD_RGB) ? TRUE : FALSE);
+			EnableWindow(GetDlgItem(hWnd, IDC_CHECK_VERTICAL_BLEND), (GetVideoType() == VT_COLOR_MONITOR_RGB) ? TRUE : FALSE);
 
 			if (g_CardMgr.IsSSCInstalled())
 			{

--- a/source/Configuration/PageConfig.cpp
+++ b/source/Configuration/PageConfig.cpp
@@ -149,7 +149,7 @@ BOOL CPageConfig::DlgProcInternal(HWND hWnd, UINT message, WPARAM wparam, LPARAM
 			if(HIWORD(wparam) == CBN_SELCHANGE)
 			{
 				const VideoType_e newVideoType = (VideoType_e) SendDlgItemMessage(hWnd, IDC_VIDEOTYPE, CB_GETCURSEL, 0, 0);
-				EnableWindow(GetDlgItem(hWnd, IDC_CHECK_VERTICAL_BLEND), (newVideoType == VT_COLOR_MONITOR_RGB) ? TRUE : FALSE);
+				EnableWindow(GetDlgItem(hWnd, IDC_CHECK_VERTICAL_BLEND), (newVideoType == VT_COLOR_MONITOR_RGB || newVideoType == VT_COLOR_VIDEOCARD_RGB) ? TRUE : FALSE);
 			}
 			break;
 
@@ -204,7 +204,7 @@ BOOL CPageConfig::DlgProcInternal(HWND hWnd, UINT message, WPARAM wparam, LPARAM
 			CheckDlgButton(hWnd, IDC_CHECK_FS_SHOW_SUBUNIT_STATUS, GetFullScreenShowSubunitStatus() ? BST_CHECKED : BST_UNCHECKED);
 
 			CheckDlgButton(hWnd, IDC_CHECK_VERTICAL_BLEND, IsVideoStyle(VS_COLOR_VERTICAL_BLEND) ? BST_CHECKED : BST_UNCHECKED);
-			EnableWindow(GetDlgItem(hWnd, IDC_CHECK_VERTICAL_BLEND), (GetVideoType() == VT_COLOR_MONITOR_RGB) ? TRUE : FALSE);
+			EnableWindow(GetDlgItem(hWnd, IDC_CHECK_VERTICAL_BLEND), (GetVideoType() == VT_COLOR_MONITOR_RGB || GetVideoType() == VT_COLOR_VIDEOCARD_RGB) ? TRUE : FALSE);
 
 			if (g_CardMgr.IsSSCInstalled())
 			{

--- a/source/NTSC.cpp
+++ b/source/NTSC.cpp
@@ -1569,6 +1569,36 @@ static void updateScreenSingleHires40Duochrome(long cycles6502)
 	}
 }
 
+//===========================================================================
+static void updateScreenSingleHires40RGB(long cycles6502)
+{
+	if (g_nVideoMixed && g_nVideoClockVert >= VIDEO_SCANNER_Y_MIXED)
+	{
+		g_pFuncUpdateTextScreen(cycles6502);
+		return;
+	}
+
+	for (; cycles6502 > 0; --cycles6502)
+	{
+		if (g_nVideoClockVert < VIDEO_SCANNER_Y_DISPLAY)
+		{
+			if ((g_nVideoClockHorz < VIDEO_SCANNER_HORZ_COLORBURST_END) && (g_nVideoClockHorz >= VIDEO_SCANNER_HORZ_COLORBURST_BEG))
+			{
+				g_nColorBurstPixels = 1024;
+			}
+			else if (g_nVideoClockHorz >= VIDEO_SCANNER_HORZ_START)
+			{
+				uint16_t addr = getVideoScannerAddressHGR();
+
+				UpdateHiResRGBCell(g_nVideoClockHorz - VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress);
+				g_pVideoAddress += 14;
+			}
+		}
+		updateVideoScannerHorzEOLSimple();
+	}
+}
+
+//===========================================================================
 void updateScreenSingleHires40 (long cycles6502)
 {
 	if (g_nVideoMixed && g_nVideoClockVert >= VIDEO_SCANNER_Y_MIXED)
@@ -2062,8 +2092,10 @@ void NTSC_SetVideoMode( uint32_t uVideoModeFlags, bool bDelay/*=false*/ )
 		}
 		else
 		{
-			if ((g_eVideoType == VT_COLOR_MONITOR_RGB) || (g_eVideoType == VT_COLOR_VIDEOCARD_RGB))
+			if (g_eVideoType == VT_COLOR_MONITOR_RGB)
 				g_pFuncUpdateGraphicsScreen = updateScreenSingleHires40Simplified;
+			if (g_eVideoType == VT_COLOR_VIDEOCARD_RGB)
+				g_pFuncUpdateGraphicsScreen = updateScreenSingleHires40RGB;
 			else
 				g_pFuncUpdateGraphicsScreen = updateScreenSingleHires40;
 		}

--- a/source/NTSC.cpp
+++ b/source/NTSC.cpp
@@ -1670,7 +1670,7 @@ void updateScreenText40RGB(long cycles6502)
 				if (0 == g_nVideoCharSet && 0x40 == (m & 0xC0)) // Flash only if mousetext not active
 					c ^= g_nTextFlashMask;
 
-				UpdateText40ColorCell(g_nVideoClockHorz - VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress, c);
+				UpdateText40ColorCell(g_nVideoClockHorz - VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress, c, m);
 				g_pVideoAddress += 14;
 
 			}
@@ -1754,9 +1754,9 @@ void updateScreenText80RGB(long cycles6502)
 				if ((0 == g_nVideoCharSet) && 0x40 == (a & 0xC0)) // Flash only if mousetext not active
 					aux ^= g_nTextFlashMask;
 
-				UpdateText80ColorCell(g_nVideoClockHorz - VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress, (uint8_t)aux);
+				UpdateText80ColorCell(g_nVideoClockHorz - VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress, (uint8_t)aux, a);
 				g_pVideoAddress += 7;
-				UpdateText80ColorCell(g_nVideoClockHorz - VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress, (uint8_t)main);
+				UpdateText80ColorCell(g_nVideoClockHorz - VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress, (uint8_t)main, m);
 				g_pVideoAddress += 7;
 
 				uint16_t bits = (main << 7) | (aux & 0x7f);

--- a/source/NTSC.cpp
+++ b/source/NTSC.cpp
@@ -1261,42 +1261,8 @@ void updateScreenDoubleHires80Simplified(long cycles6502) // wsUpdateVideoDblHir
 				uint8_t a = *MemGetAuxPtr(addr);
 				uint8_t m = *MemGetMainPtr(addr);
 
-				if (RGB_IsMixModeInvertBit7())	// Invert high bit? (GH#633)
-				{
-					a ^= 0x80;
-					m ^= 0x80;
-				}
-
-				if (RGB_Is160Mode())
-				{
-					int width = UpdateDHiRes160Cell(g_nVideoClockHorz - VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress);
-					g_pVideoAddress += width;
-				}
-				else if (RGB_Is560Mode() || (RGB_IsMixMode() && !((a | m) & 0x80)))
-				{
-					update7MonoPixels(a);
-					update7MonoPixels(m);
-				}
-				else if (!RGB_IsMixMode() || (RGB_IsMixMode() && (a & m & 0x80)))
-				{
-					UpdateDHiResCell(g_nVideoClockHorz - VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress, true, true);
-					g_pVideoAddress += 14;
-				}
-				else	// RGB_IsMixMode() && ((a ^ m) & 0x80)
-				{
-					if (a & 0x80)	// RGB color, then monochrome
-					{
-						UpdateDHiResCell(g_nVideoClockHorz - VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress, true, false);
-						g_pVideoAddress += 7;
-						update7MonoPixels(m);
-					}
-					else			// monochrome, then RGB color
-					{
-						update7MonoPixels(a);
-						UpdateDHiResCell(g_nVideoClockHorz - VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress, false, true);
-						g_pVideoAddress += 7;
-					}
-				}
+				UpdateDHiResCell(g_nVideoClockHorz - VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress, true, true);
+				g_pVideoAddress += 14;
 			}
 		}
 		updateVideoScannerHorzEOLSimple();

--- a/source/NTSC.cpp
+++ b/source/NTSC.cpp
@@ -1280,27 +1280,6 @@ void updateScreenDoubleHires80Simplified (long cycles6502 ) // wsUpdateVideoDblH
 					UpdateDHiResCell(g_nVideoClockHorz - VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress, RGB_IsMixMode(), RGB_IsMixModeInvertBit7());
 					g_pVideoAddress += 14;
 				}
-				//	
-				//	if (!RGB_IsMixMode() || (RGB_IsMixMode() && (a & m & 0x80)))
-				//{
-				//	UpdateDHiResCell(g_nVideoClockHorz-VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress, true, true);
-				//	g_pVideoAddress += 14;
-				//}
-				//else	// RGB_IsMixMode() && ((a ^ m) & 0x80)
-				//{
-				//	if (a & 0x80)	// RGB color, then monochrome
-				//	{
-				//		UpdateDHiResCell(g_nVideoClockHorz-VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress, true ,false);
-				//		g_pVideoAddress += 7;
-				//		update7MonoPixels(m);
-				//	}
-				//	else			// monochrome, then RGB color
-				//	{
-				//		update7MonoPixels(a);
-				//		UpdateDHiResCell(g_nVideoClockHorz-VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress, false, true);
-				//		g_pVideoAddress += 7;
-				//	}
-				//}
 			}
 		}
 		updateVideoScannerHorzEOLSimple();

--- a/source/NTSC.cpp
+++ b/source/NTSC.cpp
@@ -1270,31 +1270,37 @@ void updateScreenDoubleHires80Simplified (long cycles6502 ) // wsUpdateVideoDblH
 					int width = UpdateDHiRes160Cell(g_nVideoClockHorz-VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress);
 					g_pVideoAddress += width;
 				}
-				else if (RGB_Is560Mode() || (RGB_IsMixMode() && !((a | m) & 0x80)))
+				else if (RGB_Is560Mode())// || (RGB_IsMixMode() && !((a | m) & 0x80)))
 				{
 					update7MonoPixels(a);
 					update7MonoPixels(m);
 				}
-				else if (!RGB_IsMixMode() || (RGB_IsMixMode() && (a & m & 0x80)))
+				else
 				{
-					UpdateDHiResCell(g_nVideoClockHorz-VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress, true, true);
+					UpdateDHiResCell(g_nVideoClockHorz - VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress, RGB_IsMixMode(), RGB_IsMixModeInvertBit7());
 					g_pVideoAddress += 14;
 				}
-				else	// RGB_IsMixMode() && ((a ^ m) & 0x80)
-				{
-					if (a & 0x80)	// RGB color, then monochrome
-					{
-						UpdateDHiResCell(g_nVideoClockHorz-VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress, true ,false);
-						g_pVideoAddress += 7;
-						update7MonoPixels(m);
-					}
-					else			// monochrome, then RGB color
-					{
-						update7MonoPixels(a);
-						UpdateDHiResCell(g_nVideoClockHorz-VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress, false, true);
-						g_pVideoAddress += 7;
-					}
-				}
+				//	
+				//	if (!RGB_IsMixMode() || (RGB_IsMixMode() && (a & m & 0x80)))
+				//{
+				//	UpdateDHiResCell(g_nVideoClockHorz-VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress, true, true);
+				//	g_pVideoAddress += 14;
+				//}
+				//else	// RGB_IsMixMode() && ((a ^ m) & 0x80)
+				//{
+				//	if (a & 0x80)	// RGB color, then monochrome
+				//	{
+				//		UpdateDHiResCell(g_nVideoClockHorz-VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress, true ,false);
+				//		g_pVideoAddress += 7;
+				//		update7MonoPixels(m);
+				//	}
+				//	else			// monochrome, then RGB color
+				//	{
+				//		update7MonoPixels(a);
+				//		UpdateDHiResCell(g_nVideoClockHorz-VIDEO_SCANNER_HORZ_START, g_nVideoClockVert, addr, g_pVideoAddress, false, true);
+				//		g_pVideoAddress += 7;
+				//	}
+				//}
 			}
 		}
 		updateVideoScannerHorzEOLSimple();

--- a/source/NTSC.cpp
+++ b/source/NTSC.cpp
@@ -2094,7 +2094,7 @@ void NTSC_SetVideoMode( uint32_t uVideoModeFlags, bool bDelay/*=false*/ )
 		{
 			if (g_eVideoType == VT_COLOR_MONITOR_RGB)
 				g_pFuncUpdateGraphicsScreen = updateScreenSingleHires40Simplified;
-			if (g_eVideoType == VT_COLOR_VIDEOCARD_RGB)
+			else if (g_eVideoType == VT_COLOR_VIDEOCARD_RGB)
 				g_pFuncUpdateGraphicsScreen = updateScreenSingleHires40RGB;
 			else
 				g_pFuncUpdateGraphicsScreen = updateScreenSingleHires40;

--- a/source/NTSC.cpp
+++ b/source/NTSC.cpp
@@ -830,7 +830,7 @@ inline void updateVideoScannerAddress()
 		(g_pFuncUpdateGraphicsScreen == updateScreenText80) ||
 		(g_pFuncUpdateGraphicsScreen == updateScreenText80RGB) ||
 		(g_nVideoMixed && g_nVideoClockVert >= VIDEO_SCANNER_Y_MIXED && (g_pFuncUpdateTextScreen == updateScreenText80 || g_pFuncUpdateGraphicsScreen == updateScreenText80RGB)))
-		&& (g_eVideoType != VT_COLOR_MONITOR_RGB))	// Fix for "Ansi Story" (Turn the disk over) - Top row of TEXT80 is shifted by 1 pixel
+		&& (g_eVideoType != VT_COLOR_MONITOR_RGB) && (g_eVideoType != VT_COLOR_VIDEOCARD_RGB))	// Fix for "Ansi Story" (Turn the disk over) - Top row of TEXT80 is shifted by 1 pixel
 	{
 		g_pVideoAddress -= 1;
 	}
@@ -1697,7 +1697,8 @@ void updateScreenText80 (long cycles6502)
 					aux ^= g_nTextFlashMask;
 
 				uint16_t bits = (main << 7) | (aux & 0x7f);
-				if (g_eVideoType != VT_COLOR_MONITOR_RGB)			// No extra 14M bit needed for VT_COLOR_MONITOR_RGB
+				if ((g_eVideoType != VT_COLOR_MONITOR_RGB)			// No extra 14M bit needed for VT_COLOR_MONITOR_RGB
+					&& (g_eVideoType != VT_COLOR_VIDEOCARD_RGB))
 					bits = (bits << 1) | g_nLastColumnPixelNTSC;	// GH#555: Align TEXT80 chars with DHGR
 
 				updatePixels( bits );
@@ -1831,7 +1832,7 @@ uint16_t NTSC_VideoGetScannerAddressForDebugger(void)
 //===========================================================================
 void NTSC_SetVideoTextMode( int cols )
 {
-	if (g_eVideoType == VT_COLOR_MONITOR_RGB)
+	if (g_eVideoType == VT_COLOR_VIDEOCARD_RGB)
 	{
 		if (cols == 40)
 			g_pFuncUpdateTextScreen = updateScreenText40RGB;
@@ -1906,7 +1907,7 @@ void NTSC_SetVideoMode( uint32_t uVideoModeFlags, bool bDelay/*=false*/ )
 	}
 
 	// Video7_SL7 extra RGB modes handling
-	if (g_eVideoType == VT_COLOR_MONITOR_RGB
+	if (g_eVideoType == VT_COLOR_VIDEOCARD_RGB
 		&& RGB_GetVideocard() == RGB_Videocard_e::Video7_SL7
 		// Exclude following modes (fallback through regular NTSC rendering with RGB text)
 		// VF_DHIRES = 1  -> regular Apple IIe modes
@@ -1961,12 +1962,12 @@ void NTSC_SetVideoMode( uint32_t uVideoModeFlags, bool bDelay/*=false*/ )
 	{
 		if (uVideoModeFlags & VF_80COL)
 		{
-			if (g_eVideoType == VT_COLOR_MONITOR_RGB)
+			if (g_eVideoType == VT_COLOR_VIDEOCARD_RGB)
 				g_pFuncUpdateGraphicsScreen = updateScreenText80RGB;
 			else
 				g_pFuncUpdateGraphicsScreen = updateScreenText80;
 		}
-		else if (g_eVideoType == VT_COLOR_MONITOR_RGB)
+		else if (g_eVideoType == VT_COLOR_VIDEOCARD_RGB)
 			g_pFuncUpdateGraphicsScreen = updateScreenText40RGB;
 		else
 			g_pFuncUpdateGraphicsScreen = updateScreenText40;
@@ -1977,7 +1978,7 @@ void NTSC_SetVideoMode( uint32_t uVideoModeFlags, bool bDelay/*=false*/ )
 		{
 			if (uVideoModeFlags & VF_80COL)
 			{
-				if (g_eVideoType == VT_COLOR_MONITOR_RGB)
+				if ((g_eVideoType == VT_COLOR_MONITOR_RGB) || (g_eVideoType == VT_COLOR_VIDEOCARD_RGB))
 					g_pFuncUpdateGraphicsScreen = updateScreenDoubleHires80Simplified;
 				else
 					g_pFuncUpdateGraphicsScreen = updateScreenDoubleHires80;
@@ -1989,7 +1990,7 @@ void NTSC_SetVideoMode( uint32_t uVideoModeFlags, bool bDelay/*=false*/ )
 		}
 		else
 		{
-			if (g_eVideoType == VT_COLOR_MONITOR_RGB)
+			if ((g_eVideoType == VT_COLOR_MONITOR_RGB) || (g_eVideoType == VT_COLOR_VIDEOCARD_RGB))
 				g_pFuncUpdateGraphicsScreen = updateScreenSingleHires40Simplified;
 			else
 				g_pFuncUpdateGraphicsScreen = updateScreenSingleHires40;
@@ -2001,7 +2002,7 @@ void NTSC_SetVideoMode( uint32_t uVideoModeFlags, bool bDelay/*=false*/ )
 		{
 			if (uVideoModeFlags & VF_80COL)
 			{
-				if (g_eVideoType == VT_COLOR_MONITOR_RGB)
+				if ((g_eVideoType == VT_COLOR_MONITOR_RGB) || (g_eVideoType == VT_COLOR_VIDEOCARD_RGB))
 					g_pFuncUpdateGraphicsScreen = updateScreenDoubleLores80Simplified;
 				else
 					g_pFuncUpdateGraphicsScreen = updateScreenDoubleLores80;
@@ -2013,7 +2014,7 @@ void NTSC_SetVideoMode( uint32_t uVideoModeFlags, bool bDelay/*=false*/ )
 		}
 		else
 		{
-			if (g_eVideoType == VT_COLOR_MONITOR_RGB)
+			if ((g_eVideoType == VT_COLOR_MONITOR_RGB) || (g_eVideoType == VT_COLOR_VIDEOCARD_RGB))
 				g_pFuncUpdateGraphicsScreen = updateScreenSingleLores40Simplified;
 			else
 				g_pFuncUpdateGraphicsScreen = updateScreenSingleLores40;
@@ -2090,6 +2091,7 @@ void NTSC_SetVideoStyle(void)
 			goto _mono;
 
 		case VT_COLOR_MONITOR_RGB:
+		case VT_COLOR_VIDEOCARD_RGB:
 		case VT_MONO_WHITE:
 			r = 0xFF;
 			g = 0xFF;

--- a/source/RGBMonitor.cpp
+++ b/source/RGBMonitor.cpp
@@ -128,6 +128,7 @@ static RGBQUAD PalIndex2RGB[] =
 	SETRGBCOLOR(/*HGR_BLACK, */ 0x00,0x00,0x00), // For TV emulation HGR Video Mode
 	SETRGBCOLOR(/*HGR_WHITE, */ 0xFF,0xFF,0xFF),
 #else
+// Note: this is a placeholder. This palette is overwritten by VideoInitializeOriginal()
 	SETRGBCOLOR(/*HGR_BLACK, */ 0x00,0x00,0x00), // For TV emulation HGR Video Mode
 	SETRGBCOLOR(/*HGR_WHITE, */ 0xFF,0xFF,0xFF),
 	SETRGBCOLOR(/*BLUE,      */ 0x0D,0xA1,0xFF), // FC Linards Tweaked 0x00,0x00,0xFF -> 0x0D,0xA1,0xFF
@@ -145,6 +146,7 @@ static RGBQUAD PalIndex2RGB[] =
 	SETRGBCOLOR(/*HGR_PINK,  */ 0xFF,0x32,0xB5), // 0xD0,0x40,0xA0 -> 0xFF,0x32,0xB5
 
 // lores & dhires
+// Note: this is a placeholder. This palette is overwritten by VideoInitializeOriginal()
 	SETRGBCOLOR(/*BLACK,*/      0x00,0x00,0x00), // 0
 	SETRGBCOLOR(/*DEEP_RED,*/   0x9D,0x09,0x66), // 0xD0,0x00,0x30 -> Linards Tweaked 0x9D,0x09,0x66
 	SETRGBCOLOR(/*DARK_BLUE,*/  0x2A,0x2A,0xE5), // 4 // Linards Tweaked 0x00,0x00,0x80 -> 0x2A,0x2A,0xE5
@@ -160,6 +162,29 @@ static RGBQUAD PalIndex2RGB[] =
 	SETRGBCOLOR(/*GREEN,*/      0x38,0xCB,0x00), // FA Linards Tweaked 0x00,0xFF,0x00 -> 0x38,0xCB,0x00
 	SETRGBCOLOR(/*YELLOW,*/     0xD5,0xD5,0x1A), // FB Linards Tweaked 0xFF,0xFF,0x00 -> 0xD5,0xD5,0x1A
 	SETRGBCOLOR(/*AQUA,*/       0x62,0xF6,0x99), // 0x40,0xFF,0x90 -> Linards Tweaked 0x62,0xF6,0x99
+	SETRGBCOLOR(/*WHITE,*/      0xFF,0xFF,0xFF),
+};
+
+// Le Chat Mauve Feline's palette
+// extracted from a white-balanced RGB video capture
+static RGBQUAD PalIndex2RGB_Feline[] =
+{
+	// Feline test
+	SETRGBCOLOR(/*BLACK,*/      0x00,0x00,0x00),
+	SETRGBCOLOR(/*DEEP_RED,*/   0xAC,0x12,0x4C),
+	SETRGBCOLOR(/*DARK_BLUE,*/  0x00,0x07,0x83),
+	SETRGBCOLOR(/*MAGENTA,*/    0xAA,0x1A,0xD1),
+	SETRGBCOLOR(/*DARK_GREEN,*/ 0x00,0x83,0x2F),
+	SETRGBCOLOR(/*DARK_GRAY,*/  0x9F,0x97,0x7E),
+	SETRGBCOLOR(/*BLUE,*/       0x00,0x8A,0xB5),
+	SETRGBCOLOR(/*LIGHT_BLUE,*/ 0x9F,0x9E,0xFF),
+	SETRGBCOLOR(/*BROWN,*/      0x7A,0x5F,0x00),
+	SETRGBCOLOR(/*ORANGE,*/     0xFF,0x72,0x47),
+	SETRGBCOLOR(/*LIGHT_GRAY,*/ 0x78,0x68,0x7F),
+	SETRGBCOLOR(/*PINK,*/       0xFF,0x7A,0xCF),
+	SETRGBCOLOR(/*GREEN,*/      0x6F,0xE6,0x2C),
+	SETRGBCOLOR(/*YELLOW,*/     0xFF,0xF6,0x7B),
+	SETRGBCOLOR(/*AQUA,*/       0x6C,0xEE,0xB2),
 	SETRGBCOLOR(/*WHITE,*/      0xFF,0xFF,0xFF),
 };
 
@@ -815,7 +840,14 @@ void VideoInitializeOriginal(baseColors_t pBaseNtscColors)
 	// CREATE THE SOURCE IMAGE AND DRAW INTO THE SOURCE BIT BUFFER
 	V_CreateDIBSections();
 
-	memcpy(&PalIndex2RGB[BLACK], *pBaseNtscColors, sizeof(RGBQUAD)*kNumBaseColors);
+	if (g_RGBVideocard == RGB_Videocard_e::LeChatMauve_Feline)
+	{
+		memcpy(&PalIndex2RGB[BLACK], &PalIndex2RGB_Feline[0], sizeof(RGBQUAD) * kNumBaseColors);
+	}
+	else
+	{
+		memcpy(&PalIndex2RGB[BLACK], *pBaseNtscColors, sizeof(RGBQUAD) * kNumBaseColors);
+	}
 	PalIndex2RGB[HGR_BLUE]   = PalIndex2RGB[BLUE];
 	PalIndex2RGB[HGR_ORANGE] = PalIndex2RGB[ORANGE];
 	PalIndex2RGB[HGR_GREEN]  = PalIndex2RGB[GREEN];
@@ -874,12 +906,14 @@ void RGB_SetVideoMode(WORD address)
 
 bool RGB_Is140Mode(void)	// Extended 80-Column Text/AppleColor Card's Mode 2
 {
-	return g_rgbMode == 0;
+	// Feline falls back to this mode instead of 160
+	return g_rgbMode == 0 || (g_RGBVideocard == RGB_Videocard_e::LeChatMauve_Feline && g_rgbMode == 1);
 }
 
 bool RGB_Is160Mode(void)	// Extended 80-Column Text/AppleColor Card: N/A
 {
-	return g_rgbMode == 1;
+	// Unsupported by Feline
+	return g_rgbMode == 1 && (g_RGBVideocard != RGB_Videocard_e::LeChatMauve_Feline);
 }
 
 bool RGB_IsMixMode(void)	// Extended 80-Column Text/AppleColor Card's Mode 3

--- a/source/RGBMonitor.cpp
+++ b/source/RGBMonitor.cpp
@@ -575,7 +575,7 @@ static void CopySource(int w, int h, int sx, int sy, bgra_t *pVideoAddress, cons
 		{
 			for (int nBytes=0; nBytes<w; ++nBytes)
 			{
-				_ASSERT( *(pSrc+nBytes+nSrcAdjustment) < (sizeof(PaletteRGB_Apple)/sizeof(PaletteRGB_Apple[0])) );
+				_ASSERT( *(pSrc+nBytes+nSrcAdjustment) < (sizeof(PaletteRGB_NTSC)/sizeof(PaletteRGB_NTSC[0])) );
 				const RGBQUAD& rRGB = g_pPaletteRGB[ *(pSrc+nBytes+nSrcAdjustment) ];
 				*(pDst+nBytes) = *reinterpret_cast<const UINT32 *>(&rRGB);
 			}

--- a/source/RGBMonitor.cpp
+++ b/source/RGBMonitor.cpp
@@ -637,7 +637,8 @@ void UpdateDHiResCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, bool i
 		byteval4 = ~byteval4;
 	}
 
-	// To be checked on real hardware
+	// In RGB, DHGR mixed mode switch between color and BW only every 4 bits, based on bit 7 of the last read byte
+	// each case is handled below.
 	// Note: Color mode is a real 140x192 RGB mode with no color fringe (ref. patent US4631692, "THE 140x192 VIDEO MODE")
 
 	UINT32* pDst = (UINT32*)pVideoAddress;
@@ -744,20 +745,17 @@ void UpdateDHiResCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, bool i
 
 	// Second line
 	UINT32* pSrc = (UINT32*)pVideoAddress ;
-	pDst = pSrc + GetFrameBufferWidth();
-	for (int i = 0; i < 14; i++)
-		*(pDst+i) = *(pSrc+i);
-
-	// TODO: handle scanlines
-	//if (bIsHalfScanLines && !(h & 1))
-	//{
-	//	// 50% Half Scan Line clears every odd scanline (and SHIFT+PrintScreen saves only the even rows)
-	//	std::fill(pDst, pDst + 14, 0);
-	//	const UINT frameBufferWidth = GetFrameBufferWidth();
-	//}
-	//else
-	//{
-
+	pDst = pSrc - GetFrameBufferWidth();
+	if (bIsHalfScanLines)
+	{
+		// Scanlines
+		std::fill(pDst, pDst + 14, 0);
+	}
+	else
+	{
+		for (int i = 0; i < 14; i++)
+			*(pDst + i) = *(pSrc + i);
+	}
 }
 
 #if 1

--- a/source/RGBMonitor.cpp
+++ b/source/RGBMonitor.cpp
@@ -733,7 +733,7 @@ void UpdateDLoResCell (int x, int y, uint16_t addr, bgra_t *pVideoAddress)
 //===========================================================================
 // Color TEXT (some RGB cards only)
 // Default BG and FG are usually defined by hardware switches, defaults to black/white
-void UpdateText40ColorCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, uint8_t bits)
+void UpdateText40ColorCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, uint8_t bits, uint8_t character)
 {
 	uint8_t foreground = g_nRegularTextFG;
 	uint8_t background = g_nRegularTextBG;
@@ -743,13 +743,25 @@ void UpdateText40ColorCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, u
 		foreground = val >> 4;
 		background = val & 0x0F;
 	}
+	else if (g_RGBVideocard == RGB_Videocard_e::Video7_SL7 && character < 0x80)
+	{
+		// in regular 40COL mode, the SL7 videocard renders inverse characters as B&W
+		foreground = 15;
+		background = 0;
+	}
 
 	UpdateDuochromeCell(2, 14, pVideoAddress, bits, foreground, background);
 }
 
-void UpdateText80ColorCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, uint8_t bits)
+void UpdateText80ColorCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, uint8_t bits, uint8_t character)
 {
-	UpdateDuochromeCell(2, 7, pVideoAddress, bits, g_nRegularTextFG, g_nRegularTextBG);
+	if (g_RGBVideocard == RGB_Videocard_e::Video7_SL7 && character < 0x80)
+	{
+		// in all 80COL modes, the SL7 videocard renders inverse characters as B&W
+		UpdateDuochromeCell(2, 7, pVideoAddress, bits, 15, 0);
+	}
+	else
+		UpdateDuochromeCell(2, 7, pVideoAddress, bits, g_nRegularTextFG, g_nRegularTextBG);
 }
 
 //===========================================================================

--- a/source/RGBMonitor.cpp
+++ b/source/RGBMonitor.cpp
@@ -1066,11 +1066,11 @@ static bool g_rgbInvertBit7 = false;
 void RGB_SetVideoMode(WORD address)
 {
 
-	//if ((address & ~1) == 0x0C)			// 0x0C or 0x0D? (80COL)
-	//{
-	//	g_rgbSet80COL = true;
-	//	return;
-	//}
+	if ((address & ~1) == 0x0C)			// 0x0C or 0x0D? (80COL)
+	{
+		g_rgbSet80COL = true;
+		return;
+	}
 
 	if ((address & ~1) != 0x5E)			// 0x5E or 0x5F? (DHIRES)
 		return;
@@ -1085,38 +1085,22 @@ void RGB_SetVideoMode(WORD address)
 
 	// From Video7 patent and Le Chat Mauve manuals (under patent of Video7), no precondition is needed.
 
+	// In Prince of Persia, in the game demo, the RGB card switches to BW DHIRES after the HGR animation with Jaffar.
+	// It's actually the same on real hardware (tested on IIc RGB adapter).
+
 	if (address == 0x5F)
 	{
-		if (g_rgbPrevAN3Addr == 0x5E)// && g_rgbSet80COL)
+		if ((g_rgbPrevAN3Addr == 0x5E) && g_rgbSet80COL)
 		{
 			g_rgbFlags = (g_rgbFlags << 1) & 3;
 			g_rgbFlags |= ((g_uVideoMode & VF_80COL) ? 0 : 1);	// clock in !80COL
 			g_rgbMode = g_rgbFlags;								// latch F2,F1
 		}
 
-		//To test with Prince of Persia:
-		//g_rgbSet80COL = false;
+		g_rgbSet80COL = false;
 	}
 
 	g_rgbPrevAN3Addr = address;
-
-	//if ((g_uVideoMode & VF_MIXED) || (g_rgbSet80COL && address == 0x5F))
-	//{
-	//	g_rgbMode = 0;
-	//	g_rgbPrevAN3Addr = 0;
-	//	g_rgbSet80COL = false;
-	//	return;
-	//}
-
-	//if (address == 0x5F && g_rgbPrevAN3Addr == 0x5E)	// Check for AN3 clock transition
-	//{
-	//	g_rgbFlags = (g_rgbFlags<<1) & 3;
-	//	g_rgbFlags |= ((g_uVideoMode & VF_80COL) ? 0 : 1);	// clock in !80COL
-	//	g_rgbMode = g_rgbFlags;								// latch F2,F1
-	//}
-
-	//g_rgbPrevAN3Addr = address;
-	//g_rgbSet80COL = false;
 }
 
 bool RGB_Is140Mode(void)	// Extended 80-Column Text/AppleColor Card's Mode 2

--- a/source/RGBMonitor.cpp
+++ b/source/RGBMonitor.cpp
@@ -667,7 +667,6 @@ void UpdateHiResRGBCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress)
 	int color = 0;
 	DWORD dwordval_tmp = dwordval;
 	dwordval_tmp = dwordval_tmp >> 7;
-	int value;
 	bool offset = (byteval2 & 0x80);
 	for (int i = 0; i < 14; i++)
 	{

--- a/source/RGBMonitor.cpp
+++ b/source/RGBMonitor.cpp
@@ -594,10 +594,41 @@ void UpdateHiResCell (int x, int y, uint16_t addr, bgra_t *pVideoAddress)
 #define COLOR  ((xpixel + PIXEL) & 3)
 #define VALUE  (dwordval >> (4 + PIXEL - COLOR))
 
+void UpdateDHiResCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, bool updateAux, bool updateMain)
+{
+	const int xpixel = x * 14;
+
+	uint8_t* pAux = MemGetAuxPtr(addr);
+	uint8_t* pMain = MemGetMainPtr(addr);
+
+	BYTE byteval1 = (x > 0) ? *(pMain - 1) : 0;
+	BYTE byteval2 = *pAux;
+	BYTE byteval3 = *pMain;
+	BYTE byteval4 = (x < 39) ? *(pAux + 1) : 0;
+
+	DWORD dwordval = (byteval1 & 0x70) | ((byteval2 & 0x7F) << 7) |
+		((byteval3 & 0x7F) << 14) | ((byteval4 & 0x07) << 21);
+
+#define PIXEL  0
+	if (updateAux)
+	{
+		CopySource(7, 2, SRCOFFS_DHIRES + 10 * HIBYTE(VALUE) + COLOR, LOBYTE(VALUE), pVideoAddress);
+		pVideoAddress += 7;
+	}
+#undef PIXEL
+
+#define PIXEL  7
+	if (updateMain)
+	{
+		CopySource(7, 2, SRCOFFS_DHIRES + 10 * HIBYTE(VALUE) + COLOR, LOBYTE(VALUE), pVideoAddress);
+	}
+#undef PIXEL
+}
+
 bool dhgr_lastcell_iscolor = true;
 int dhgr_lastbit = 0;
 
-void UpdateDHiResCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, bool isMixMode, bool isBit7Inversed)
+void UpdateDHiResCellRGB(int x, int y, uint16_t addr, bgra_t* pVideoAddress, bool isMixMode, bool isBit7Inversed)
 {
 	const int xpixel = x * 14;
 	int xoffset = x & 1; // offset to start of the 2 bytes

--- a/source/RGBMonitor.h
+++ b/source/RGBMonitor.h
@@ -19,6 +19,7 @@ void UpdateText40ColorCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, u
 void UpdateText80ColorCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, uint8_t bits, uint8_t character);
 void UpdateHiResDuochromeCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress);
 void UpdateDuochromeCell(int h, int w, bgra_t* pVideoAddress, uint8_t bits, uint8_t foreground, uint8_t background);
+void UpdateHiResRGBCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress);
 
 const UINT kNumBaseColors = 16;
 typedef bgra_t (*baseColors_t)[kNumBaseColors];

--- a/source/RGBMonitor.h
+++ b/source/RGBMonitor.h
@@ -14,8 +14,8 @@ void UpdateDHiResCell (int x, int y, uint16_t addr, bgra_t *pVideoAddress, bool 
 int UpdateDHiRes160Cell (int x, int y, uint16_t addr, bgra_t *pVideoAddress);
 void UpdateLoResCell(int x, int y, uint16_t addr, bgra_t *pVideoAddress);
 void UpdateDLoResCell(int x, int y, uint16_t addr, bgra_t *pVideoAddress);
-void UpdateText40ColorCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, uint8_t bits);
-void UpdateText80ColorCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, uint8_t bits);
+void UpdateText40ColorCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, uint8_t bits, uint8_t character);
+void UpdateText80ColorCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, uint8_t bits, uint8_t character);
 void UpdateHiResDuochromeCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress);
 void UpdateDuochromeCell(int h, int w, bgra_t* pVideoAddress, uint8_t bits, uint8_t foreground, uint8_t background);
 

--- a/source/RGBMonitor.h
+++ b/source/RGBMonitor.h
@@ -23,6 +23,7 @@ void UpdateDuochromeCell(int h, int w, bgra_t* pVideoAddress, uint8_t bits, uint
 const UINT kNumBaseColors = 16;
 typedef bgra_t (*baseColors_t)[kNumBaseColors];
 void VideoInitializeOriginal(baseColors_t pBaseNtscColors);
+void VideoSwitchVideocardPalette(RGB_Videocard_e videocard, VideoType_e type);
 
 void RGB_SetVideoMode(WORD address);
 bool RGB_Is140Mode(void);

--- a/source/RGBMonitor.h
+++ b/source/RGBMonitor.h
@@ -10,7 +10,8 @@ enum RGB_Videocard_e
 
 
 void UpdateHiResCell(int x, int y, uint16_t addr, bgra_t *pVideoAddress);
-void UpdateDHiResCell (int x, int y, uint16_t addr, bgra_t *pVideoAddress, bool updateAux, bool updateMain);
+void UpdateDHiResCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress, bool updateAux, bool updateMain);
+void UpdateDHiResCellRGB(int x, int y, uint16_t addr, bgra_t* pVideoAddress, bool isMixMode, bool isBit7Inversed);
 int UpdateDHiRes160Cell (int x, int y, uint16_t addr, bgra_t *pVideoAddress);
 void UpdateLoResCell(int x, int y, uint16_t addr, bgra_t *pVideoAddress);
 void UpdateDLoResCell(int x, int y, uint16_t addr, bgra_t *pVideoAddress);

--- a/source/Video.cpp
+++ b/source/Video.cpp
@@ -101,8 +101,9 @@ static LPDIRECTDRAW g_lpDD = NULL;
 	// NOTE: KEEP IN SYNC: VideoType_e g_aVideoChoices g_apVideoModeDesc
 	TCHAR g_aVideoChoices[] =
 		TEXT("Monochrome (Custom)\0")
-		TEXT("Color (RGB Monitor)\0")
-		TEXT("Color (NTSC Monitor)\0")
+		TEXT("Color (RGB Idealized)\0")		// newly added
+		TEXT("Color (RGB Card/Monitor)\0")	// was "Color (RGB Monitor)"
+		TEXT("Color (Composite Monitor)\0")	// was "Color (NTSC Monitor)"
 		TEXT("Color TV\0")
 		TEXT("B&W TV\0")
 		TEXT("Monochrome (Amber)\0")
@@ -114,14 +115,15 @@ static LPDIRECTDRAW g_lpDD = NULL;
 	// The window title will be set to this.
 	const char *g_apVideoModeDesc[ NUM_VIDEO_MODES ] =
 	{
-		  "Monochrome Monitor (Custom)"
-		, "Color (RGB Monitor)"
-		, "Color (NTSC/PAL Monitor)"
+		  "Monochrome (Custom)"
+		, "Color (RGB Idealized)"
+		, "Color (RGB Card/Monitor)"
+		, "Color (Composite Monitor)"
 		, "Color TV"
 		, "B&W TV"
-		, "Amber Monitor"
-		, "Green Monitor"
-		, "White Monitor"
+		, "Monochrome (Amber)"
+		, "Monochrome (Green)"
+		, "Monochrome (White)"
 	};
 
 // Prototypes (Private) _____________________________________________

--- a/source/Video.cpp
+++ b/source/Video.cpp
@@ -101,7 +101,7 @@ static LPDIRECTDRAW g_lpDD = NULL;
 	// NOTE: KEEP IN SYNC: VideoType_e g_aVideoChoices g_apVideoModeDesc
 	TCHAR g_aVideoChoices[] =
 		TEXT("Monochrome (Custom)\0")
-		TEXT("Color (RGB Idealized)\0")		// newly added
+		TEXT("Color (Composite Idealized)\0")		// newly added
 		TEXT("Color (RGB Card/Monitor)\0")	// was "Color (RGB Monitor)"
 		TEXT("Color (Composite Monitor)\0")	// was "Color (NTSC Monitor)"
 		TEXT("Color TV\0")
@@ -116,7 +116,7 @@ static LPDIRECTDRAW g_lpDD = NULL;
 	const char *g_apVideoModeDesc[ NUM_VIDEO_MODES ] =
 	{
 		  "Monochrome (Custom)"
-		, "Color (RGB Idealized)"
+		, "Color (Composite Idealized)"
 		, "Color (RGB Card/Monitor)"
 		, "Color (Composite Monitor)"
 		, "Color TV"

--- a/source/Video.cpp
+++ b/source/Video.cpp
@@ -617,6 +617,7 @@ void VideoReinitialize (bool bInitVideoScannerAddress /*= true*/)
 	NTSC_SetVideoStyle();
 	NTSC_SetVideoTextMode( g_uVideoMode &  VF_80COL ? 80 : 40 );
 	NTSC_SetVideoMode( g_uVideoMode );	// Pre-condition: g_nVideoClockHorz (derived from g_dwCyclesThisFrame)
+	VideoSwitchVideocardPalette(RGB_GetVideocard(), GetVideoType());
 }
 
 //===========================================================================

--- a/source/Video.h
+++ b/source/Video.h
@@ -8,6 +8,7 @@
 	{
 		  VT_MONO_CUSTOM
 		, VT_COLOR_MONITOR_RGB		// Color rendering from AppleWin 1.25 (GH#357)
+		, VT_COLOR_VIDEOCARD_RGB    // Real RGB card rendering
 		, VT_COLOR_MONITOR_NTSC		// NTSC or PAL
 		, VT_COLOR_TV
 		, VT_MONO_TV


### PR DESCRIPTION
This is a revised version of PR #832.

New features since #832:

- New video mode, as proposed in #832
- Legacy RGB rendering is back
- On-the-fly RGB palette switch for some cards
- HIRES RGB rendering
- This is a new branch with only the most recent commits

Previous PR features:
- Fixed the SL7 color text features
- Support for Le Chat Mauve Féline/IIc adapter (under Video7 patent)
- DHIRES color & mixed mode rewrite
- DHIRES modes setup cleanup _(needs review)_


Details:

- New video mode, as proposed in #832

The available video modes are now:
```
	const char *g_apVideoModeDesc[ NUM_VIDEO_MODES ] =
	{
		  "Monochrome (Custom)"
		, "Color (RGB Idealized)"
		, "Color (RGB Card/Monitor)"
		, "Color (Composite Monitor)"
		, "Color TV"
		, "B&W TV"
		, "Monochrome (Amber)"
		, "Monochrome (Green)"
		, "Monochrome (White)"
	};
```

The new RGB supported features (extra modes, different palette etc) show only when `Color (RGB Card/Monitor)` is selected.

The new mode is referenced as `VT_COLOR_VIDEOCARD_RGB` and can be selected with the switch `-video-mode=rgb-videocard`.

- Legacy RGB rendering is back

`Color (RGB Idealized)`
This is the idealized legacy RGB mode that the users of AppleWin are used to see. This does not emulate an actual RGB card but represent an idealized clean version of the composite output.

- On-the-fly RGB palette switch for some cards

The RGB palette is now a pointer that can be used instead of the static `Pal2IndexRGB` array that contains the actual palette and then, the palette can be changed on the fly.
`VideoSwitchVideocardPalette()` does that.
Some RGB cards may use a different color palette than the regular NTSC colors, so in that case the palette is switched when the user goes in or out of the `Color (RGB Card/Monitor)` mode.

- HIRES RGB rendering

Enabled only in `Color (RGB Card/Monitor)` mode.
The main difference with other composite/ideal modes is that there is no half-pixel shift when bit 7 changes. That's why "Press any key" in this capture looks distorted. On the opposite, ©1982 looks okay in RGB but is distorted in composite.

As a matter of fact, I think that the RGB render looks a lot like what a generic Apple II emulator without precise NTSC timing handling would display.
It was checked against real hardware (Le Chat Mauve Feline card).

![image](https://user-images.githubusercontent.com/17545417/94210080-19ee7f00-fece-11ea-9d99-b5d6db1e2278.png)

- Fixed the SL7 color text features

In all regular text modes, when a default color is selected, all characters that are <0x80 shows in black and white. This was specified in the manual as "Inverse text always show in black and white"

The matching `UpdateText` functions now take the character value to handle this.

![image](https://user-images.githubusercontent.com/17545417/92338793-ebda0400-f0b2-11ea-9dd1-78e42977202e.png)

- Support for Le Chat Mauve Féline/IIc adapter (under Video7 patent)

Enabled with `-rgb-card-type feline`

It has the same features of the Apple RGB card except that the 160 DHIRES mode is not implemented.

The palette is different from the regular AW palette, so I added it and it's selected when the users activates the `Color (RGB Card/Monitor)` mode. One of the main differences is that DARK_GREY and LIGHT_GREY are different colors. The colors were sampled from a white-balanced video capture done with my OSSC.

However, I will try to make more captures of other Féline and IIc adapters to further validate it.

Regular:
![image](https://user-images.githubusercontent.com/17545417/92339016-40ca4a00-f0b4-11ea-9375-41c22c67a39c.png)

Féline:
![image](https://user-images.githubusercontent.com/17545417/92338813-11ffa400-f0b3-11ea-9467-0eeeaa33ef90.png)


- DHIRES color & mixed mode rewrite

The current AW implementation of DHIRES in RGB was not an emulation of the real RGB cards, so I analyzed the Video7 patent and the output of my IIc in RGB.
I rewrote it, but it was not as straightforward that I first thought.

1. Color mode is a real 140x192 mode with no color fringe (Video7 patent, shows that way on real hardware)

![image](https://user-images.githubusercontent.com/17545417/92338878-63a82e80-f0b3-11ea-939a-44aeca954f94.png)

2. Mixed mode works with 4-bits cells that are organized in packs of 7 cells over 4 bytes:
Bit 7 defines if the 7 bits of that byte are color of B&W;
BW pixels are 1 bit wide, color pixels are usually 4 bits wide;
If a 4-bits color cell falls into a BW byte, then it immediatly reverts to the BW mode and the color pixel is less than 4 bits wide;
If a 4-bits BW cell falls into a Color byte, then the last BW pixel is repeated until the next color cell starts.

This was once again validated on my IIc adapter. The last one was tricky to understand. Some mixed DHGR pictures bundled with the drawing software "Extasie" didn't initially show correctly because of this. For instance on the "Elephant" picture, the left side of the Elephant shows 1-bit wide color pixels while the right side shows a column of repeated 1-bit BW pixels.

IIc:
![image](https://user-images.githubusercontent.com/17545417/92338966-f9dc5480-f0b3-11ea-99a7-9b0bf8917d43.png)
AppleWin (feline card):
![image](https://user-images.githubusercontent.com/17545417/92338998-2001f480-f0b4-11ea-937a-d7940181f226.png)

- DHIRES modes setup cleanup

**Since #832 I found out that it doesn't work well with Matterhorn Screamer.** I'm still scratching my head over this one.

The precondition tests that were present prevented Extasie to enter the mixed DHGR mode.

The Video7 patent doesn't state any precondition to enable the various DHGR modes through the hidden F1/F2 registers. However 80COL needs to be written to be detected, and its detection is reset when the card detects a C05E->C05F toggle (as previously implemented in AW).

This behavior triggers a bug in the game introduction of Prince of Persia: once it reverts to DHGR after the HGR animation with Jaffar, every following DHGR screen will show in BW (560) mode only. It's the same on real hardware.

IIc:
![image](https://user-images.githubusercontent.com/17545417/92339109-b7674780-f0b4-11ea-83cf-0037b03a0e1c.png)


