### PR TITLE
Support for synchronous events

### DIFF
--- a/AppleWinExpress2008.vcproj
+++ b/AppleWinExpress2008.vcproj
@@ -758,6 +758,14 @@
 					>
 				</File>
 				<File
+					RelativePath=".\source\SynchronousEventManager.cpp"
+					>
+				</File>
+				<File
+					RelativePath=".\source\SynchronousEventManager.h"
+					>
+				</File>
+				<File
 					RelativePath=".\source\Tape.cpp"
 					>
 				</File>

--- a/AppleWinExpress2019.vcxproj
+++ b/AppleWinExpress2019.vcxproj
@@ -96,6 +96,7 @@
     <ClInclude Include="source\Speech.h" />
     <ClInclude Include="source\SSI263Phonemes.h" />
     <ClInclude Include="source\StdAfx.h" />
+    <ClInclude Include="source\SynchronousEventManager.h" />
     <ClInclude Include="source\Tape.h" />
     <ClInclude Include="source\Tfe\Bittypes.h" />
     <ClInclude Include="source\Tfe\Bpf.h" />
@@ -184,6 +185,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release NoDX|Win32'">Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="source\SynchronousEventManager.cpp" />
     <ClCompile Include="source\Tape.cpp" />
     <ClCompile Include="source\Tfe\Tfe.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>

--- a/AppleWinExpress2019.vcxproj.filters
+++ b/AppleWinExpress2019.vcxproj.filters
@@ -199,6 +199,9 @@
     <ClCompile Include="source\Disk2CardManager.cpp">
       <Filter>Source Files\Disk</Filter>
     </ClCompile>
+    <ClCompile Include="source\SynchronousEventManager.cpp">
+      <Filter>Source Files\Emulator</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="source\Applewin.h">
@@ -481,6 +484,9 @@
       <Filter>Source Files\Disk</Filter>
     </ClInclude>
     <ClInclude Include="source\Card.h">
+      <Filter>Source Files\Emulator</Filter>
+    </ClInclude>
+    <ClInclude Include="source\SynchronousEventManager.h">
       <Filter>Source Files\Emulator</Filter>
     </ClInclude>
   </ItemGroup>

--- a/source/Applewin.cpp
+++ b/source/Applewin.cpp
@@ -1483,6 +1483,8 @@ int APIENTRY WinMain(HINSTANCE passinstance, HINSTANCE, LPSTR lpCmdLine, int)
 			DSUninit();
 			LogFileOutput("Main: DSUninit()\n");
 
+			g_SynchronousEventMgr.Reset();
+
 			if (g_bHookSystemKey)
 			{
 				UninitHookThread();

--- a/source/Applewin.cpp
+++ b/source/Applewin.cpp
@@ -127,60 +127,6 @@ CSpeech		g_Speech;
 
 //===========================================================================
 
-int testCB(int id, int underflowCycles, ULONG uExecutedCycles)
-{
-	return 0;
-}
-
-void SyncEventTest(void)
-{
-	SyncEvent syncEvent0(0, 0x10, testCB);
-	SyncEvent syncEvent1(1, 0x20, testCB);
-	SyncEvent syncEvent2(2, 0x30, testCB);
-	SyncEvent syncEvent3(3, 0x40, testCB);
-
-	g_SynchronousEventMgr.Insert(&syncEvent0);
-	g_SynchronousEventMgr.Insert(&syncEvent1);
-	g_SynchronousEventMgr.Insert(&syncEvent2);
-	g_SynchronousEventMgr.Insert(&syncEvent3);
-	// id0 -> id1 -> id2 -> id3
-	_ASSERT(syncEvent0.m_cyclesRemaining == 0x10);
-	_ASSERT(syncEvent1.m_cyclesRemaining == 0x10);
-	_ASSERT(syncEvent2.m_cyclesRemaining == 0x10);
-	_ASSERT(syncEvent3.m_cyclesRemaining == 0x10);
-
-	g_SynchronousEventMgr.Remove(1);
-	g_SynchronousEventMgr.Remove(3);
-	g_SynchronousEventMgr.Remove(0);
-	_ASSERT(syncEvent2.m_cyclesRemaining == 0x30);
-	g_SynchronousEventMgr.Remove(2);
-
-	//
-
-	syncEvent0.m_cyclesRemaining = 0x40;
-	syncEvent1.m_cyclesRemaining = 0x30;
-	syncEvent2.m_cyclesRemaining = 0x20;
-	syncEvent3.m_cyclesRemaining = 0x10;
-
-	g_SynchronousEventMgr.Insert(&syncEvent0);
-	g_SynchronousEventMgr.Insert(&syncEvent1);
-	g_SynchronousEventMgr.Insert(&syncEvent2);
-	g_SynchronousEventMgr.Insert(&syncEvent3);
-	// id3 -> id2 -> id1 -> id0
-	_ASSERT(syncEvent0.m_cyclesRemaining == 0x10);
-	_ASSERT(syncEvent1.m_cyclesRemaining == 0x10);
-	_ASSERT(syncEvent2.m_cyclesRemaining == 0x10);
-	_ASSERT(syncEvent3.m_cyclesRemaining == 0x10);
-
-	g_SynchronousEventMgr.Remove(3);
-	g_SynchronousEventMgr.Remove(0);
-	g_SynchronousEventMgr.Remove(1);
-	_ASSERT(syncEvent2.m_cyclesRemaining == 0x20);
-	g_SynchronousEventMgr.Remove(2);
-}
-
-//===========================================================================
-
 #ifdef LOG_PERF_TIMINGS
 static UINT64 g_timeTotal = 0;
 UINT64 g_timeCpu = 0;
@@ -1437,8 +1383,6 @@ static CmdLine g_cmdLine;
 
 int APIENTRY WinMain(HINSTANCE passinstance, HINSTANCE, LPSTR lpCmdLine, int)
 {
-	SyncEventTest();
-
 	char startDir[_MAX_PATH];
 	GetCurrentDirectory(sizeof(startDir), startDir);
 	g_sStartDir = startDir;

--- a/source/Applewin.cpp
+++ b/source/Applewin.cpp
@@ -2276,8 +2276,6 @@ static void RepeatInitialization(void)
 				g_cmdLine.bBoot = false;
 			}
 		}
-
-//		SetMouseCardInstalled( g_CardMgr.IsMouseCardInstalled() );
 }
 
 static void Shutdown(void)

--- a/source/Applewin.cpp
+++ b/source/Applewin.cpp
@@ -127,7 +127,7 @@ CSpeech		g_Speech;
 
 //===========================================================================
 
-int testCB(int syncEventId)
+int testCB(int id, int underflowCycles)
 {
 	return 0;
 }
@@ -139,10 +139,10 @@ void SyncEventTest(void)
 	SyncEvent syncEvent2(2, 0x30, testCB);
 	SyncEvent syncEvent3(3, 0x40, testCB);
 
-	g_SynchronousEventMgr.Add(&syncEvent0);
-	g_SynchronousEventMgr.Add(&syncEvent1);
-	g_SynchronousEventMgr.Add(&syncEvent2);
-	g_SynchronousEventMgr.Add(&syncEvent3);
+	g_SynchronousEventMgr.Insert(&syncEvent0);
+	g_SynchronousEventMgr.Insert(&syncEvent1);
+	g_SynchronousEventMgr.Insert(&syncEvent2);
+	g_SynchronousEventMgr.Insert(&syncEvent3);
 	// id0 -> id1 -> id2 -> id3
 	_ASSERT(syncEvent0.m_cyclesRemaining == 0x10);
 	_ASSERT(syncEvent1.m_cyclesRemaining == 0x10);
@@ -162,10 +162,10 @@ void SyncEventTest(void)
 	syncEvent2.m_cyclesRemaining = 0x20;
 	syncEvent3.m_cyclesRemaining = 0x10;
 
-	g_SynchronousEventMgr.Add(&syncEvent0);
-	g_SynchronousEventMgr.Add(&syncEvent1);
-	g_SynchronousEventMgr.Add(&syncEvent2);
-	g_SynchronousEventMgr.Add(&syncEvent3);
+	g_SynchronousEventMgr.Insert(&syncEvent0);
+	g_SynchronousEventMgr.Insert(&syncEvent1);
+	g_SynchronousEventMgr.Insert(&syncEvent2);
+	g_SynchronousEventMgr.Insert(&syncEvent3);
 	// id3 -> id2 -> id1 -> id0
 	_ASSERT(syncEvent0.m_cyclesRemaining == 0x10);
 	_ASSERT(syncEvent1.m_cyclesRemaining == 0x10);

