### PR TITLE
Source clean-up, portability and debugger fixes.

### DIFF
--- a/source/CPU.cpp
+++ b/source/CPU.cpp
@@ -428,7 +428,7 @@ static __forceinline void IRQ(ULONG& uExecutedCycles, BOOL& flagc, BOOL& flagn, 
 		PUSH(regs.pc & 0xFF)
 		EF_TO_AF
 		PUSH(regs.ps & ~AF_BREAK)
-		regs.ps = regs.ps | AF_INTERRUPT & ~AF_DECIMAL;
+		regs.ps = (regs.ps | AF_INTERRUPT) & (~AF_DECIMAL);
 		regs.pc = * (WORD*) (mem+0xFFFE);
 		UINT uExtraCycles = 0;	// Needed for CYC(a) macro
 		CYC(7)

--- a/source/CardManager.cpp
+++ b/source/CardManager.cpp
@@ -29,7 +29,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include "StdAfx.h"
 
-#include "AppleWin.h"
+#include "Applewin.h"
 #include "CardManager.h"
 
 #include "Disk.h"

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -1826,7 +1826,13 @@ Update_t _CmdAssemble( WORD nAddress, int iArg, int nArgs )
 
 	bool bStatus = Assemble( iArg, nArgs, nAddress );
 	if ( bStatus)
+	{
+		// move disassembler to current address
+		g_nDisasmCurAddress = g_nAssemblerAddress;
+		WindowUpdateDisasmSize(); // calc cur line
+		DisasmCalcTopBotAddress();
 		return UPDATE_ALL;
+	}
 		
 	return UPDATE_CONSOLE_DISPLAY; // UPDATE_NOTHING;
 }
@@ -1845,6 +1851,14 @@ Update_t CmdAssemble (int nArgs)
 	// 1 : A address
 	// 2+: A address mnemonic...
 
+	if (nArgs > 0)
+		g_nAssemblerAddress = g_aArgs[1].nValue;
+
+	// move disassembler window to current assembler address
+	g_nDisasmCurAddress = g_nAssemblerAddress;       // (2)
+	WindowUpdateDisasmSize(); // calc cur line
+	DisasmCalcTopBotAddress();
+
 	if (! nArgs)
 	{
 //		return Help_Arg_1( CMD_ASSEMBLE );
@@ -1853,8 +1867,6 @@ Update_t CmdAssemble (int nArgs)
 		AssemblerOn();
 		return UPDATE_CONSOLE_DISPLAY;
 	}
-		
-	g_nAssemblerAddress = g_aArgs[1].nValue;
 
 	if (nArgs == 1)
 	{

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -2190,7 +2190,7 @@ Update_t CmdNOP (int nArgs)
 	int iOpmode;
 	int nOpbytes;
 
- 	_6502_GetOpcodeOpmodeOpbyte( iOpcode, iOpmode, nOpbytes );
+	_6502_GetOpcodeOpmodeOpbyte( iOpcode, iOpmode, nOpbytes );
 
 	while (nOpbytes--)
 	{
@@ -3034,7 +3034,7 @@ void DisasmCalcTopFromCurAddress( bool bUpdateTop )
 			break;
 		}
 		iTop++;
- 	}
+	}
 
 	if (! bFound)
 	{
@@ -3061,7 +3061,7 @@ void DisasmCalcTopFromCurAddress( bool bUpdateTop )
 			MessageBox( g_hFrameWindow, sText, "ERROR", MB_OK );
 #endif
 	}
- }
+}
 
 
 //===========================================================================

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -4762,7 +4762,7 @@ Update_t CmdMemorySave (int nArgs)
 //		if (g_aArgs[1].bType & TOKEN_QUOTE_DOUBLE)
 //			bHaveFileName = true;
 
-		int iArgComma1  = 2;
+//		int iArgComma1  = 2;
 		int iArgAddress = 3;
 		int iArgComma2  = 4;
 		int iArgLength  = 5;
