### PR TITLE
Debugger, minor clean-up: compiler warnings, unused variables etc

### DIFF
--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -5370,7 +5370,7 @@ Update_t CmdNTSC (int nArgs)
 							*pDst++ = pTmp[3];
 					}
 				}
-/*
+
 				// we duplicate phase 0 a total of 4 times
 				const size_t nBytesPerScanLine = 4096 * nBPP;
 				for( int iPhase = 1; iPhase < 4; iPhase++ )

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -701,8 +701,6 @@ Update_t CmdBookmarkList (int nArgs)
 //===========================================================================
 Update_t CmdBookmarkLoad (int nArgs)
 {
-	char sFilePath[ MAX_PATH ] = "";
-
 	if (nArgs == 1)
 	{
 //		strcpy( sMiniFileName, pFileName );
@@ -991,7 +989,7 @@ Update_t CmdBreakInvalid (int nArgs) // Breakpoint IFF Full-speed!
 	return UPDATE_CONSOLE_DISPLAY;
 
 _Help:
-		return HelpLastCommand();
+	return HelpLastCommand();
 }
 
 
@@ -1457,8 +1455,6 @@ Update_t CmdBreakpointAddPC (int nArgs)
 		g_aArgs[1].nValue = g_nDisasmCurAddress;
 	}
 
-	bool bHaveCmp = false;
-
 //	int iParamSrc;
 	int iParamCmp;
 
@@ -1476,12 +1472,12 @@ Update_t CmdBreakpointAddPC (int nArgs)
 			{
 				switch (iParamCmp)
 				{
-					case PARAM_BP_LESS_EQUAL   : iCmp = BP_OP_LESS_EQUAL   ; bHaveCmp = true; break;
-					case PARAM_BP_LESS_THAN    : iCmp = BP_OP_LESS_THAN    ; bHaveCmp = true; break;
-					case PARAM_BP_EQUAL        : iCmp = BP_OP_EQUAL        ; bHaveCmp = true; break;
-					case PARAM_BP_NOT_EQUAL    : iCmp = BP_OP_NOT_EQUAL    ; bHaveCmp = true; break;
-					case PARAM_BP_GREATER_THAN : iCmp = BP_OP_GREATER_THAN ; bHaveCmp = true; break;
-					case PARAM_BP_GREATER_EQUAL: iCmp = BP_OP_GREATER_EQUAL; bHaveCmp = true; break;
+					case PARAM_BP_LESS_EQUAL   : iCmp = BP_OP_LESS_EQUAL   ; break;
+					case PARAM_BP_LESS_THAN    : iCmp = BP_OP_LESS_THAN    ; break;
+					case PARAM_BP_EQUAL        : iCmp = BP_OP_EQUAL        ; break;
+					case PARAM_BP_NOT_EQUAL    : iCmp = BP_OP_NOT_EQUAL    ; break;
+					case PARAM_BP_GREATER_THAN : iCmp = BP_OP_GREATER_THAN ; break;
+					case PARAM_BP_GREATER_EQUAL: iCmp = BP_OP_GREATER_EQUAL; break;
 					default:
 						break;
 				}
@@ -1816,8 +1812,6 @@ Update_t CmdBreakpointSave (int nArgs)
 //===========================================================================
 Update_t _CmdAssemble( WORD nAddress, int iArg, int nArgs )
 {
-	bool bHaveLabel = false;
-
 	// if AlphaNumeric
 	ArgToken_e iTokenSrc = NO_TOKEN;
 	ParserFindToken( g_pConsoleInput, g_aTokens, NUM_TOKENS, &iTokenSrc );
@@ -1825,8 +1819,6 @@ Update_t _CmdAssemble( WORD nAddress, int iArg, int nArgs )
 	if (iTokenSrc == NO_TOKEN) // is TOKEN_ALPHANUMERIC
 	if (g_pConsoleInput[0] != CHAR_SPACE)
 	{
-		bHaveLabel = true;
-
 		// Symbol
 		char *pSymbolName = g_aArgs[ iArg ].sArg; // pArg->sArg;
 		SymbolUpdate( SYMBOLS_ASSEMBLY, pSymbolName, nAddress, false, true ); // bool bRemoveSymbol, bool bUpdateSymbol )
@@ -5939,11 +5931,6 @@ Update_t _CmdMemorySearch (int nArgs, bool bTextIsAscii = true )
 		return ConsoleDisplayError( TEXT("Error: Missing address seperator (comma or colon)" ) );
 
 	int iArgFirstByte = 4;
-
-	// S start,len #
-	int nMinLen = nArgs - (iArgFirstByte - 1);
-
-	bool bHaveWildCards = false;
 	int iArg;
 
 	MemorySearchValues_t vMemorySearchValues;
@@ -6240,8 +6227,6 @@ Update_t CmdOutputCalc (int nArgs)
 //===========================================================================
 Update_t CmdOutputEcho (int nArgs)
 {
-	TCHAR sText[ CONSOLE_WIDTH ] = TEXT("");
-
 	if (g_aArgs[1].bType & TYPE_QUOTED_2)
 	{
 		ConsoleDisplayPush( g_aArgs[1].sArg );
@@ -6534,7 +6519,6 @@ Update_t CmdOutputRun (int nArgs)
 
 	if (script.Read( sFileName ))
 	{
-		int iLine = 0;
 		int nLine = script.GetNumLines();
 
 		Update_t bUpdateDisplay = UPDATE_NOTHING;	
@@ -6652,10 +6636,6 @@ bool ParseAssemblyListing( bool bBytesToMemory, bool bAddSymbols )
 	g_nSourceAssemblySymbols = 0;
 
 	const DWORD INVALID_ADDRESS = _6502_MEM_END + 1;
-
-	bool bPrevSymbol = false;
-	bool bFourBytes = false;		
-	BYTE nByte4 = 0;
 
 	int nLines = g_AssemblerSourceBuffer.GetNumLines();
 	for( int iLine = 0; iLine < nLines; iLine++ )

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -440,10 +440,10 @@ bool DebugGetVideoMode(UINT* pVideoMode)
 
 // File _______________________________________________________________________
 
-int _GetFileSize( FILE *hFile )
+size_t _GetFileSize( FILE *hFile )
 {
 	fseek( hFile, 0, SEEK_END );
-	int nFileBytes = ftell( hFile );
+	size_t nFileBytes = ftell( hFile );
 	fseek( hFile, 0, SEEK_SET );
 
 	return nFileBytes;
@@ -4497,7 +4497,7 @@ Update_t CmdMemoryLoad (int nArgs)
 	FILE *hFile = fopen( sLoadSaveFilePath.c_str(), "rb" );
 	if (hFile)
 	{
-		int nFileBytes = _GetFileSize( hFile );
+		size_t nFileBytes = _GetFileSize( hFile );
 
 		if (nFileBytes > _6502_MEM_END)
 			nFileBytes = _6502_MEM_END + 1; // Bank-switched RAM/ROM is only 16-bit
@@ -8134,6 +8134,9 @@ Update_t ExecuteCommand (int nArgs)
 //===========================================================================
 void OutputTraceLine ()
 {
+	if (!g_hTraceFile)
+		return;
+
 	DisasmLine_t line;
 	GetDisassemblyLine( regs.pc, line );
 
@@ -8151,9 +8154,6 @@ void OutputTraceLine ()
 			sFlags[nFlag] = g_aBreakpointSource[BP_SRC_FLAG_C + iFlag][0];
 		nRegFlags >>= 1;
 	}
-
-	if (!g_hTraceFile)
-		return;
 
 	if (g_bTraceHeader)
 	{

--- a/source/Debugger/Debugger_Assembler.cpp
+++ b/source/Debugger/Debugger_Assembler.cpp
@@ -787,8 +787,6 @@ bool _6502_GetTargetAddress ( const WORD & nAddress, WORD & nTarget_ )
 	iOpcode = _6502_GetOpmodeOpbyte( nAddress, iOpmode, nOpbytes );
 
 	// Composite string that has the target nAddress
-//	WORD nTarget = 0;
-	int nTargetOffset_ = 0;
 
 	if ((iOpmode != AM_IMPLIED) &&
 		(iOpmode != AM_1) &&
@@ -797,7 +795,6 @@ bool _6502_GetTargetAddress ( const WORD & nAddress, WORD & nTarget_ )
 	{
 		int nTargetPartial;
 		int nTargetPointer;
-		WORD nTargetValue = 0; // de-ref
 		int nTargetBytes;
 		_6502_GetTargets( nAddress, &nTargetPartial, &nTargetPointer, &nTargetBytes, false );
 
@@ -870,9 +867,8 @@ int AssemblerHashMnemonic ( const TCHAR * pMnemonic )
 	const int    NUM_MSK_BITS =  5; //  4 ->  5 prime
 	const Hash_t BIT_MSK_HIGH = ((1 << NUM_MSK_BITS) - 1) << NUM_LOW_BITS;
 
-	int nLen = strlen( pMnemonic );
-
 #if DEBUG_ASSEMBLER
+	int nLen = strlen( pMnemonic );
 	static int nMaxLen = 0;
 	if (nMaxLen < nLen) {
 		nMaxLen = nLen;
@@ -961,7 +957,7 @@ void _CmdAssembleHashDump ()
 	
 	std::sort( vHashes.begin(), vHashes.end(), HashOpcode_t() );
 
-	Hash_t nPrevHash = vHashes.at( 0 ).m_nValue;
+//	Hash_t nPrevHash = vHashes.at( 0 ).m_nValue;
 	Hash_t nThisHash = 0;
 
 	for( iOpcode = 0; iOpcode < NUM_OPCODES; iOpcode++ )
@@ -1097,7 +1093,7 @@ bool AssemblerGetArgs( int iArg, int nArgs, WORD nBaseAddress )
 	while (iArg < g_nArgRaw)
 	{
 		int iToken = pArg->eToken;
-		int iType  = pArg->bType;
+//		int iType  = pArg->bType;
 
 		if (iToken == TOKEN_HASH)
 		{

--- a/source/Debugger/Debugger_Assembler.cpp
+++ b/source/Debugger/Debugger_Assembler.cpp
@@ -794,9 +794,10 @@ bool _6502_GetTargetAddress ( const WORD & nAddress, WORD & nTarget_ )
 		(iOpmode != AM_3))
 	{
 		int nTargetPartial;
+		int nTargetPartial2;
 		int nTargetPointer;
 		int nTargetBytes;
-		_6502_GetTargets( nAddress, &nTargetPartial, &nTargetPointer, &nTargetBytes, false );
+		_6502_GetTargets( nAddress, &nTargetPartial, &nTargetPartial2, &nTargetPointer, &nTargetBytes, false );
 
 //		if (nTargetPointer == NO_6502_TARGET)
 //		{

--- a/source/Debugger/Debugger_Console.cpp
+++ b/source/Debugger/Debugger_Console.cpp
@@ -354,7 +354,6 @@ void ConsoleBufferToDisplay ()
 //===========================================================================
 void ConsoleConvertFromText ( conchar_t * sText, const char * pText )
 {
-	int x = 0;
 	const char *pSrc = pText;
 	conchar_t  *pDst = sText;
 	while (pSrc && *pSrc)
@@ -522,13 +521,6 @@ void ConsoleInputReset ()
 //	_tcscpy( g_aConsoleInput, g_sConsolePrompt ); // Assembler can change prompt
 	g_aConsoleInput[0] = g_sConsolePrompt[0];
 	g_nConsolePromptLen = 1;
-
-//	int nLen = strlen( g_aConsoleInput );
-#if CONSOLE_INPUT_CHAR16
-	int nLen = ConsoleLineLength( g_aConsoleInput );
-#else
-	int nLen = strlen( g_aConsoleInput );
-#endif
 
 	g_pConsoleInput = &g_aConsoleInput[ g_nConsolePromptLen ];
 	g_nConsoleInputChars = 0;

--- a/source/Debugger/Debugger_DisassemblerData.cpp
+++ b/source/Debugger/Debugger_DisassemblerData.cpp
@@ -197,7 +197,7 @@ Update_t CmdDisasmDataList (int nArgs)
 	// Need to iterate through all blocks
 	DisasmData_t* pData = NULL;
 
-	while( pData = Disassembly_Enumerate( pData ) )
+	while( (pData = Disassembly_Enumerate( pData )) )
 	{
 		if (pData->iDirective != _NOP_REMOVED)
 		{

--- a/source/Debugger/Debugger_Display.cpp
+++ b/source/Debugger/Debugger_Display.cpp
@@ -1061,7 +1061,6 @@ char ColorizeSpecialChar( char * sText, BYTE nData, const MemoryView_e iView,
 		const int iCtrlBackground /*= BG_INFO_CHAR*/, const int iCtrlForeground /*= FG_INFO_CHAR_LO*/ )
 {
 	bool bHighBit = false;
-	bool bAsciBit = false;
 	bool bCtrlBit = false;
 
 	int iTextBG = iAsciBackground;
@@ -1154,7 +1153,6 @@ void DrawBreakpoints ( int line )
 	rect.right  = DISPLAY_WIDTH;
 	rect.bottom = rect.top + g_nFontHeight;
 
-	const int MAX_BP_LEN = 16;
 	char sText[16] = "Breakpoints"; // TODO: Move to BP1
 
 #if DISPLAY_BREAKPOINT_TITLE
@@ -1499,7 +1497,7 @@ int GetDisassemblyLine ( WORD nBaseAddress, DisasmLine_t & line_ )
 		(iOpmode != AM_3))
 	{
 		// Assume target address starts after the opcode ...
-		// BUT in the Assembler Directve / Data Disassembler case for define addr/word
+		// BUT in the Assembler Directive / Data Disassembler case for define addr/word
 		// the opcode literally IS the target address!
 		if( pData )
 		{
@@ -1763,10 +1761,10 @@ void FormatOpcodeBytes ( WORD nBaseAddress, DisasmLine_t & line_ )
 void FormatNopcodeBytes ( WORD nBaseAddress, DisasmLine_t & line_ )
 {
 		char *pDst = line_.sTarget;
-const	char *pSrc = 0;
+		const	char *pSrc = 0;
 		DWORD nStartAddress = line_.pDisasmData->nStartAddress;
 		DWORD nEndAddress   = line_.pDisasmData->nEndAddress  ;
-		int   nDataLen      = nEndAddress - nStartAddress + 1 ;
+//		int   nDataLen      = nEndAddress - nStartAddress + 1 ;
 		int   nDisplayLen   = nEndAddress - nBaseAddress  + 1 ; // *inclusive* KEEP IN SYNC: _CmdDefineByteRange() CmdDisasmDataList() _6502_GetOpmodeOpbyte() FormatNopcodeBytes()
 		int   len           = nDisplayLen;
 
@@ -1920,7 +1918,7 @@ WORD DrawDisassemblyLine ( int iLine, const WORD nBaseAddress )
 	if (! ((g_iWindowThis == WINDOW_CODE) || ((g_iWindowThis == WINDOW_DATA))))
 		return 0;
 
-	int iOpcode;
+//	int iOpcode;
 	int iOpmode;
 	int nOpbyte;
 	DisasmLine_t line;
@@ -1931,7 +1929,7 @@ WORD DrawDisassemblyLine ( int iLine, const WORD nBaseAddress )
 	int bDisasmFormatFlags = GetDisassemblyLine( nBaseAddress, line );
 	const DisasmData_t *pData = line.pDisasmData;
 
-	iOpcode = line.iOpcode;	
+//	iOpcode = line.iOpcode;	
 	iOpmode = line.iOpmode;
 	nOpbyte = line.nOpbyte;
 
@@ -1984,7 +1982,6 @@ WORD DrawDisassemblyLine ( int iLine, const WORD nBaseAddress )
 		aTabs[ TS_IMMEDIATE   ] -= 1;
 	}
 #endif	
-	const int OPCODE_TO_LABEL_SPACE = static_cast<int>( aTabs[ TS_INSTRUCTION ] - aTabs[ TS_LABEL ] );
 
 	int iTab = 0;
 	int nSpacer = 11; // 9
@@ -2009,12 +2006,6 @@ WORD DrawDisassemblyLine ( int iLine, const WORD nBaseAddress )
 
 		aTabs[ iTab ] *= nDefaultFontWidth;
 	}	
-
-#if USE_APPLE_FONT
-	const int DISASM_SYMBOL_LEN = 12;
-#else
-	const int DISASM_SYMBOL_LEN = 9;
-#endif
 
 	int nFontHeight = g_aFontConfig[ FONT_DISASM_DEFAULT ]._nLineHeight; // _nFontHeight; // g_nFontHeight
 
@@ -2563,7 +2554,6 @@ void DrawMemory ( int line, int iMemDump )
 
 	const int MAX_MEM_VIEW_TXT = 16;
 	char sText[ MAX_MEM_VIEW_TXT * 2 ];
-	char sData[ MAX_MEM_VIEW_TXT * 2 ];
 
 	char sType   [ 6 ] = "Mem";
 	char sAddress[ 8 ] = "";
@@ -2610,8 +2600,6 @@ void DrawMemory ( int line, int iMemDump )
 	rect.top    = rect2.top;
 	rect.bottom = rect2.bottom;
 
-	sData[0] = 0;
-
 	WORD iAddress = nAddr;
 
 	int nLines = g_nDisplayMemoryLines;
@@ -2648,9 +2636,6 @@ void DrawMemory ( int line, int iMemDump )
 
 		for (int iCol = 0; iCol < nCols; iCol++)
 		{
-			bool bHiBit = false;
-			bool bLoBit = false;
-
 			DebuggerSetColorBG( DebuggerGetColor( iBackground ));
 			DebuggerSetColorFG( DebuggerGetColor( iForeground ));
 
@@ -2682,8 +2667,6 @@ void DrawMemory ( int line, int iMemDump )
 				BYTE nData = (unsigned)*(LPBYTE)(mem+iAddress);
 				sText[0] = 0;
 
-				char c = nData;
-
 				if (iView == MEM_VIEW_HEX)
 				{
 					if ((iAddress >= _6502_IO_BEGIN) && (iAddress <= _6502_IO_END))
@@ -2712,7 +2695,6 @@ void DrawMemory ( int line, int iMemDump )
 
 		rect.top    += g_nFontHeight;
 		rect.bottom += g_nFontHeight;
-		sData[0] = 0;
 	}
 }
 
@@ -2857,7 +2839,6 @@ void _DrawSoftSwitchAddress( RECT & rect, int nAddress, int bg_default = BG_INFO
 void _DrawSoftSwitch( RECT & rect, int nAddress, bool bSet, char *sPrefix, char *sOn, char *sOff, const char *sSuffix = NULL, int bg_default = BG_INFO )
 {
 	RECT temp = rect;
-	char sText[ 4 ] = "";
 
 	_DrawSoftSwitchAddress( temp, nAddress, bg_default );
 
@@ -3103,10 +3084,9 @@ void DrawSoftSwitches( int iSoftSwitch )
 
 		DebuggerSetColorBG( DebuggerGetColor( BG_INFO ));
 		DebuggerSetColorFG( DebuggerGetColor( FG_INFO_TITLE ));
-
-		char sText[16] = "";
 		
 #if SOFTSWITCH_OLD
+		char sText[16] = "";
 		// $C050 / $C051 = TEXTOFF/TEXTON = SW.TXTCLR/SW.TXTSET
 		// GR  / TEXT
 		// GRAPH/TEXT
@@ -3411,7 +3391,6 @@ void DrawWatches (int line)
 			PrintTextCursorX( ":", rect2 );
 
 			BYTE nTarget8 = 0;
-			BYTE nValue8 = 0;
 
 			nTarget8 = (unsigned)*(LPBYTE)(mem+g_aWatches[iWatch].nAddress);
 			sprintf(sText,"%02X", nTarget8 );
@@ -3717,7 +3696,7 @@ void DrawSubWindow_Data (Update_t bUpdate)
 
 		rect.left = X_CHAR;
 
-	// Seperator
+	// Separator
 		DebuggerSetColorFG( DebuggerGetColor( FG_DISASM_OPERATOR ));
 		PrintTextCursorX( "  |  ", rect );
 
@@ -3733,12 +3712,12 @@ void DrawSubWindow_Data (Update_t bUpdate)
 		for (iByte = 0; iByte < nMaxOpcodes; iByte++ )
 		{
 			BYTE nImmediate = (unsigned)*(LPBYTE)(mem + iAddress);
-			int iTextBackground = iBackground;
+			/*int iTextBackground = iBackground;
 			if ((iAddress >= _6502_IO_BEGIN) && (iAddress <= _6502_IO_END))
 			{
 				iTextBackground = BG_INFO_IO_BYTE;
 			}
-
+			*/
 			ColorizeSpecialChar( sImmediate, (BYTE) nImmediate, eView, iBackground );
 			PrintTextCursorX( (LPCSTR) sImmediate, rect );
 
@@ -3975,7 +3954,6 @@ void DrawSubWindow_Source2 (Update_t bUpdate)
 
 	DebuggerSetColorFG( DebuggerGetColor( FG_SOURCE ));
 
-	int iSource = g_iSourceDisplayStart;
 	int nLines  = g_nDisasmWinHeight;
 
 	int y = g_nDisasmWinHeight;
@@ -4130,7 +4108,7 @@ void DrawWindowBackground_Info( int g_iWindowThis )
 {
     RECT rect;
     rect.top    = 0;
-	rect.left   = DISPLAY_DISASM_RIGHT;
+    rect.left   = DISPLAY_DISASM_RIGHT;
     rect.right  = DISPLAY_WIDTH;
 	int nTop = GetConsoleTopPixels( g_nConsoleDisplayLines - 1 );
 	rect.bottom = nTop;

--- a/source/Debugger/Debugger_Display.h
+++ b/source/Debugger/Debugger_Display.h
@@ -85,7 +85,7 @@
 	{
 	public:
 		VideoScannerDisplayInfo(void) : isDecimal(false), isHorzReal(false), cycleMode(rel),
-										lastCumulativeCycles(0), cycleDelta(0) {}
+										lastCumulativeCycles(0), savedCumulativeCycles(0), cycleDelta(0) {}
 		void Reset(void) { lastCumulativeCycles = savedCumulativeCycles = g_nCumulativeCycles; cycleDelta = 0; }
 
 		bool isDecimal;

--- a/source/Debugger/Debugger_Help.cpp
+++ b/source/Debugger/Debugger_Help.cpp
@@ -60,7 +60,6 @@ bool TestStringCat ( TCHAR * pDst, LPCSTR pSrc, const int nDstSize )
 	int nLenDst = _tcslen( pDst );
 	int nLenSrc = _tcslen( pSrc );
 	int nSpcDst = nDstSize - nLenDst;
-	int nChars  = MIN( nLenSrc, nSpcDst );
 
 	bool bOverflow = (nSpcDst <= nLenSrc); // 2.5.6.25 BUGFIX
 	if (bOverflow)
@@ -390,7 +389,6 @@ bool Colorize( char * pDst, const char * pSrc )
 	const char sExamples[] = "Examples:";
 	const int  nExamples = sizeof( sExamples ) - 1;
 
-	int nLen = 0;
 	while (*pSrc)
 	{
 		if (strncmp( sUsage, pSrc, nUsage) == 0)
@@ -1530,10 +1528,6 @@ Update_t CmdHelpList (int nArgs)
 
 	char sText[ nBuf ] = "";
 	
-	int nLenLine = strlen( sText );
-	int y = 0;
-	int nLinesScrolled = 0;
-
 	int nMaxWidth = g_nConsoleDisplayWidth - 1;
 	int iCommand;
 
@@ -1547,7 +1541,6 @@ Update_t CmdHelpList (int nArgs)
 		}
 		std::sort( g_vSortedCommands.begin(), g_vSortedCommands.end(), commands_functor_compare() );
 	}
-	int nCommands = g_vSortedCommands.size();
 
 	int nLen = 0;
 //		Colorize( sText, "Commands: " );

--- a/source/Debugger/Debugger_Parser.cpp
+++ b/source/Debugger/Debugger_Parser.cpp
@@ -418,7 +418,6 @@ void ArgsRawParse ( void )
 	WORD   nAddressArg;
 	WORD   nAddressSymbol;
 	WORD   nAddressValue;
-	int    nParamLen = 0;
 
 	while (iArg <= nArg)
 	{
@@ -869,8 +868,6 @@ const TCHAR * FindTokenOrAlphaNumeric ( const TCHAR *pSrc, const TokenTable_t *a
 //===========================================================================
 void TextConvertTabsToSpaces( TCHAR *pDeTabified_, LPCTSTR pText, const int nDstSize, int nTabStop )
 {
-	int nLen = _tcslen( pText );
-
 	int TAB_SPACING = 8;
 	int TAB_SPACING_1 = 16;
 	int TAB_SPACING_2 = 21;
@@ -881,7 +878,6 @@ void TextConvertTabsToSpaces( TCHAR *pDeTabified_, LPCTSTR pText, const int nDst
 	LPCTSTR pSrc = pText;
 	LPTSTR  pDst = pDeTabified_;
 
-	int iTab = 0; // number of tabs seen
 	int nTab = 0; // gap left to next tab
 	int nGap = 0; // actual gap
 	int nCur = 0; // current cursor position


### PR DESCRIPTION
Minor clean-up changes in the Debugger code to fix some compiler warnings. Mainly affects forgotten, unused local variables.