--- a/source/Applewin.cpp
+++ b/source/Applewin.cpp
@@ -127,7 +127,7 @@ CSpeech		g_Speech;
 
 //===========================================================================
 
-int testCB(int id, int underflowCycles)
+int testCB(int id, int underflowCycles, ULONG uExecutedCycles)
 {
 	return 0;
 }

--- a/source/Applewin.cpp
+++ b/source/Applewin.cpp
@@ -1483,7 +1483,8 @@ int APIENTRY WinMain(HINSTANCE passinstance, HINSTANCE, LPSTR lpCmdLine, int)
 			DSUninit();
 			LogFileOutput("Main: DSUninit()\n");
 
-			g_SynchronousEventMgr.Reset();
+			if (g_bRestart)
+				g_SynchronousEventMgr.Reset();
 
 			if (g_bHookSystemKey)
 			{
@@ -2276,7 +2277,7 @@ static void RepeatInitialization(void)
 			}
 		}
 
-		SetMouseCardInstalled( g_CardMgr.IsMouseCardInstalled() );
+//		SetMouseCardInstalled( g_CardMgr.IsMouseCardInstalled() );
 }
 
 static void Shutdown(void)

--- a/source/Applewin.h
+++ b/source/Applewin.h
@@ -53,6 +53,7 @@ extern bool       g_bDisableDirectSoundMockingboard;	// Cmd line switch: don't i
 extern int        g_nMemoryClearType;					// Cmd line switch: use specific MIP (Memory Initialization Pattern)
 
 extern class CardManager g_CardMgr;
+extern class SynchronousEventManager g_SynchronousEventMgr;
 
 extern HANDLE	g_hCustomRomF8;		// INVALID_HANDLE_VALUE if no custom F8 rom
 extern HANDLE	g_hCustomRom;		// INVALID_HANDLE_VALUE if no custom rom
@@ -63,42 +64,6 @@ extern CSpeech g_Speech;
 #endif
 
 extern __interface IPropertySheet& sg_PropertySheet;
-
-//
-
-typedef int (*syncEventCB)(int id);
-
-class SyncEvent;
-extern SyncEvent* g_syncEventHead;
-void SyncEventAdd(SyncEvent* pNewEvent);
-
-class SyncEvent
-{
-public:
-	SyncEvent(int id, int initCycles, syncEventCB callback)
-		: m_id(id), m_cyclesRemaining(initCycles), m_callback(callback), m_next(NULL)
-	{}
-	~SyncEvent(){}
-
-	void Update(int cycles)
-	{
-		m_cyclesRemaining -= cycles;
-		if (m_cyclesRemaining < 0)
-		{
-			m_cyclesRemaining = m_callback(m_id);
-			g_syncEventHead = m_next;	// unlink this event
-			m_next = NULL;
-
-			if (m_cyclesRemaining)
-				SyncEventAdd(this);			// re-add event
-		}
-	}
-
-	int m_id;
-	int m_cyclesRemaining;
-	syncEventCB m_callback;
-	SyncEvent* m_next;
-};
 
 //
 

--- a/source/CPU.cpp
+++ b/source/CPU.cpp
@@ -96,6 +96,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #ifdef USE_SPEECH_API
 #include "Speech.h"
 #endif
+#include "SynchronousEventManager.h"
 #include "Video.h"
 #include "NTSC.h"
 #include "Log.h"
@@ -472,10 +473,7 @@ void CpuAdjustIrqCheck(UINT uCyclesUntilInterrupt)
 
 static __forceinline void CheckSynchronousInterruptSources(UINT cycles)
 {
-	if (!g_syncEventHead)
-		return;
-
-	g_syncEventHead->Update(cycles);
+	g_SynchronousEventMgr.Update(cycles);
 }
 
 //===========================================================================

--- a/source/CPU.cpp
+++ b/source/CPU.cpp
@@ -404,9 +404,9 @@ static __forceinline void NMI(ULONG& uExecutedCycles, BOOL& flagc, BOOL& flagn, 
 #endif
 }
 
-static __forceinline void CheckSynchronousInterruptSources(UINT cycles)
+static __forceinline void CheckSynchronousInterruptSources(UINT cycles, ULONG uExecutedCycles)
 {
-	g_SynchronousEventMgr.Update(cycles);
+	g_SynchronousEventMgr.Update(cycles, uExecutedCycles);
 }
 
 // NB. No need to save to save-state, as IRQ() follows CheckInterruptSources(), and IRQ() always sets it to false.
@@ -441,7 +441,7 @@ static __forceinline void IRQ(ULONG& uExecutedCycles, BOOL& flagc, BOOL& flagn, 
 #if defined(_DEBUG) && LOG_IRQ_TAKEN_AND_RTI
 		LogOutput("IRQ\n");
 #endif
-		CheckSynchronousInterruptSources(7);
+		CheckSynchronousInterruptSources(7, uExecutedCycles);
 	}
 
 	g_irqOnLastOpcodeCycle = false;

--- a/source/CPU.cpp
+++ b/source/CPU.cpp
@@ -409,7 +409,7 @@ static __forceinline void CheckSynchronousInterruptSources(UINT cycles, ULONG uE
 	g_SynchronousEventMgr.Update(cycles, uExecutedCycles);
 }
 
-// NB. No need to save to save-state, as IRQ() follows CheckInterruptSources(), and IRQ() always sets it to false.
+// NB. No need to save to save-state, as IRQ() follows CheckSynchronousInterruptSources(), and IRQ() always sets it to false.
 bool g_irqOnLastOpcodeCycle = false;
 
 static __forceinline void IRQ(ULONG& uExecutedCycles, BOOL& flagc, BOOL& flagn, BOOL& flagv, BOOL& flagz)
@@ -466,14 +466,6 @@ static __forceinline void CheckInterruptSources(ULONG uExecutedCycles, const boo
 
 	if (g_isMouseCardInstalled)
 		g_CardMgr.GetMouseCard()->SetVBlank( !VideoGetVblBar(uExecutedCycles) );
-}
-
-// GH#608: IRQ needs to occur within 17 cycles (6 opcodes) of configuring the timer interrupt
-void CpuAdjustIrqCheck(UINT uCyclesUntilInterrupt)
-{
-	const UINT opcodesUntilInterrupt = uCyclesUntilInterrupt/3;	// assume 3 cycles per opcode
-	if (g_bFullSpeed && opcodesUntilInterrupt < IRQ_CHECK_OPCODE_FULL_SPEED)
-		g_fullSpeedOpcodeCount = opcodesUntilInterrupt;
 }
 #endif
 

--- a/source/CPU.cpp
+++ b/source/CPU.cpp
@@ -440,6 +440,7 @@ static __forceinline void IRQ(ULONG& uExecutedCycles, BOOL& flagc, BOOL& flagn, 
 	g_irqOnLastOpcodeCycle = false;
 }
 
+#if 0
 const int IRQ_CHECK_OPCODE_FULL_SPEED = 40;	// ~128 cycles (assume 3 cycles per opcode)
 static int g_fullSpeedOpcodeCount = IRQ_CHECK_OPCODE_FULL_SPEED;
 
@@ -466,6 +467,15 @@ void CpuAdjustIrqCheck(UINT uCyclesUntilInterrupt)
 	const UINT opcodesUntilInterrupt = uCyclesUntilInterrupt/3;	// assume 3 cycles per opcode
 	if (g_bFullSpeed && opcodesUntilInterrupt < IRQ_CHECK_OPCODE_FULL_SPEED)
 		g_fullSpeedOpcodeCount = opcodesUntilInterrupt;
+}
+#endif
+
+static __forceinline void CheckSynchronousInterruptSources(UINT cycles)
+{
+	if (!g_syncEventHead)
+		return;
+
+	g_syncEventHead->Update(cycles);
 }
 
 //===========================================================================

--- a/source/CPU.cpp
+++ b/source/CPU.cpp
@@ -404,6 +404,11 @@ static __forceinline void NMI(ULONG& uExecutedCycles, BOOL& flagc, BOOL& flagn, 
 #endif
 }
 
+static __forceinline void CheckSynchronousInterruptSources(UINT cycles)
+{
+	g_SynchronousEventMgr.Update(cycles);
+}
+
 // NB. No need to save to save-state, as IRQ() follows CheckInterruptSources(), and IRQ() always sets it to false.
 static bool g_irqOnLastOpcodeCycle = false;
 