@@ -4771,7 +4771,7 @@ Update_t CmdMemorySave (int nArgs)
 
 		if (! bHaveFileName)
 		{
-			iArgComma1  = 1;
+//			iArgComma1  = 1;
 			iArgAddress = 2;
 			iArgComma2  = 3;
 			iArgLength  = 4;
@@ -5767,8 +5767,6 @@ int _SearchMemoryFind(
 				// if next block matches, then this block matches (since we are wild)
 				if ((iBlock + 1) == nMemBlocks) // there is no next block, hence we match
 					continue;
-					
-				MemorySearch_t ms2 = vMemorySearchValues.at( iBlock + 1 );
 
 				WORD nAddress3 = nAddress2;
 				for (nAddress3 = nAddress2; nAddress3 < nAddressEnd; nAddress3++ )
@@ -6338,7 +6336,6 @@ Update_t CmdOutputPrintf (int nArgs)
 	int nLen = 0;
 
 	PrintState_e eThis = PS_LITERAL;
-//	PrintState_e eNext = PS_NEXT_ARG_HEX; // PS_LITERAL;
 
 	int nWidth = 0;
 

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -6501,7 +6501,7 @@ Update_t CmdOutputRun (int nArgs)
 
 //	if (g_aArgs[1].bType & TYPE_QUOTED_2)
 
-	sMiniFileName = pFileName.substr(0, min(pFileName.size(), CONSOLE_WIDTH));
+	sMiniFileName = pFileName.substr(0, MIN(pFileName.size(), CONSOLE_WIDTH));
 //	_tcscat( sMiniFileName, ".aws" ); // HACK: MAGIC STRING
 
 	if (pFileName[0] == '\\' || pFileName[1] == ':')	// NB. Any prefix quote has already been stripped
@@ -6778,7 +6778,7 @@ Update_t CmdSource (int nArgs)
 				const std::string sFileName = g_sProgramDir + pFileName;
 
 				const int MAX_MINI_FILENAME = 20; 
-				const std::string sMiniFileName = sFileName.substr(0, min(MAX_MINI_FILENAME, sFileName.size()));
+				const std::string sMiniFileName = sFileName.substr(0, MIN(MAX_MINI_FILENAME, sFileName.size()));
 
 				TCHAR buffer[MAX_PATH] = { 0 };
 

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -297,8 +297,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 	static bool      g_bBenchmarking = false;
 
-	static BOOL      fulldisp      = 0;
-
 	static BOOL      g_bProfiling       = 0;
 	static int       g_nDebugSteps      = 0;
 	static DWORD     g_nDebugStepCycles = 0;

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -898,7 +898,7 @@ static void SetDebugBreakOnInvalid( int iOpcodeType, int nValue )
 Update_t CmdBreakInvalid (int nArgs) // Breakpoint IFF Full-speed!
 {
 	if (nArgs > 2) // || (nArgs == 0))
-		goto _Help;
+		return HelpLastCommand();
 
 	int iType = AM_IMPLIED; // default to BRK
 	int nActive = 0;
@@ -3754,7 +3754,7 @@ Update_t CmdFlag (int nArgs)
 Update_t CmdDisk ( int nArgs)
 {
 	if (! nArgs)
-		goto _Help;
+		return HelpLastCommand();
 
 	if (g_CardMgr.QuerySlot(SLOT6) != CT_Disk2)
 		return ConsoleDisplayError("No DiskII card in slot-6");
@@ -3768,7 +3768,7 @@ Update_t CmdDisk ( int nArgs)
 	if (iParam == PARAM_DISK_INFO)
 	{
 		if (nArgs > 2)
-			goto _Help;
+			return HelpLastCommand();
 
 		char buffer[200] = "";
 		ConsoleBufferPushFormat(buffer, "FW%2d: D%d at T$%s, phase $%s, offset $%X, mask $%02X, extraCycles %.2f, %s",
@@ -3786,7 +3786,7 @@ Update_t CmdDisk ( int nArgs)
 	}
 
 	if (nArgs < 2)
-		goto _Help;
+		return HelpLastCommand();
 
 	// first param should be drive
 	int iDrive = g_aArgs[ 1 ].nValue;
@@ -3800,12 +3800,12 @@ Update_t CmdDisk ( int nArgs)
 	int nFound = FindParam( g_aArgs[ 2 ].sArg, MATCH_EXACT, iParam, _PARAM_DISK_BEGIN, _PARAM_DISK_END );
 
 	if (! nFound)
-		goto _Help;
+		return HelpLastCommand();
 
 	if (iParam == PARAM_DISK_EJECT)
 	{
 		if (nArgs > 2)
-			goto _Help;
+			return HelpLastCommand();
 
 		diskCard.EjectDisk( iDrive );
 		FrameRefreshStatus(DRAW_LEDS | DRAW_BUTTON_DRIVES);
@@ -3814,7 +3814,7 @@ Update_t CmdDisk ( int nArgs)
 	if (iParam == PARAM_DISK_PROTECT)
 	{
 		if (nArgs > 3)
-			goto _Help;
+			return HelpLastCommand();
 
 		bool bProtect = true;
 
@@ -3827,7 +3827,7 @@ Update_t CmdDisk ( int nArgs)
 	else
 	{
 		if (nArgs != 3)
-			goto _Help;
+			return HelpLastCommand();
 
 		LPCTSTR pDiskName = g_aArgs[ 3 ].sArg;
 
@@ -3837,9 +3837,6 @@ Update_t CmdDisk ( int nArgs)
 	}
 
 	return UPDATE_CONSOLE_DISPLAY;
-
-_Help:
-	return HelpLastCommand();
 }
 
 
@@ -6336,7 +6333,7 @@ Update_t CmdOutputPrintf (int nArgs)
 	int nValue = 0;
 
 	if (! nArgs)
-		goto _Help;
+		return Help_Arg_1( CMD_OUTPUT_PRINTF );
 
 	int nLen = 0;
 

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -7837,7 +7837,7 @@ int FindCommand( LPCTSTR pName, CmdFuncPtr_t & pFunction_, int * iCommand_ )
 					if (iCommand_)
 						*iCommand_ = iCommand;
 // !_tcscmp
-					if (!_tcsicmp(pName, pCommandName)) // exact match?
+					if (!_tcsicmp(sCommand, pCommandName)) // exact match?
 					{
 	//					if (iCommand_)
 	//						*iCommand_ = iCommand;
@@ -7965,8 +7965,9 @@ Update_t ExecuteCommand (int nArgs)
 				}
 				else
 				// ####L -> Unassemble $address
-				if ((pCommand[nLen-1] == 'L') ||
-					(pCommand[nLen-1] == 'l'))
+				if (((pCommand[nLen-1] == 'L') ||
+				     (pCommand[nLen-1] == 'l'))&&
+				    (strcmp("cl", pCommand) != 0)) // workaround for ambiguous "cl": must be handled by "clear flag" command
 				{
 					pCommand[nLen-1] = 0;
 					ArgsGetValue( pArg, & nAddress );

--- a/source/Debugger/Debugger_Assembler.cpp
+++ b/source/Debugger/Debugger_Assembler.cpp
@@ -858,10 +858,10 @@ bool _6502_IsOpcodeValid ( int iOpcode )
 
 
 //===========================================================================
-int AssemblerHashMnemonic ( const TCHAR * pMnemonic )
+Hash_t AssemblerHashMnemonic ( const TCHAR * pMnemonic )
 {
 	const TCHAR *pText = pMnemonic;
-	int nMnemonicHash = 0;
+	Hash_t nMnemonicHash = 0;
 	int iHighBits;
 
 	const int    NUM_LOW_BITS = 19; // 24 -> 19 prime
@@ -1471,7 +1471,7 @@ bool Assemble( int iArg, int nArgs, WORD nAddress )
 	m_nAsmBaseAddress = nAddress;
 
 	TCHAR *pMnemonic = g_aArgs[ iArg ].sArg;
-	int nMnemonicHash = AssemblerHashMnemonic( pMnemonic );
+	Hash_t nMnemonicHash = AssemblerHashMnemonic( pMnemonic );
 
 #if DEBUG_ASSEMBLER
 	char sText[ CONSOLE_WIDTH * 2 ];

--- a/source/Debugger/Debugger_Assembler.h
+++ b/source/Debugger/Debugger_Assembler.h
@@ -199,7 +199,7 @@ extern	int g_aAssemblerFirstDirective[ NUM_ASSEMBLERS ];
 	bool _6502_IsOpcodeBranch( int nOpcode );
 	bool _6502_IsOpcodeValid( int nOpcode );
 
-	int  AssemblerHashMnemonic ( const TCHAR * pMnemonic );
+	Hash_t  AssemblerHashMnemonic ( const TCHAR * pMnemonic );
 //	bool AssemblerGetAddressingMode ( int iArg, int nArgs, WORD nAddress, std::vector<int> & vOpcodes );
 	void _CmdAssembleHashDump ();
 	

--- a/source/Debugger/Debugger_Color.cpp
+++ b/source/Debugger/Debugger_Color.cpp
@@ -163,7 +163,7 @@ bool DebuggerSetColor( const int iScheme, const int iColor, const COLORREF nColo
 		bStatus = true;
 	}
 
-	// Propogate to console since it has its own copy of colors
+	// Propagate to console since it has its own copy of colors
 	if (iColor == FG_CONSOLE_OUTPUT)
 	{
 		COLORREF nConsole = DebuggerGetColor( FG_CONSOLE_OUTPUT );

--- a/source/Debugger/Debugger_DisassemblerData.cpp
+++ b/source/Debugger/Debugger_DisassemblerData.cpp
@@ -116,7 +116,7 @@ WORD _CmdDefineByteRange(int nArgs,int iArg,DisasmData_t & tData_)
 		else
 			sprintf( aSymbolName, "B_%04X", tData_.nStartAddress ); // DB range
 
-			pSymbolName = aSymbolName;
+		pSymbolName = aSymbolName;
 	}
 
 	// bRemoveSymbol = false // use arg[2]

--- a/source/Debugger/Debugger_Display.cpp
+++ b/source/Debugger/Debugger_Display.cpp
@@ -3528,7 +3528,7 @@ void DrawZeroPagePointers ( int line )
 			}
 			else
 			{
-				int nMin = min( nLen1, nMaxSymbolLen );
+				int nMin = MIN( nLen1, nMaxSymbolLen );
 				memcpy(sText, pSymbol1, nMin);
 				DebuggerSetColorFG( DebuggerGetColor( FG_DISASM_SYMBOL ) );
 			}
@@ -3970,7 +3970,7 @@ void DrawSubWindow_Source2 (Update_t bUpdate)
 
 // Draw Title
 	std::string sTitle = "   Source: " + g_aSourceFileName;
-	sTitle.resize(min(sTitle.size(), size_t(g_nConsoleDisplayWidth)));
+	sTitle.resize(MIN(sTitle.size(), size_t(g_nConsoleDisplayWidth)));
 
 	DebuggerSetColorBG( DebuggerGetColor( BG_SOURCE_TITLE ));
 	DebuggerSetColorFG( DebuggerGetColor( FG_SOURCE_TITLE ));

--- a/source/Debugger/Debugger_Help.cpp
+++ b/source/Debugger/Debugger_Help.cpp
@@ -877,7 +877,8 @@ Update_t CmdHelpSpecific (int nArgs)
 		{	
 	// CPU / General
 		case CMD_ASSEMBLE:
-			ConsoleBufferPush( " Built-in assember isn't functional yet." );
+			ConsoleColorizePrint( sText, " Usage: [address | symbol]" );
+			ConsoleBufferPush( " Enter mini-assembler mode [starting at optional address or symbol]." );
 			break;
 		case CMD_UNASSEMBLE:
 			ConsoleColorizePrint( sText, " Usage: [address | symbol]" );

--- a/source/Debugger/Debugger_Symbols.cpp
+++ b/source/Debugger/Debugger_Symbols.cpp
@@ -556,7 +556,7 @@ int ParseSymbolTable(const std::string & pPathFileName, SymbolTable_Index_e eSym
 	char sText[ CONSOLE_WIDTH * 3 ];
 	bool bFileDisplayed = false;
 
-	const int nMaxLen = min(MAX_TARGET_LEN,MAX_SYMBOLS_LEN);
+	const int nMaxLen = MIN(MAX_TARGET_LEN,MAX_SYMBOLS_LEN);
 
 	int nSymbolsLoaded = 0;
 

--- a/source/Debugger/Debugger_Types.h
+++ b/source/Debugger/Debugger_Types.h
@@ -1543,19 +1543,7 @@ const	DisasmData_t* pDisasmData; // If != NULL then bytes are marked up as data 
 	
 	struct WindowSplit_t
 	{
-		RECT tBoundingBox; // 
-
-		int  nWidth ; // Width & Height are always valid 
-		int  nHeight; // If window is split/join, then auto-updated (right,bottom)
-
-		int  nCursorY; // Address
-		int  nCursorX; // or line,col of text file ...
-
 		int  bSplit ; 
-
-		int  iParent;// index into g_aWindowConfig
-		int  iChild ; // index into g_aWindowConfig
-
 		Window_e eTop;
 		Window_e eBot;	
 	};

--- a/source/Disk2CardManager.cpp
+++ b/source/Disk2CardManager.cpp
@@ -29,7 +29,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include "StdAfx.h"
 
-#include "AppleWin.h"
+#include "Applewin.h"
 #include "CardManager.h"
 #include "Disk.h"
 #include "Disk2CardManager.h"

--- a/source/Memory.cpp
+++ b/source/Memory.cpp
@@ -1840,12 +1840,12 @@ void MemReset()
 	//   F2. Ctrl-F2. CALL-151, C050 C053 C057
 	// OR
 	//   F2, Ctrl-F2, F7, HGR
-	DWORD clock = getRandomTime();
+	DWORD randTime = getRandomTime();
 	MemoryInitPattern_e eMemoryInitPattern = static_cast<MemoryInitPattern_e>(g_nMemoryClearType);
 
 	if (g_nMemoryClearType < 0)	// random
 	{
-		eMemoryInitPattern = static_cast<MemoryInitPattern_e>( clock % NUM_MIP );
+		eMemoryInitPattern = static_cast<MemoryInitPattern_e>( randTime % NUM_MIP );
 
 		// Don't use unless manually specified as a
 		// few badly written programs will not work correctly
@@ -1866,12 +1866,12 @@ void MemReset()
 			// Exceptions: xx28 xx29 xx68 xx69 Apple //e
 			for( iByte = 0x0000; iByte < 0xC000; iByte += 512 )
 			{
-				clock = getRandomTime();
-				memmain[ iByte + 0x28 ] = (clock >>  0) & 0xFF;
-				memmain[ iByte + 0x29 ] = (clock >>  8) & 0xFF;
-				clock = getRandomTime();
-				memmain[ iByte + 0x68 ] = (clock >>  0) & 0xFF;
-				memmain[ iByte + 0x69 ] = (clock >>  8) & 0xFF;
+				randTime = getRandomTime();
+				memmain[ iByte + 0x28 ] = (randTime >>  0) & 0xFF;
+				memmain[ iByte + 0x29 ] = (randTime >>  8) & 0xFF;
+				randTime = getRandomTime();
+				memmain[ iByte + 0x68 ] = (randTime >>  0) & 0xFF;
+				memmain[ iByte + 0x69 ] = (randTime >>  8) & 0xFF;
 			}
 			break;
 		
@@ -1907,9 +1907,9 @@ void MemReset()
 			{
 				for( int i = 0; i < 256; i++ )
 				{
-					clock = getRandomTime();
-					random[ (i+0) & 0xFF ] = (clock >>  0) & 0xFF;
-					random[ (i+1) & 0xFF ] = (clock >> 11) & 0xFF;
+					randTime = getRandomTime();
+					random[ (i+0) & 0xFF ] = (randTime >>  0) & 0xFF;
+					random[ (i+1) & 0xFF ] = (randTime >> 11) & 0xFF;
 				}
 
 				memcpy( &memmain[ iByte ], random, 256 );
@@ -1932,9 +1932,9 @@ void MemReset()
 
 	// https://github.com/AppleWin/AppleWin/issues/206
 	// Work-around for a cold-booting bug in "Pooyan" which expects RNDL and RNDH to be non-zero.
-	clock = getRandomTime();
-	memmain[ 0x4E ] = 0x20 | (clock >> 0) & 0xFF;
-	memmain[ 0x4F ] = 0x20 | (clock >> 8) & 0xFF;
+	randTime = getRandomTime();
+	memmain[ 0x4E ] = 0x20 | (randTime >> 0) & 0xFF;
+	memmain[ 0x4F ] = 0x20 | (randTime >> 8) & 0xFF;
 
 	// https://github.com/AppleWin/AppleWin/issues/222
 	// MIP_PAGE_ADDRESS_LOW breaks a few badly written programs!

--- a/source/MouseInterface.cpp
+++ b/source/MouseInterface.cpp
@@ -131,8 +131,8 @@ void M6821_Listener_A( void* objTo, BYTE byData )
 
 CMouseInterface::CMouseInterface(UINT slot) :
 	Card(CT_MouseInterface),
-	m_uSlot(slot),
-	m_pSlotRom(NULL)
+	m_pSlotRom(NULL),
+	m_uSlot(slot)
 {
 	m_6821.SetListenerB( this, M6821_Listener_B );
 	m_6821.SetListenerA( this, M6821_Listener_A );

--- a/source/ParallelPrinter.cpp
+++ b/source/ParallelPrinter.cpp
@@ -159,17 +159,17 @@ static BYTE __stdcall PrintStatus(WORD, WORD, BYTE, BYTE, ULONG)
 //===========================================================================
 static BYTE __stdcall PrintTransmit(WORD, WORD, BYTE, BYTE value, ULONG)
 {
-	         char Lat8A[]= "abwgdevzijklmnoprstufhc~{}yx`q|]";
-             char Lat82[]= "abwgdevzijklmnoprstufhc^[]yx@q{}~`"; 
-			 char Kir82[]= "ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÜÞß[]^@";
-	  char Kir8ACapital[]= "ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÜÞßÝ";
+	char Lat8A[]= "abwgdevzijklmnoprstufhc~{}yx`q|]";
+	char Lat82[]= "abwgdevzijklmnoprstufhc^[]yx@q{}~`";
+	char Kir82[]= "ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÜÞß[]^@";
+	char Kir8ACapital[]= "ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÜÞßÝ";
 	char Kir8ALowerCase[]= "àáâãäåæçèéêëìíîïðñòóôõö÷øùúüþÿý";
-	bool Pres = false;
-    if (!CheckPrint())
-    {
-        return 0;
-    }
-	
+
+	if (!CheckPrint())
+	{
+			return 0;
+	}
+
 	char c = 0;
 	if ((g_Apple2Type == A2TYPE_PRAVETS8A) &&  g_bConvertEncoding)  //This is print conversion for Pravets 8A/C. Print conversion for Pravets82/M is still to be done.
 		{

--- a/source/SaveState_Structs_v1.h
+++ b/source/SaveState_Structs_v1.h
@@ -99,7 +99,7 @@ struct SS_CARD_DISK2
 {
 	SS_CARD_HDR	Hdr;
 	DISK2_Unit	Unit[2];
-    WORD    phases;
+	WORD    phases;
 	WORD	currdrive;
 	BOOL	diskaccessed;
 	BOOL	enhancedisk;

--- a/source/Speaker.cpp
+++ b/source/Speaker.cpp
@@ -79,8 +79,6 @@ double		    g_fClksPerSpkrSample;		// Setup in SetClksPerSpkrSample()
 bool			g_bQuieterSpeaker = false;
 
 // Globals
-static DWORD	lastcyclenum	= 0;
-static DWORD	toggles			= 0;
 static unsigned __int64	g_nSpkrQuietCycleCount = 0;
 static unsigned __int64 g_nSpkrLastCycle = 0;
 static bool g_bSpkrToggleFlag = false;
@@ -90,9 +88,9 @@ static bool g_bSpkrAvailable = false;
 //-----------------------------------------------------------------------------
 
 // Forward refs:
-ULONG   Spkr_SubmitWaveBuffer_FullSpeed(short* pSpeakerBuffer, ULONG nNumSamples);
-ULONG   Spkr_SubmitWaveBuffer(short* pSpeakerBuffer, ULONG nNumSamples);
-void    Spkr_SetActive(bool bActive);
+static ULONG   Spkr_SubmitWaveBuffer_FullSpeed(short* pSpeakerBuffer, ULONG nNumSamples);
+static ULONG   Spkr_SubmitWaveBuffer(short* pSpeakerBuffer, ULONG nNumSamples);
+static void    Spkr_SetActive(bool bActive);
 
 //=============================================================================
 

--- a/source/Speaker.h
+++ b/source/Speaker.h
@@ -24,8 +24,6 @@ void    SpkrReset();
 BOOL    SpkrSetEmulationType (HWND window, SoundType_e newSoundType);
 void    SpkrUpdate (DWORD);
 void    SpkrUpdate_Timer();
-void    Spkr_SetErrorInc(const int nErrorInc);
-void    Spkr_SetErrorMax(const int nErrorMax);
 DWORD   SpkrGetVolume();
 void    SpkrSetVolume(DWORD dwVolume, DWORD dwVolumeMax);
 void    Spkr_Mute();

--- a/source/YamlHelper.h
+++ b/source/YamlHelper.h
@@ -74,10 +74,10 @@ public:
 	YamlLoadHelper(YamlHelper& yamlHelper)
 		: m_yamlHelper(yamlHelper),
 		  m_pMapYaml(&yamlHelper.m_mapYaml),
-		  m_bIteratingOverMap(false),
 		  m_bDoGetMapRemainder(true),
 		  m_topLevelMapName(yamlHelper.m_scalarName),
-		  m_currentMapName(m_topLevelMapName)
+		  m_currentMapName(m_topLevelMapName),
+		  m_bIteratingOverMap(false)
 	{
 		if (!m_yamlHelper.ParseMap(yamlHelper.m_mapYaml))
 		{


### PR DESCRIPTION
Another set of commits fixing compiler warnings and portability issues.
While the changes may not be required for MSVC (some will depend on the compiler warning lelvel) , they should not hurt - and even provide some clean-up.
It's mainly issues reported by gcc, such as some naming conflicts of local variables with gcc standard library symbols. It would really help/ease the synchronization of sources with the Linux port, if you could take these minor changes upstream. 

The final two commits fix two general issues:
* confusing behavior when entering the builtin (mini) assembler mode,
* and also fixes the "cl" (clear flag) command - which was documented, but did not work at all (due to an "interesting" command/syntax conflict...).
