### PR TITLE
More clean-up, portability and another debugger fix

### DIFF
--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -3521,13 +3521,10 @@ void _CursorMoveDownAligned( int nDelta )
 {
 	if (g_iWindowThis == WINDOW_DATA)
 	{
-		if (g_aMemDump[0].bActive)
+		if (g_aMemDump[0].eDevice == DEV_MEMORY)
 		{
-			if (g_aMemDump[0].eDevice == DEV_MEMORY)
-			{
-				g_aMemDump[0].nAddress += nDelta;
-				g_aMemDump[0].nAddress &= _6502_MEM_END;
-			}
+			g_aMemDump[0].nAddress += nDelta;
+			g_aMemDump[0].nAddress &= _6502_MEM_END;
 		}
 	}
 	else
@@ -3549,13 +3546,10 @@ void _CursorMoveUpAligned( int nDelta )
 {
 	if (g_iWindowThis == WINDOW_DATA)
 	{
-		if (g_aMemDump[0].bActive)
+		if (g_aMemDump[0].eDevice == DEV_MEMORY)
 		{
-			if (g_aMemDump[0].eDevice == DEV_MEMORY)
-			{
-				g_aMemDump[0].nAddress -= nDelta;
-				g_aMemDump[0].nAddress &= _6502_MEM_END;
-			}
+			g_aMemDump[0].nAddress -= nDelta;
+			g_aMemDump[0].nAddress &= _6502_MEM_END;
 		}
 	}
 	else

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -7979,7 +7979,7 @@ Update_t ExecuteCommand (int nArgs)
 				// ####L -> Unassemble $address
 				if (((pCommand[nLen-1] == 'L') ||
 				     (pCommand[nLen-1] == 'l'))&&
-				    (strcmp("cl", pCommand) != 0)) // workaround for ambiguous "cl": must be handled by "clear flag" command
+				    (_stricmp("cl", pCommand) != 0)) // workaround for ambiguous "cl": must be handled by "clear flag" command
 				{
 					pCommand[nLen-1] = 0;
 					ArgsGetValue( pArg, & nAddress );

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -3502,19 +3502,6 @@ Update_t CmdCursorRunUntil (int nArgs)
 	return CmdGo( nArgs, true );
 }
 
-
-//===========================================================================
-WORD _ClampAddress( int nAddress )
-{
-	if (nAddress < 0)
-		nAddress = 0;
-	if (nAddress > _6502_MEM_END)
-		nAddress = _6502_MEM_END;
-
-	return (WORD) nAddress;
-}
-
-
 // nDelta must be a power of 2
 //===========================================================================
 void _CursorMoveDownAligned( int nDelta )

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -1264,7 +1264,7 @@ Update_t CmdBreakpoint (int nArgs)
 //===========================================================================
 Update_t CmdBreakpointAddSmart (int nArgs)
 {
-	int nAddress = g_aArgs[1].nValue;
+	unsigned int nAddress = g_aArgs[1].nValue;
 
 	if (! nArgs)
 	{
@@ -1368,7 +1368,7 @@ bool _CmdBreakpointAddReg( Breakpoint_t *pBP, BreakpointSource_t iSrc, Breakpoin
 	if (pBP)
 	{
 		_ASSERT(nLen <= _6502_MEM_LEN);
-		if (nLen > _6502_MEM_LEN) nLen = _6502_MEM_LEN;
+		if (nLen > (int) _6502_MEM_LEN) nLen = (int) _6502_MEM_LEN;
 
 		pBP->eSource   = iSrc;
 		pBP->eOperator = iCmp;
@@ -1944,7 +1944,7 @@ static Update_t CmdGo (int nArgs, const bool bFullSpeed)
 				{
 					nLen = g_aArgs[ iArg + 2 ].nValue;
 					nEnd = g_nDebugSkipStart + nLen;
-					if (nEnd > _6502_MEM_END)
+					if (nEnd > (int) _6502_MEM_END)
 						nEnd = _6502_MEM_END + 1;
 				}
 				else
@@ -4527,7 +4527,7 @@ Update_t CmdMemoryLoad (int nArgs)
 		}
 		else
 		{
-			for (UINT i=(nAddressStart>>8); i!=((nAddressStart+nAddressLen)>>8); i++)
+			for (WORD i=(nAddressStart>>8); i!=((nAddressStart+(WORD)nAddressLen)>>8); i++)
 			{
 				memdirty[i] = 0xff;
 			}

--- a/source/Debugger/Debugger_Display.cpp
+++ b/source/Debugger/Debugger_Display.cpp
@@ -2430,7 +2430,6 @@ static void DrawFlags ( int line, WORD nRegFlags )
 	if (! ((g_iWindowThis == WINDOW_CODE) || ((g_iWindowThis == WINDOW_DATA))))
 		return;
 
-	char sFlagNames[ _6502_NUM_FLAGS+1 ] = ""; // = "NVRBDIZC"; // copy from g_aFlagNames
 	char sText[4] = "?";
 	RECT rect;
 
@@ -2540,8 +2539,6 @@ void DrawMemory ( int line, int iMemDump )
 
 	if ((eDevice == DEV_SY6522) || (eDevice == DEV_AY8910))
 		MB_GetSnapshot_v1(&SS_MB, 4+(nAddr>>1));		// Slot4 or Slot5
-
-	int nFontWidth = g_aFontConfig[ FONT_INFO ]._nFontWidthAvg;
 
 	RECT rect;
 	rect.left   = DISPLAY_MINIMEM_COLUMN;
@@ -2685,7 +2682,7 @@ void DrawMemory ( int line, int iMemDump )
 					ColorizeSpecialChar( sText, nData, iView, iBackground );
 				}
 			}
-			int nChars = PrintTextCursorX( sText, rect2 ); // PrintTextCursorX()
+			PrintTextCursorX( sText, rect2 ); // PrintTextCursorX()
 			iAddress++;
 		}
 		// Windows HACK: Bugfix: Rest of line is still background color
@@ -3632,8 +3629,6 @@ void DrawSubWindow_Data (Update_t bUpdate)
 
 	MemoryDump_t* pMD = &g_aMemDump[ iMemDump ];
 	USHORT       nAddress = pMD->nAddress;
-	DEVICE_e     eDevice  = pMD->eDevice;
-	MemoryView_e iView    = pMD->eView;
 
 //	if (!pMD->bActive)
 //		return;
@@ -3893,8 +3888,7 @@ void DrawSubWindow_Info ( Update_t bUpdate, int iWindow )
 		if (bUpdate & UPDATE_ZERO_PAGE)
 			DrawZeroPagePointers( yZeroPage );
 
-		bool bForceDisplaySoftSwitches = DEBUG_FORCE_DISPLAY || (bUpdate & UPDATE_SOFTSWITCHES);
-			DrawSoftSwitches( ySoft );
+		DrawSoftSwitches( ySoft );
 
 	#if defined(SUPPORT_Z80_EMU) && defined(OUTPUT_Z80_REGS)
 		DrawRegister( 19,"AF",2,*(WORD*)(membank+REG_AF));

--- a/source/Debugger/Debugger_Display.cpp
+++ b/source/Debugger/Debugger_Display.cpp
@@ -3616,7 +3616,7 @@ void DrawSubWindow_Data (Update_t bUpdate)
 	const int nMaxOpcodes = WINDOW_DATA_BYTES_PER_LINE;
 	char  sAddress[ 5 ];
 
-	assert( CONSOLE_WIDTH > WINDOW_DATA_BYTES_PER_LINE );
+	_ASSERT( CONSOLE_WIDTH > WINDOW_DATA_BYTES_PER_LINE );
 
 	char sOpcodes  [ CONSOLE_WIDTH ] = "";
 	char sImmediate[ 4 ]; // 'c'

--- a/source/Debugger/Debugger_Display.cpp
+++ b/source/Debugger/Debugger_Display.cpp
@@ -800,8 +800,8 @@ void DebuggerPrint ( int x, int y, const char *pText )
 
 	char c;
 	const char *p = pText;
-	
-	while (c = *p)
+
+	while ((c = *p))
 	{
 		if (c == '\n')
 		{
@@ -828,7 +828,7 @@ void DebuggerPrintColor( int x, int y, const conchar_t * pText )
 	if( !pText)
 		return;
 
-	while (g = (*pSrc))
+	while ((g = (*pSrc)))
 	{
 		if (g == '\n')
 		{

--- a/source/Frame.cpp
+++ b/source/Frame.cpp
@@ -176,7 +176,7 @@ static std::string driveTooltip;
 // __ Prototypes __________________________________________________________________________________
 void DrawCrosshairs (int x, int y);
 void UpdateMouseInAppleViewport(int iOutOfBoundsX, int iOutOfBoundsY, int x=0, int y=0);
-void ScreenWindowResize(const bool bCtrlKey);
+static void ScreenWindowResize(const bool bCtrlKey);
 void FrameResizeWindow(int nNewScale);
 
 
@@ -2484,7 +2484,7 @@ void SetNormalMode ()
 }
 
 //===========================================================================
-void SetUsingCursor (BOOL bNewValue)
+static void SetUsingCursor (BOOL bNewValue)
 {
 	if (bNewValue == g_bUsingCursor)
 		return;

--- a/source/Frame.h
+++ b/source/Frame.h
@@ -15,7 +15,6 @@
 	extern bool   g_bFreshReset;
 	extern std::string PathFilename[2];
 	extern bool   g_bScrollLock_FullSpeed;
-	extern int    g_nCharsetType;
 
 
 // Prototypes

--- a/source/Harddisk.cpp
+++ b/source/Harddisk.cpp
@@ -657,16 +657,16 @@ static BYTE __stdcall HD_IO_EMUL(WORD pc, WORD addr, BYTE bWrite, BYTE d, ULONG 
 			g_nHD_UnitNum = d;
 			break;
 		case 0xF4:
-			pHDD->hd_memblock = pHDD->hd_memblock & 0xFF00 | d;
+			pHDD->hd_memblock = (pHDD->hd_memblock & 0xFF00) | d;
 			break;
 		case 0xF5:
-			pHDD->hd_memblock = pHDD->hd_memblock & 0x00FF | (d << 8);
+			pHDD->hd_memblock = (pHDD->hd_memblock & 0x00FF) | (d << 8);
 			break;
 		case 0xF6:
-			pHDD->hd_diskblock = pHDD->hd_diskblock & 0xFF00 | d;
+			pHDD->hd_diskblock = (pHDD->hd_diskblock & 0xFF00) | d;
 			break;
 		case 0xF7:
-			pHDD->hd_diskblock = pHDD->hd_diskblock & 0x00FF | (d << 8);
+			pHDD->hd_diskblock = (pHDD->hd_diskblock & 0x00FF) | (d << 8);
 			break;
 		default:
 #if HD_LED

--- a/source/Keyboard.cpp
+++ b/source/Keyboard.cpp
@@ -118,7 +118,7 @@ BYTE KeybGetKeycode ()		// Used by IORead_C01x() and TapeRead() for Pravets8A
 
 //===========================================================================
 
-bool IsVirtualKeyAnAppleIIKey(WPARAM wparam);
+static bool IsVirtualKeyAnAppleIIKey(WPARAM wparam);
 
 void KeybQueueKeypress (WPARAM key, Keystroke_e bASCII)
 {

--- a/source/Memory.h
+++ b/source/Memory.h
@@ -54,8 +54,6 @@ extern LPBYTE     memdirty;
 
 #ifdef RAMWORKS
 const UINT kMaxExMemoryBanks = 127;	// 127 * aux mem(64K) + main mem(64K) = 8MB
-extern UINT       g_uMaxExPages;	// user requested ram pages (from cmd line)
-extern UINT       g_uActiveBank;
 #endif
 
 void	RegisterIoHandler(UINT uSlot, iofunction IOReadC0, iofunction IOWriteC0, iofunction IOReadCx, iofunction IOWriteCx, LPVOID lpSlotParameter, BYTE* pExpansionRom);

--- a/source/Mockingboard.cpp
+++ b/source/Mockingboard.cpp
@@ -1818,7 +1818,7 @@ static BYTE __stdcall MB_Write(WORD PC, WORD nAddr, BYTE bWrite, BYTE nValue, UL
 		}
 	}
 
-	BYTE nMB = (nAddr>>8)&0xf - SLOT4;
+	BYTE nMB = ((nAddr>>8)&0xf) - SLOT4;
 	BYTE nOffset = nAddr&0xff;
 
 	if(g_bPhasorEnable)

--- a/source/MouseInterface.cpp
+++ b/source/MouseInterface.cpp
@@ -44,7 +44,7 @@ Etc.
 #include "SaveState_Structs_common.h"
 #include "Common.h"
 
-#include "AppleWin.h"	// g_SynchronousEventMgr
+#include "Applewin.h"	// g_SynchronousEventMgr
 #include "CardManager.h"
 #include "CPU.h"
 #include "Frame.h"	// FrameSetCursorPosByMousePos()

--- a/source/SAM.cpp
+++ b/source/SAM.cpp
@@ -71,7 +71,7 @@ static BYTE __stdcall IOWrite_SAM(WORD pc, WORD addr, BYTE bWrite, BYTE d, ULONG
 	// 
 	//  SAM card     WAV driver           SAM WAV
 	//  0xFF 255     0x7f  127      _      FF  7F 
-	//  0x81 129     0x01    1     / \
+	//  0x81 129     0x01    1     / \     .
 	//  0x80 128     0x00    0    /   \   /80  00
 	//  0x7f 127     0xFF   -1         \_/
 	//  0x00   0     0x80 -128             00  80

--- a/source/SaveState.cpp
+++ b/source/SaveState.cpp
@@ -122,7 +122,6 @@ const std::string & Snapshot_GetPath()
 
 //-----------------------------------------------------------------------------
 
-static HANDLE m_hFile = INVALID_HANDLE_VALUE;
 static CConfigNeedingRestart m_ConfigNew;
 
 static std::string GetSnapshotUnitApple2Name(void)

--- a/source/Speaker.cpp
+++ b/source/Speaker.cpp
@@ -226,7 +226,7 @@ void SpkrInitialize ()
 {
 	if(g_fh)
 	{
-		fprintf(g_fh, "Spkr Config: soundtype = %d ",soundtype);
+		fprintf(g_fh, "Spkr Config: soundtype = %d ", (int) soundtype);
 		switch(soundtype)
 		{
 			case SOUND_NONE:   fprintf(g_fh, "(NONE)\n"); break;

--- a/source/SynchronousEventManager.cpp
+++ b/source/SynchronousEventManager.cpp
@@ -41,7 +41,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include "StdAfx.h"
 
-#include "AppleWin.h"
+#include "Applewin.h"
 #include "SynchronousEventManager.h"
 
 void SynchronousEventManager::Insert(SyncEvent* pNewEvent)


### PR DESCRIPTION
Again, another set of minor fixes for compiler warnings etc, making AppleWin more portable.
Most changes are no-brainers, separated into individual commits for clarity.

The only functional change is another debugger fix for the data window. When entering the debugger and switching to the data window ("data" command in the console) then the cursor keys did not work. They only worked, once the mini dump #1 in the right panel was also activated ("md1" command) - which made no sense. When the data is visible in the main window, then the cursor keys should also work.

Commit comment concerning g_uMaxExPages/g_uActiveBank below is not quite accurate: they are still used, of course, but declared "static" and now local within Memory.cpp, which contradicts their "extern" declaration in the header (and gcc does not like that).