@@ -436,6 +441,7 @@ static __forceinline void IRQ(ULONG& uExecutedCycles, BOOL& flagc, BOOL& flagn, 
 #if defined(_DEBUG) && LOG_IRQ_TAKEN_AND_RTI
 		LogOutput("IRQ\n");
 #endif
+		CheckSynchronousInterruptSources(7);
 	}
 
 	g_irqOnLastOpcodeCycle = false;
@@ -470,11 +476,6 @@ void CpuAdjustIrqCheck(UINT uCyclesUntilInterrupt)
 		g_fullSpeedOpcodeCount = opcodesUntilInterrupt;
 }
 #endif
-
-static __forceinline void CheckSynchronousInterruptSources(UINT cycles)
-{
-	g_SynchronousEventMgr.Update(cycles);
-}
 
 //===========================================================================
 

--- a/source/CPU.cpp
+++ b/source/CPU.cpp
@@ -150,8 +150,6 @@ static volatile BOOL g_bNmiFlank = FALSE; // Positive going flank on NMI line
 
 static bool g_irqDefer1Opcode = false;
 
-//static bool g_isMouseCardInstalled = false;
-
 //
 
 static eCpuType g_MainCPU = CPU_65C02;
@@ -206,11 +204,6 @@ void ResetCyclesExecutedForDebugger(void)
 {
 	g_nCyclesExecuted = 0;
 }
-
-//void SetMouseCardInstalled(bool installed)
-//{
-//	g_isMouseCardInstalled = installed;
-//}
 
 //
 
@@ -446,28 +439,6 @@ static __forceinline void IRQ(ULONG& uExecutedCycles, BOOL& flagc, BOOL& flagn, 
 
 	g_irqOnLastOpcodeCycle = false;
 }
-
-#if 0
-const int IRQ_CHECK_OPCODE_FULL_SPEED = 40;	// ~128 cycles (assume 3 cycles per opcode)
-static int g_fullSpeedOpcodeCount = IRQ_CHECK_OPCODE_FULL_SPEED;
-
-static __forceinline void CheckInterruptSources(ULONG uExecutedCycles, const bool bVideoUpdate)
-{
-	if (!bVideoUpdate)
-	{
-		g_fullSpeedOpcodeCount--;
-		if (g_fullSpeedOpcodeCount >= 0)
-			return;
-		g_fullSpeedOpcodeCount = IRQ_CHECK_OPCODE_FULL_SPEED;
-	}
-
-	if (MB_UpdateCycles(uExecutedCycles))
-		g_irqOnLastOpcodeCycle = true;
-
-	if (g_isMouseCardInstalled)
-		g_CardMgr.GetMouseCard()->SetVBlank( !VideoGetVblBar(uExecutedCycles) );
-}
-#endif
 
 //===========================================================================
 

--- a/source/CPU.cpp
+++ b/source/CPU.cpp
@@ -150,7 +150,7 @@ static volatile BOOL g_bNmiFlank = FALSE; // Positive going flank on NMI line
 
 static bool g_irqDefer1Opcode = false;
 
-static bool g_isMouseCardInstalled = false;
+//static bool g_isMouseCardInstalled = false;
 
 //
 
@@ -207,10 +207,10 @@ void ResetCyclesExecutedForDebugger(void)
 	g_nCyclesExecuted = 0;
 }
 
-void SetMouseCardInstalled(bool installed)
-{
-	g_isMouseCardInstalled = installed;
-}
+//void SetMouseCardInstalled(bool installed)
+//{
+//	g_isMouseCardInstalled = installed;
+//}
 
 //
 
@@ -507,7 +507,7 @@ static __forceinline void CheckInterruptSources(ULONG uExecutedCycles, const boo
 
 static DWORD InternalCpuExecute(const DWORD uTotalCycles, const bool bVideoUpdate)
 {
-	if (g_nAppMode == MODE_RUNNING)
+	if (g_nAppMode == MODE_RUNNING || g_nAppMode == MODE_BENCHMARK)
 	{
 		if (GetMainCpu() == CPU_6502)
 			return Cpu6502(uTotalCycles, bVideoUpdate);		// Apple ][, ][+, //e, Clones

--- a/source/CPU.cpp
+++ b/source/CPU.cpp
@@ -410,7 +410,7 @@ static __forceinline void CheckSynchronousInterruptSources(UINT cycles)
 }
 
 // NB. No need to save to save-state, as IRQ() follows CheckInterruptSources(), and IRQ() always sets it to false.
-static bool g_irqOnLastOpcodeCycle = false;
+bool g_irqOnLastOpcodeCycle = false;
 
 static __forceinline void IRQ(ULONG& uExecutedCycles, BOOL& flagc, BOOL& flagn, BOOL& flagv, BOOL& flagz)
 {

--- a/source/CPU.h
+++ b/source/CPU.h
@@ -44,4 +44,4 @@ void     SetActiveCpu(eCpuType cpu);
 
 bool Is6502InterruptEnabled(void);
 void ResetCyclesExecutedForDebugger(void);
-void SetMouseCardInstalled(bool installed);
+//void SetMouseCardInstalled(bool installed);

--- a/source/CPU.h
+++ b/source/CPU.h
@@ -14,7 +14,6 @@ struct regsrec
 extern regsrec    regs;
 extern unsigned __int64 g_nCumulativeCycles;
 
-//void    CpuAdjustIrqCheck(UINT uCyclesUntilInterrupt);
 void    CpuDestroy ();
 void    CpuCalcCycles(ULONG nExecutedCycles);
 DWORD   CpuExecute(const DWORD uCycles, const bool bVideoUpdate);

--- a/source/CPU.h
+++ b/source/CPU.h
@@ -14,7 +14,7 @@ struct regsrec
 extern regsrec    regs;
 extern unsigned __int64 g_nCumulativeCycles;
 
-void    CpuAdjustIrqCheck(UINT uCyclesUntilInterrupt);
+//void    CpuAdjustIrqCheck(UINT uCyclesUntilInterrupt);
 void    CpuDestroy ();
 void    CpuCalcCycles(ULONG nExecutedCycles);
 DWORD   CpuExecute(const DWORD uCycles, const bool bVideoUpdate);

--- a/source/CPU.h
+++ b/source/CPU.h
@@ -44,4 +44,3 @@ void     SetActiveCpu(eCpuType cpu);
 
 bool Is6502InterruptEnabled(void);
 void ResetCyclesExecutedForDebugger(void);
-//void SetMouseCardInstalled(bool installed);

--- a/source/CPU/cpu6502.h
+++ b/source/CPU/cpu6502.h
@@ -318,7 +318,7 @@ static DWORD Cpu6502(DWORD uTotalCycles, const bool bVideoUpdate)
 		}
 
 //		CheckInterruptSources(uExecutedCycles, bVideoUpdate);
-		CheckSynchronousInterruptSources(uExecutedCycles - uPreviousCycles);
+		CheckSynchronousInterruptSources(uExecutedCycles - uPreviousCycles, uExecutedCycles);
 		NMI(uExecutedCycles, flagc, flagn, flagv, flagz);
 		IRQ(uExecutedCycles, flagc, flagn, flagv, flagz);
 

--- a/source/CPU/cpu6502.h
+++ b/source/CPU/cpu6502.h
@@ -317,7 +317,6 @@ static DWORD Cpu6502(DWORD uTotalCycles, const bool bVideoUpdate)
 			}
 		}
 
-//		CheckInterruptSources(uExecutedCycles, bVideoUpdate);
 		CheckSynchronousInterruptSources(uExecutedCycles - uPreviousCycles, uExecutedCycles);
 		NMI(uExecutedCycles, flagc, flagn, flagv, flagz);
 		IRQ(uExecutedCycles, flagc, flagn, flagv, flagz);

--- a/source/CPU/cpu6502.h
+++ b/source/CPU/cpu6502.h
@@ -317,7 +317,8 @@ static DWORD Cpu6502(DWORD uTotalCycles, const bool bVideoUpdate)
 			}
 		}
 
-		CheckInterruptSources(uExecutedCycles, bVideoUpdate);
+//		CheckInterruptSources(uExecutedCycles, bVideoUpdate);
+		CheckSynchronousInterruptSources(uExecutedCycles - uPreviousCycles);
 		NMI(uExecutedCycles, flagc, flagn, flagv, flagz);
 		IRQ(uExecutedCycles, flagc, flagn, flagv, flagz);
 

--- a/source/CPU/cpu65C02.h
+++ b/source/CPU/cpu65C02.h
@@ -318,7 +318,7 @@ static DWORD Cpu65C02(DWORD uTotalCycles, const bool bVideoUpdate)
 		}
 
 //		CheckInterruptSources(uExecutedCycles, bVideoUpdate);
-		CheckSynchronousInterruptSources(uExecutedCycles - uPreviousCycles);
+		CheckSynchronousInterruptSources(uExecutedCycles - uPreviousCycles, uExecutedCycles);
 		NMI(uExecutedCycles, flagc, flagn, flagv, flagz);
 		IRQ(uExecutedCycles, flagc, flagn, flagv, flagz);
 

--- a/source/CPU/cpu65C02.h
+++ b/source/CPU/cpu65C02.h
@@ -317,7 +317,8 @@ static DWORD Cpu65C02(DWORD uTotalCycles, const bool bVideoUpdate)
 			}
 		}
 
-		CheckInterruptSources(uExecutedCycles, bVideoUpdate);
+//		CheckInterruptSources(uExecutedCycles, bVideoUpdate);
+		CheckSynchronousInterruptSources(uExecutedCycles - uPreviousCycles);
 		NMI(uExecutedCycles, flagc, flagn, flagv, flagz);
 		IRQ(uExecutedCycles, flagc, flagn, flagv, flagz);
 

--- a/source/CPU/cpu65C02.h
+++ b/source/CPU/cpu65C02.h
@@ -317,7 +317,6 @@ static DWORD Cpu65C02(DWORD uTotalCycles, const bool bVideoUpdate)
 			}
 		}
 
-//		CheckInterruptSources(uExecutedCycles, bVideoUpdate);
 		CheckSynchronousInterruptSources(uExecutedCycles - uPreviousCycles, uExecutedCycles);
 		NMI(uExecutedCycles, flagc, flagn, flagv, flagz);
 		IRQ(uExecutedCycles, flagc, flagn, flagv, flagz);

--- a/source/Common.h
+++ b/source/Common.h
@@ -24,6 +24,7 @@ enum AppMode_e
 	, MODE_RUNNING  // 6502 is running at normal/full speed (Debugger breakpoints may or may not be active)
 	, MODE_DEBUG    // 6502 is paused
 	, MODE_STEPPING // 6502 is running at normal/full speed (Debugger breakpoints always active)
+	, MODE_BENCHMARK
 };
 
 #define  SPEED_MIN         0

--- a/source/Frame.cpp
+++ b/source/Frame.cpp
@@ -1911,10 +1911,11 @@ LRESULT CALLBACK FrameWndProc (
     case WM_USER_BENCHMARK: {
       UpdateWindow(window);
       ResetMachineState();
-      g_nAppMode = MODE_LOGO;
       DrawStatusArea((HDC)0,DRAW_TITLE);
       HCURSOR oldcursor = SetCursor(LoadCursor(0,IDC_WAIT));
+      g_nAppMode = MODE_BENCHMARK;
       VideoBenchmark();
+      g_nAppMode = MODE_LOGO;
       ResetMachineState();
       SetCursor(oldcursor);
       break;

--- a/source/Mockingboard.cpp
+++ b/source/Mockingboard.cpp
@@ -518,12 +518,12 @@ static void SY6522_Write(BYTE nDevice, BYTE nReg, BYTE nValue)
 			pMB->sy6522.TIMER1_LATCH.l = nValue;
 			break;
 		case 0x05:	// TIMER1H_COUNTER
-			UpdateIFR(pMB, IxR_TIMER1);				// Clear Timer Interrupt Flag
-			pMB->sy6522.TIMER1_LATCH.h = nValue;
-			StartTimer1(pMB);
 			{
+				UpdateIFR(pMB, IxR_TIMER1);			// Clear Timer Interrupt Flag
+				pMB->sy6522.TIMER1_LATCH.h = nValue;
 				const UINT id = nDevice*kNumTimersPer6522+0;	// TIMER1
 				pMB->sy6522.TIMER1_COUNTER.w = SetTimerSyncEvent(id, nReg, pMB->sy6522.TIMER1_LATCH.w);
+				StartTimer1(pMB);
 			}
 			break;
 		case 0x07:	// TIMER1H_LATCH
@@ -534,12 +534,12 @@ static void SY6522_Write(BYTE nDevice, BYTE nReg, BYTE nValue)
 			pMB->sy6522.TIMER2_LATCH.l = nValue;
 			break;
 		case 0x09:	// TIMER2H
-			UpdateIFR(pMB, IxR_TIMER2);				// Clear Timer2 Interrupt Flag
-			pMB->sy6522.TIMER2_LATCH.h = nValue;	// NB. Real 6522 doesn't have TIMER2_LATCH.h
-			StartTimer2(pMB);
 			{
+				UpdateIFR(pMB, IxR_TIMER2);			// Clear Timer2 Interrupt Flag
+				pMB->sy6522.TIMER2_LATCH.h = nValue;	// NB. Real 6522 doesn't have TIMER2_LATCH.h
 				const UINT id = nDevice*kNumTimersPer6522+1;	// TIMER2
 				pMB->sy6522.TIMER2_COUNTER.w = SetTimerSyncEvent(id, nReg, pMB->sy6522.TIMER2_LATCH.w);
+				StartTimer2(pMB);
 			}
 			break;
 		case 0x0a:	// SERIAL_SHIFT

--- a/source/Mockingboard.cpp
+++ b/source/Mockingboard.cpp
@@ -437,7 +437,7 @@ static void SY6522_Write(BYTE nDevice, BYTE nReg, BYTE nValue)
 			UpdateIFR(pMB, IxR_TIMER1);
 
 			pMB->sy6522.TIMER1_LATCH.h = nValue;
-			pMB->bLoadT1C = true;
+//			pMB->bLoadT1C = true;
 
 			StartTimer1(pMB);
 //			CpuAdjustIrqCheck(pMB->sy6522.TIMER1_LATCH.w);	// Sync IRQ check timeout with 6522 counter underflow - GH#608
@@ -448,7 +448,7 @@ static void SY6522_Write(BYTE nDevice, BYTE nReg, BYTE nValue)
 					 (mem[regs.pc-3] == 0x8D) ||	// STA abs16
 					 (mem[regs.pc-3] == 0x8E) )		// STX abs16
 				{
-					opcodeCycleAdjust = 4;
+					opcodeCycleAdjust = 4;			// Same as the bLoadT1C flag
 				}
 
 				UINT id = nDevice*2+0;						// TIMER1

--- a/source/Mockingboard.cpp
+++ b/source/Mockingboard.cpp
@@ -1626,7 +1626,6 @@ static void ResetState()
 	{
 		if (g_syncEvent[id] && g_syncEvent[id]->m_active)
 			g_SynchronousEventMgr.Remove(id);
-
 	}
 
 	// Not these, as they don't change on a CTRL+RESET or power-cycle:
@@ -2028,7 +2027,7 @@ void MB_UpdateCycles(ULONG uExecutedCycles)
 		return;
 
 	g_uLastCumulativeCycles = g_nCumulativeCycles;
-	_ASSERT(uCycles < 0x10000);
+	_ASSERT(uCycles < 0x10000 || g_nAppMode == MODE_BENCHMARK);
 	USHORT nClocks = (USHORT)uCycles;
 
 	for (int i = 0; i < NUM_SY6522; i++)

--- a/source/Mockingboard.cpp
+++ b/source/Mockingboard.cpp
@@ -519,7 +519,7 @@ static void SY6522_Write(BYTE nDevice, BYTE nReg, BYTE nValue)
 			break;
 		case 0x05:	// TIMER1H_COUNTER
 			{
-				UpdateIFR(pMB, IxR_TIMER1);			// Clear Timer Interrupt Flag
+				UpdateIFR(pMB, IxR_TIMER1);			// Clear Timer1 Interrupt Flag
 				pMB->sy6522.TIMER1_LATCH.h = nValue;
 				const UINT id = nDevice*kNumTimersPer6522+0;	// TIMER1
 				pMB->sy6522.TIMER1_COUNTER.w = SetTimerSyncEvent(id, nReg, pMB->sy6522.TIMER1_LATCH.w);

--- a/source/Mockingboard.cpp
+++ b/source/Mockingboard.cpp
@@ -224,7 +224,7 @@ static UINT g_cyclesThisAudioFrame = 0;
 // Forward refs:
 static DWORD WINAPI SSI263Thread(LPVOID);
 static void Votrax_Write(BYTE nDevice, BYTE nValue);
-static int MB_SyncEventCallback(int id, ULONG uExecutedCycles);
+static int MB_SyncEventCallback(int id, int cycles, ULONG uExecutedCycles);
 
 //---------------------------------------------------------------------------
 
@@ -2108,7 +2108,7 @@ void MB_UpdateCycles(ULONG uExecutedCycles)
 
 //-----------------------------------------------------------------------------
 
-static int MB_SyncEventCallback(int id, ULONG uExecutedCycles)
+static int MB_SyncEventCallback(int id, int /*cycles*/, ULONG uExecutedCycles)
 {
 	SY6522_AY8910* pMB = &g_MB[id / kNumTimersPer6522];
 

--- a/source/Mockingboard.h
+++ b/source/Mockingboard.h
@@ -16,7 +16,7 @@ void    MB_CheckCumulativeCycles();	// DEBUG
 void    MB_SetCumulativeCycles();
 void    MB_PeriodicUpdate(UINT executedCycles);
 void    MB_CheckIRQ();
-bool    MB_UpdateCycles(ULONG uExecutedCycles);
+void    MB_UpdateCycles(ULONG uExecutedCycles);
 SS_CARDTYPE MB_GetSoundcardType();
 bool    MB_IsActive();
 DWORD   MB_GetVolume();

--- a/source/MouseInterface.cpp
+++ b/source/MouseInterface.cpp
@@ -493,7 +493,7 @@ void CMouseInterface::SetVBlank(void)
 	OnMouseEvent(true);
 }
 
-int CMouseInterface::SyncEventCallback(int id, int underflowCycles, ULONG uExecutedCycles)
+int CMouseInterface::SyncEventCallback(int id, ULONG uExecutedCycles)
 {
 	g_CardMgr.GetMouseCard()->SetVBlank();
 	return NTSC_GetCyclesUntilVBlank();

--- a/source/MouseInterface.cpp
+++ b/source/MouseInterface.cpp
@@ -193,7 +193,7 @@ void CMouseInterface::Initialize(LPBYTE pCxRomPeripheral, UINT uSlot)
 	RegisterIoHandler(uSlot, &CMouseInterface::IORead, &CMouseInterface::IOWrite, NULL, NULL, this, NULL);
 
 	if (m_syncEvent.m_active) g_SynchronousEventMgr.Remove(m_syncEvent.m_id);
-	m_syncEvent.m_cyclesRemaining = NTSC_GetCyclesUntilVBlank();
+	m_syncEvent.m_cyclesRemaining = NTSC_GetCyclesUntilVBlank(0);
 	g_SynchronousEventMgr.Insert(&m_syncEvent);
 }
 
@@ -488,15 +488,10 @@ void CMouseInterface::OnMouseEvent(bool bEventVBL)
 	}
 }
 
-void CMouseInterface::SetVBlank(void)
+int CMouseInterface::SyncEventCallback(int id, int cycles, ULONG /*uExecutedCycles*/)
 {
-	OnMouseEvent(true);
-}
-
-int CMouseInterface::SyncEventCallback(int id, ULONG uExecutedCycles)
-{
-	g_CardMgr.GetMouseCard()->SetVBlank();
-	return NTSC_GetCyclesUntilVBlank();
+	g_CardMgr.GetMouseCard()->OnMouseEvent(true);
+	return NTSC_GetCyclesUntilVBlank(cycles);
 }
 
 void CMouseInterface::Clear()

--- a/source/MouseInterface.h
+++ b/source/MouseInterface.h
@@ -24,7 +24,6 @@ public:
 	bool IsEnabled() { return m_bEnabled; }	// NB. m_bEnabled == true implies that m_bActive == true
 	bool IsActiveAndEnabled() { return /*IsActive() &&*/ IsEnabled(); }	// todo: just use IsEnabled()
 	void SetEnabled(bool bEnabled) { m_bEnabled = bEnabled; }
-	void SetVBlank(void);
 	void GetXY(int& iX, int& iMinX, int& iMaxX, int& iY, int& iMinY, int& iMaxY)
 	{
 		iX    = m_iX;
@@ -63,7 +62,7 @@ protected:
 	void SetClampX(int iMinX, int iMaxX);
 	void SetClampY(int iMinY, int iMaxY);
 
-	static int SyncEventCallback(int id, ULONG uExecutedCycles);
+	static int SyncEventCallback(int id, int cycles, ULONG uExecutedCycles);
 
 	void SaveSnapshotMC6821(class YamlSaveHelper& yamlSaveHelper, std::string key);
 	void LoadSnapshotMC6821(class YamlLoadHelper& yamlLoadHelper, std::string key);

--- a/source/MouseInterface.h
+++ b/source/MouseInterface.h
@@ -1,6 +1,7 @@
 #include "6821.h"
 #include "Common.h"
 #include "Card.h"
+#include "SynchronousEventManager.h"
 
 class CMouseInterface : public Card
 {
@@ -23,7 +24,7 @@ public:
 	bool IsEnabled() { return m_bEnabled; }	// NB. m_bEnabled == true implies that m_bActive == true
 	bool IsActiveAndEnabled() { return /*IsActive() &&*/ IsEnabled(); }	// todo: just use IsEnabled()
 	void SetEnabled(bool bEnabled) { m_bEnabled = bEnabled; }
-	void SetVBlank(bool bVBL);
+	void SetVBlank(void);
 	void GetXY(int& iX, int& iMinX, int& iMaxX, int& iY, int& iMinY, int& iMaxY)
 	{
 		iX    = m_iX;
@@ -61,6 +62,8 @@ protected:
 	int ClampY();
 	void SetClampX(int iMinX, int iMaxX);
 	void SetClampY(int iMinY, int iMaxY);
+
+	static int SyncEventCallback(int id, int underflowCycles, ULONG uExecutedCycles);
 
 	void SaveSnapshotMC6821(class YamlSaveHelper& yamlSaveHelper, std::string key);
 	void LoadSnapshotMC6821(class YamlLoadHelper& yamlLoadHelper, std::string key);
@@ -102,6 +105,8 @@ protected:
 	bool	m_bEnabled;		// Windows' mouse events get passed to Apple]['s mouse h/w (m_bEnabled == true implies that m_bActive == true)
 	LPBYTE	m_pSlotRom;
 	UINT	m_uSlot;
+
+	SyncEvent m_syncEvent;
 };
 
 namespace DIMouse

--- a/source/MouseInterface.h
+++ b/source/MouseInterface.h
@@ -63,7 +63,7 @@ protected:
 	void SetClampX(int iMinX, int iMaxX);
 	void SetClampY(int iMinY, int iMaxY);
 
-	static int SyncEventCallback(int id, int underflowCycles, ULONG uExecutedCycles);
+	static int SyncEventCallback(int id, ULONG uExecutedCycles);
 
 	void SaveSnapshotMC6821(class YamlSaveHelper& yamlSaveHelper, std::string key);
 	void LoadSnapshotMC6821(class YamlLoadHelper& yamlLoadHelper, std::string key);

--- a/source/NTSC.cpp
+++ b/source/NTSC.cpp
@@ -2609,6 +2609,19 @@ UINT NTSC_GetVideoLines(void)
 	return (GetVideoRefreshRate() == VR_50HZ) ? VIDEO_SCANNER_MAX_VERT_PAL : VIDEO_SCANNER_MAX_VERT;
 }
 
+// Get cycles until rising Vbl edge: !VBl -> VBl at (0,192)
+// . need to ensure that event occurs just after VBl edge, so use h=7 (where longest opcode is 7 cycles)
+// . NB. Called from CMouseInterface::SyncEventCallback(), which occurs before NTSC_VideoUpdateCycles(), so g_nVideoClockVert/Horz will be behind
+UINT NTSC_GetCyclesUntilVBlank(void)
+{
+	const UINT cycleVBl = VIDEO_SCANNER_Y_DISPLAY * VIDEO_SCANNER_MAX_HORZ;
+	const UINT cycleCurrentPos = g_nVideoClockVert * VIDEO_SCANNER_MAX_HORZ + g_nVideoClockHorz;
+
+	return (cycleCurrentPos < cycleVBl) ?
+		((cycleVBl+7) - cycleCurrentPos) :
+		(NTSC_GetCyclesPerFrame() - cycleCurrentPos + (cycleVBl+7));
+}
+
 bool NTSC_IsVisible(void)
 {
 	return (g_nVideoClockVert < VIDEO_SCANNER_Y_DISPLAY) && (g_nVideoClockHorz >= VIDEO_SCANNER_HORZ_START);

--- a/source/NTSC.h
+++ b/source/NTSC.h
@@ -23,4 +23,5 @@
 	UINT NTSC_GetCyclesPerFrame(void);
 	UINT NTSC_GetCyclesPerLine(void);
 	UINT NTSC_GetVideoLines(void);
+	UINT NTSC_GetCyclesUntilVBlank(void);
 	bool NTSC_IsVisible(void);

--- a/source/NTSC.h
+++ b/source/NTSC.h
@@ -23,5 +23,5 @@
 	UINT NTSC_GetCyclesPerFrame(void);
 	UINT NTSC_GetCyclesPerLine(void);
 	UINT NTSC_GetVideoLines(void);
-	UINT NTSC_GetCyclesUntilVBlank(void);
+	UINT NTSC_GetCyclesUntilVBlank(int cycles);
 	bool NTSC_IsVisible(void);

--- a/source/SaveState.cpp
+++ b/source/SaveState.cpp
@@ -479,7 +479,6 @@ static void Snapshot_LoadState_v2(void)
 
 		MemUpdatePaging(TRUE);
 
-//		SetMouseCardInstalled( g_CardMgr.IsMouseCardInstalled() );
 		DebugReset();
 		if (g_nAppMode == MODE_DEBUG)
 			DebugDisplay(TRUE);

--- a/source/SaveState.cpp
+++ b/source/SaveState.cpp
@@ -479,7 +479,7 @@ static void Snapshot_LoadState_v2(void)
 
 		MemUpdatePaging(TRUE);
 
-		SetMouseCardInstalled( g_CardMgr.IsMouseCardInstalled() );
+//		SetMouseCardInstalled( g_CardMgr.IsMouseCardInstalled() );
 		DebugReset();
 		if (g_nAppMode == MODE_DEBUG)
 			DebugDisplay(TRUE);

--- a/source/SynchronousEventManager.cpp
+++ b/source/SynchronousEventManager.cpp
@@ -127,7 +127,7 @@ bool SynchronousEventManager::Remove(int id)
 
 extern bool g_irqOnLastOpcodeCycle;
 
-void SynchronousEventManager::Update(int cycles)
+void SynchronousEventManager::Update(int cycles, ULONG uExecutedCycles)
 {
 	SyncEvent* pCurrEvent = m_syncEventHead;
 
@@ -142,14 +142,14 @@ void SynchronousEventManager::Update(int cycles)
 
 		int cyclesUnderflowed = -pCurrEvent->m_cyclesRemaining;
 
-		pCurrEvent->m_cyclesRemaining = pCurrEvent->m_callback(pCurrEvent->m_id, cyclesUnderflowed);
+		pCurrEvent->m_cyclesRemaining = pCurrEvent->m_callback(pCurrEvent->m_id, cyclesUnderflowed, uExecutedCycles);
 		m_syncEventHead = pCurrEvent->m_next;	// unlink this event
 
 		pCurrEvent->m_active = false;
 		pCurrEvent->m_next = NULL;
 
 		// Always Update even if cyclesUnderflowed=0, as next event may have cycleRemaining=0 (ie. the 2 events fire at the same time)
-		Update(cyclesUnderflowed);	// update (potential) next event with underflow cycles
+		Update(cyclesUnderflowed, uExecutedCycles);	// update (potential) next event with underflow cycles
 
 		if (pCurrEvent->m_cyclesRemaining)
 			Insert(pCurrEvent);	// re-add event

--- a/source/SynchronousEventManager.cpp
+++ b/source/SynchronousEventManager.cpp
@@ -1,0 +1,145 @@
+/*
+AppleWin : An Apple //e emulator for Windows
+
+Copyright (C) 1994-1996, Michael O'Brien
+Copyright (C) 1999-2001, Oliver Schmidt
+Copyright (C) 2002-2005, Tom Charlesworth
+Copyright (C) 2006-2020, Tom Charlesworth, Michael Pohoreski, Nick Westgate
+
+AppleWin is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+AppleWin is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with AppleWin; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+/* Description: Synchronous Event Manager
+ *
+ * Author: Various
+ *
+ */
+
+#include "StdAfx.h"
+
+#include "AppleWin.h"
+#include "SynchronousEventManager.h"
+
+void SynchronousEventManager::Add(SyncEvent* pNewEvent)
+{
+	pNewEvent->m_active = true;	// add always succeeds
+
+	if (!m_syncEventHead)
+	{
+		m_syncEventHead = pNewEvent;
+		return;
+	}
+
+	// walk list to find where to insert new event
+
+	SyncEvent* pPrevEvent = NULL;
+	SyncEvent* pCurrEvent = m_syncEventHead;
+	int newEventExtraCycles = pNewEvent->m_cyclesRemaining;
+
+	do
+	{
+		if (newEventExtraCycles >= pCurrEvent->m_cyclesRemaining)
+		{
+			newEventExtraCycles -= pCurrEvent->m_cyclesRemaining;
+			_ASSERT(newEventExtraCycles >= 0);
+		}
+		else
+		{
+			// insert new event
+			if (!pPrevEvent)
+				m_syncEventHead = pNewEvent;
+			else
+				pPrevEvent->m_next = pNewEvent;
+			pNewEvent->m_next = pCurrEvent;
+
+			pNewEvent->m_cyclesRemaining = newEventExtraCycles;
+
+			// update cycles for next event
+			if (pCurrEvent)
+			{
+				pCurrEvent->m_cyclesRemaining -= newEventExtraCycles;
+				_ASSERT(pCurrEvent->m_cyclesRemaining >= 0);
+			}
+
+			return;
+		}
+
+		pPrevEvent = pCurrEvent;
+		pCurrEvent = pCurrEvent->m_next;
+
+		if (!pCurrEvent)	// end of list
+		{
+			pPrevEvent->m_next = pNewEvent;
+			pNewEvent->m_cyclesRemaining = newEventExtraCycles;
+		}
+	}
+	while (pCurrEvent);
+}
+
+bool SynchronousEventManager::Remove(int id)
+{
+	SyncEvent* pPrevEvent = NULL;
+	SyncEvent* pCurrEvent = m_syncEventHead;
+
+	while (pCurrEvent)
+	{
+		if (pCurrEvent->m_id == id)
+		{
+			// remove event
+			if (!pPrevEvent)
+				m_syncEventHead = pCurrEvent->m_next;
+			else
+				pPrevEvent->m_next = pCurrEvent->m_next;
+
+			int oldEventExtraCycles = pCurrEvent->m_cyclesRemaining;
+			pPrevEvent = pCurrEvent;
+			pCurrEvent = pCurrEvent->m_next;
+
+			pPrevEvent->m_active = false;
+			pPrevEvent->m_next = NULL;
+
+			// update cycles for next event
+			if (pCurrEvent)
+				pCurrEvent->m_cyclesRemaining += oldEventExtraCycles;
+
+			return true;
+		}
+
+		pPrevEvent = pCurrEvent;
+		pCurrEvent = pCurrEvent->m_next;
+	}
+
+	_ASSERT(0);
+	return false;
+}
+
+void SynchronousEventManager::Update(int cycles)
+{
+	SyncEvent* pCurrEvent = m_syncEventHead;
+
+	if (!pCurrEvent)
+		return;
+
+	pCurrEvent->m_cyclesRemaining -= cycles;
+	if (pCurrEvent->m_cyclesRemaining < 0)
+	{
+		pCurrEvent->m_cyclesRemaining = pCurrEvent->m_callback(pCurrEvent->m_id);
+		m_syncEventHead = pCurrEvent->m_next;	// unlink this event
+		pCurrEvent->m_next = NULL;
+
+		if (pCurrEvent->m_cyclesRemaining)
+			Add(pCurrEvent);	// re-add event
+	}
+}

--- a/source/SynchronousEventManager.cpp
+++ b/source/SynchronousEventManager.cpp
@@ -125,6 +125,8 @@ bool SynchronousEventManager::Remove(int id)
 	return false;
 }
 
+extern bool g_irqOnLastOpcodeCycle;
+
 void SynchronousEventManager::Update(int cycles)
 {
 	SyncEvent* pCurrEvent = m_syncEventHead;
@@ -135,6 +137,9 @@ void SynchronousEventManager::Update(int cycles)
 	pCurrEvent->m_cyclesRemaining -= cycles;
 	if (pCurrEvent->m_cyclesRemaining <= 0)
 	{
+		if (pCurrEvent->m_cyclesRemaining == 0)
+			g_irqOnLastOpcodeCycle = true;		// IRQ occurs on last cycle of opcode
+
 		int cyclesUnderflowed = -pCurrEvent->m_cyclesRemaining;
 
 		pCurrEvent->m_cyclesRemaining = pCurrEvent->m_callback(pCurrEvent->m_id, cyclesUnderflowed);

--- a/source/SynchronousEventManager.cpp
+++ b/source/SynchronousEventManager.cpp
@@ -141,7 +141,7 @@ void SynchronousEventManager::Update(int cycles, ULONG uExecutedCycles)
 
 		int cyclesUnderflowed = -pCurrEvent->m_cyclesRemaining;
 
-		pCurrEvent->m_cyclesRemaining = pCurrEvent->m_callback(pCurrEvent->m_id, uExecutedCycles);
+		pCurrEvent->m_cyclesRemaining = pCurrEvent->m_callback(pCurrEvent->m_id, cycles, uExecutedCycles);
 		m_syncEventHead = pCurrEvent->m_next;	// unlink this event
 
 		pCurrEvent->m_active = false;

--- a/source/SynchronousEventManager.cpp
+++ b/source/SynchronousEventManager.cpp
@@ -142,7 +142,7 @@ void SynchronousEventManager::Update(int cycles, ULONG uExecutedCycles)
 
 		int cyclesUnderflowed = -pCurrEvent->m_cyclesRemaining;
 
-		pCurrEvent->m_cyclesRemaining = pCurrEvent->m_callback(pCurrEvent->m_id, cyclesUnderflowed, uExecutedCycles);
+		pCurrEvent->m_cyclesRemaining = pCurrEvent->m_callback(pCurrEvent->m_id, uExecutedCycles);
 		m_syncEventHead = pCurrEvent->m_next;	// unlink this event
 
 		pCurrEvent->m_active = false;

--- a/source/SynchronousEventManager.cpp
+++ b/source/SynchronousEventManager.cpp
@@ -23,6 +23,18 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 /* Description: Synchronous Event Manager
  *
+ * This manager class maintains a linked-list of ordered timer-based event,
+ * where only the head of the list needs updating after every opcode.
+ *
+ * The Nth event in the list will expire in: event[1] + ... + event[N] cycles time.
+ * (So each event has a cycle delta expiry time relative to the previous event.)
+ *
+ * A synchronous event is used for a deterministic event that will occur in N cycles' time,
+ * eg. 6522 timer & Mousecard VBlank. (As opposed to async events, like SSC Rx/Tx interrupts.)
+ *
+ * Events that are active in the list can be removed before they expire,
+ * eg. 6522 timer when the interval changes.
+ *
  * Author: Various
  *
  */

--- a/source/SynchronousEventManager.cpp
+++ b/source/SynchronousEventManager.cpp
@@ -133,11 +133,16 @@ void SynchronousEventManager::Update(int cycles)
 		return;
 
 	pCurrEvent->m_cyclesRemaining -= cycles;
-	if (pCurrEvent->m_cyclesRemaining < 0)
+	if (pCurrEvent->m_cyclesRemaining <= 0)
 	{
+		int underflowCycles = -pCurrEvent->m_cyclesRemaining;
+
 		pCurrEvent->m_cyclesRemaining = pCurrEvent->m_callback(pCurrEvent->m_id);
 		m_syncEventHead = pCurrEvent->m_next;	// unlink this event
 		pCurrEvent->m_next = NULL;
+
+		// Always Update even if underflowCycles=0, as next event may have cycleRemaining=0 (ie. the 2 events fire at the same time)
+		Update(underflowCycles);	// update (potential) next event with underflow cycles
 
 		if (pCurrEvent->m_cyclesRemaining)
 			Add(pCurrEvent);	// re-add event

--- a/source/SynchronousEventManager.h
+++ b/source/SynchronousEventManager.h
@@ -1,0 +1,40 @@
+#pragma once
+
+class SyncEvent;
+
+class SynchronousEventManager
+{
+public:
+	SynchronousEventManager() : m_syncEventHead(NULL)
+	{}
+	~SynchronousEventManager(){}
+
+	SyncEvent* GetHead(void) { return m_syncEventHead; }
+	void SetHead(SyncEvent* head) { m_syncEventHead = head; }
+
+	void Add(SyncEvent* pNewEvent);
+	bool Remove(int id);
+	void Update(int cycles);
+
+private:
+	SyncEvent* m_syncEventHead;
+};
+
+//
+
+typedef int (*syncEventCB)(int id);
+
+class SyncEvent
+{
+public:
+	SyncEvent(int id, int initCycles, syncEventCB callback)
+		: m_id(id), m_cyclesRemaining(initCycles), m_active(false), m_callback(callback), m_next(NULL)
+	{}
+	~SyncEvent(){}
+
+	int m_id;
+	int m_cyclesRemaining;
+	bool m_active;
+	syncEventCB m_callback;
+	SyncEvent* m_next;
+};

--- a/source/SynchronousEventManager.h
+++ b/source/SynchronousEventManager.h
@@ -15,6 +15,7 @@ public:
 	void Add(SyncEvent* pNewEvent);
 	bool Remove(int id);
 	void Update(int cycles);
+	void Reset(void) { m_syncEventHead = NULL; }
 
 private:
 	SyncEvent* m_syncEventHead;
@@ -28,9 +29,18 @@ class SyncEvent
 {
 public:
 	SyncEvent(int id, int initCycles, syncEventCB callback)
-		: m_id(id), m_cyclesRemaining(initCycles), m_active(false), m_callback(callback), m_next(NULL)
+		: m_id(id),
+		m_cyclesRemaining(initCycles),
+		m_active(false),
+		m_callback(callback),
+		m_next(NULL)
 	{}
 	~SyncEvent(){}
+
+	void SetCycles(int cycles)
+	{
+		m_cyclesRemaining = cycles;
+	}
 
 	int m_id;
 	int m_cyclesRemaining;

--- a/source/SynchronousEventManager.h
+++ b/source/SynchronousEventManager.h
@@ -23,7 +23,7 @@ private:
 
 //
 
-typedef int (*syncEventCB)(int id, int cyclesUnderflowed, ULONG uExecutedCycles);
+typedef int (*syncEventCB)(int id, ULONG uExecutedCycles);
 
 class SyncEvent
 {

--- a/source/SynchronousEventManager.h
+++ b/source/SynchronousEventManager.h
@@ -14,7 +14,7 @@ public:
 
 	void Insert(SyncEvent* pNewEvent);
 	bool Remove(int id);
-	void Update(int cycles);
+	void Update(int cycles, ULONG uExecutedCycles);
 	void Reset(void) { m_syncEventHead = NULL; }
 
 private:
@@ -23,7 +23,7 @@ private:
 
 //
 
-typedef int (*syncEventCB)(int id, int cyclesUnderflowed);
+typedef int (*syncEventCB)(int id, int cyclesUnderflowed, ULONG uExecutedCycles);
 
 class SyncEvent
 {

--- a/source/SynchronousEventManager.h
+++ b/source/SynchronousEventManager.h
@@ -12,7 +12,7 @@ public:
 	SyncEvent* GetHead(void) { return m_syncEventHead; }
 	void SetHead(SyncEvent* head) { m_syncEventHead = head; }
 
-	void Add(SyncEvent* pNewEvent);
+	void Insert(SyncEvent* pNewEvent);
 	bool Remove(int id);
 	void Update(int cycles);
 	void Reset(void) { m_syncEventHead = NULL; }
@@ -23,7 +23,7 @@ private:
 
 //
 
-typedef int (*syncEventCB)(int id);
+typedef int (*syncEventCB)(int id, int cyclesUnderflowed);
 
 class SyncEvent
 {

--- a/source/SynchronousEventManager.h
+++ b/source/SynchronousEventManager.h
@@ -23,7 +23,7 @@ private:
 
 //
 
-typedef int (*syncEventCB)(int id, ULONG uExecutedCycles);
+typedef int (*syncEventCB)(int id, int cycles, ULONG uExecutedCycles);
 
 class SyncEvent
 {

--- a/source/Video.cpp
+++ b/source/Video.cpp
@@ -35,6 +35,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "Keyboard.h"
 #include "Log.h"
 #include "Memory.h"
+#include "Mockingboard.h"	// MB_SetCumulativeCycles()
 #include "Registry.h"
 #include "Video.h"
 #include "NTSC.h"
@@ -172,6 +173,7 @@ void VideoInitialize ()
 
 //===========================================================================
 void VideoBenchmark () {
+  _ASSERT(g_nAppMode == MODE_BENCHMARK);
   Sleep(500);
 
   // PREPARE TWO DIFFERENT FRAME BUFFERS, EACH OF WHICH HAVE HALF OF THE

--- a/source/Video.cpp
+++ b/source/Video.cpp
@@ -35,7 +35,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "Keyboard.h"
 #include "Log.h"
 #include "Memory.h"
-#include "Mockingboard.h"	// MB_SetCumulativeCycles()
 #include "Registry.h"
 #include "Video.h"
 #include "NTSC.h"

--- a/test/TestCPU6502/TestCPU6502-vs2008.vcproj
+++ b/test/TestCPU6502/TestCPU6502-vs2008.vcproj
@@ -195,6 +195,10 @@
 				>
 			</File>
 			<File
+				RelativePath="..\..\source\SynchronousEventManager.cpp"
+				>
+			</File>
+			<File
 				RelativePath=".\TestCPU6502.cpp"
 				>
 			</File>

--- a/test/TestCPU6502/TestCPU6502-vs2019.vcxproj
+++ b/test/TestCPU6502/TestCPU6502-vs2019.vcxproj
@@ -11,6 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\source\SynchronousEventManager.cpp" />
     <ClCompile Include="stdafx.cpp" />
     <ClCompile Include="TestCPU6502.cpp" />
   </ItemGroup>

--- a/test/TestCPU6502/TestCPU6502-vs2019.vcxproj.filters
+++ b/test/TestCPU6502/TestCPU6502-vs2019.vcxproj.filters
@@ -13,6 +13,9 @@
     <ClCompile Include="TestCPU6502.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\source\SynchronousEventManager.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="stdafx.h">

--- a/test/TestCPU6502/TestCPU6502.cpp
+++ b/test/TestCPU6502/TestCPU6502.cpp
@@ -54,10 +54,6 @@ static __forceinline void DoIrqProfiling(DWORD uCycles)
 {
 }
 
-//static __forceinline void CheckInterruptSources(ULONG uExecutedCycles, const bool bVideoUpdate)
-//{
-//}
-
 static __forceinline void CheckSynchronousInterruptSources(UINT cycles, ULONG uExecutedCycles)
 {
 }

--- a/test/TestCPU6502/TestCPU6502.cpp
+++ b/test/TestCPU6502/TestCPU6502.cpp
@@ -54,7 +54,11 @@ static __forceinline void DoIrqProfiling(DWORD uCycles)
 {
 }
 
-static __forceinline void CheckInterruptSources(ULONG uExecutedCycles, const bool bVideoUpdate)
+//static __forceinline void CheckInterruptSources(ULONG uExecutedCycles, const bool bVideoUpdate)
+//{
+//}
+
+static __forceinline void CheckSynchronousInterruptSources(UINT cycles)
 {
 }
 

--- a/test/TestCPU6502/TestCPU6502.cpp
+++ b/test/TestCPU6502/TestCPU6502.cpp
@@ -1254,7 +1254,7 @@ int GH321_test()
 
 //-------------------------------------
 
-int testCB(int id, ULONG uExecutedCycles)
+int testCB(int id, int cycles, ULONG uExecutedCycles)
 {
 	return 0;
 }

--- a/test/TestCPU6502/TestCPU6502.cpp
+++ b/test/TestCPU6502/TestCPU6502.cpp
@@ -58,7 +58,7 @@ static __forceinline void DoIrqProfiling(DWORD uCycles)
 //{
 //}
 
-static __forceinline void CheckSynchronousInterruptSources(UINT cycles)
+static __forceinline void CheckSynchronousInterruptSources(UINT cycles, ULONG uExecutedCycles)
 {
 }
 

--- a/test/TestCPU6502/TestCPU6502.cpp
+++ b/test/TestCPU6502/TestCPU6502.cpp
@@ -3,10 +3,12 @@
 #include "../../source/Applewin.h"
 #include "../../source/CPU.h"
 #include "../../source/Memory.h"
+#include "../../source/SynchronousEventManager.h"
 
 // From Applewin.cpp
 bool g_bFullSpeed = false;
 enum AppMode_e g_nAppMode = MODE_RUNNING;
+SynchronousEventManager g_SynchronousEventMgr;
 
 // From Memory.cpp
 LPBYTE         memwrite[0x100];		// TODO: Init
@@ -27,8 +29,7 @@ iofunction		IOWrite[256] = {0};	// TODO: Init
 
 regsrec regs;
 
-static const int IRQ_CHECK_TIMEOUT = 128;
-static signed int g_nIrqCheckTimeout = IRQ_CHECK_TIMEOUT;
+bool g_irqOnLastOpcodeCycle = false;
 
 static eCpuType g_ActiveCPU = CPU_65C02;
 
@@ -1253,6 +1254,62 @@ int GH321_test()
 
 //-------------------------------------
 
+int testCB(int id, int underflowCycles, ULONG uExecutedCycles)
+{
+	return 0;
+}
+
+int SyncEvents_test(void)
+{
+	SyncEvent syncEvent0(0, 0x10, testCB);
+	SyncEvent syncEvent1(1, 0x20, testCB);
+	SyncEvent syncEvent2(2, 0x30, testCB);
+	SyncEvent syncEvent3(3, 0x40, testCB);
+
+	g_SynchronousEventMgr.Insert(&syncEvent0);
+	g_SynchronousEventMgr.Insert(&syncEvent1);
+	g_SynchronousEventMgr.Insert(&syncEvent2);
+	g_SynchronousEventMgr.Insert(&syncEvent3);
+	// id0 -> id1 -> id2 -> id3
+	if (syncEvent0.m_cyclesRemaining != 0x10) return 1;
+	if (syncEvent1.m_cyclesRemaining != 0x10) return 1;
+	if (syncEvent2.m_cyclesRemaining != 0x10) return 1;
+	if (syncEvent3.m_cyclesRemaining != 0x10) return 1;
+
+	g_SynchronousEventMgr.Remove(1);
+	g_SynchronousEventMgr.Remove(3);
+	g_SynchronousEventMgr.Remove(0);
+	if (syncEvent2.m_cyclesRemaining != 0x30) return 1;
+	g_SynchronousEventMgr.Remove(2);
+
+	//
+
+	syncEvent0.m_cyclesRemaining = 0x40;
+	syncEvent1.m_cyclesRemaining = 0x30;
+	syncEvent2.m_cyclesRemaining = 0x20;
+	syncEvent3.m_cyclesRemaining = 0x10;
+
+	g_SynchronousEventMgr.Insert(&syncEvent0);
+	g_SynchronousEventMgr.Insert(&syncEvent1);
+	g_SynchronousEventMgr.Insert(&syncEvent2);
+	g_SynchronousEventMgr.Insert(&syncEvent3);
+	// id3 -> id2 -> id1 -> id0
+	if (syncEvent0.m_cyclesRemaining != 0x10) return 1;
+	if (syncEvent1.m_cyclesRemaining != 0x10) return 1;
+	if (syncEvent2.m_cyclesRemaining != 0x10) return 1;
+	if (syncEvent3.m_cyclesRemaining != 0x10) return 1;
+
+	g_SynchronousEventMgr.Remove(3);
+	g_SynchronousEventMgr.Remove(0);
+	g_SynchronousEventMgr.Remove(1);
+	if (syncEvent2.m_cyclesRemaining != 0x20) return 1;
+	g_SynchronousEventMgr.Remove(2);
+
+	return 0;
+}
+
+//-------------------------------------
+
 int _tmain(int argc, _TCHAR* argv[])
 {
 	int res = 1;
@@ -1275,6 +1332,9 @@ int _tmain(int argc, _TCHAR* argv[])
 	if (res) return res;
 
 	res = GH292_test();
+	if (res) return res;
+
+	res = SyncEvents_test();
 	if (res) return res;
 
 	return 0;

--- a/test/TestCPU6502/TestCPU6502.cpp
+++ b/test/TestCPU6502/TestCPU6502.cpp
@@ -1254,7 +1254,7 @@ int GH321_test()
 
 //-------------------------------------
 
-int testCB(int id, int underflowCycles, ULONG uExecutedCycles)
+int testCB(int id, ULONG uExecutedCycles)
 {
 	return 0;
 }


### PR DESCRIPTION
PR for #612.

Switched Mockingboard/6522 Timer interrupts & Mousecard's VBlank interrupt to use synchronous events.
This is a linked-list of ordered timer-based event, where _only the head_ of the list needs updating after every opcode.

Improvements:
- 6502 interrupts are now cycle accurate in full-speed (unthrottled) mode (eg. fixes Broadsides, #608)
  - Also FT demos (eg. MAD2) can be toggled full-speed on/of without losing the video/6522 sync.
- The emulation performance is now unaffected by having Mockingboard 6522 timers, as it's not having to update the 4x 6522 timers after every opcode!

Tested with _all_ FT demos (eg. "CHIP" uses 6522-A & 6522-B timer1 interrupts during the video frame, "TRIBU" re-uses the 6522-A timer1 interrupt as it scans down the video frame). Also tested with Dazzle Draw (for Mousecard VBlank).