### PR TITLE
Improve determining path & filename when saving/loading a save-state

### DIFF
--- a/help/CommandLine.html
+++ b/help/CommandLine.html
@@ -61,7 +61,7 @@
 		Emulate a RamWorks III card with 1 to 127 pages (each page is 64K, giving a max of 8MB) in the auxiliary slot in an Apple //e machine.<br><br>
 		-load-state &lt;savestate&gt;<br>
 		Load a save-state file (and auto power-on the Apple II).<br>
-		NB. This takes precedent over the -d1, -d2, -d#s#, -h1, -h2, s0-7, -model and -r switches.<br><br>
+		NB. This takes precedent over the -d1, -d2, -s#d#, -h1, -h2, s0-7, -model and -r switches.<br><br>
 		-f<br>
 		Start in full-screen mode<br><br>
 		-fs-height=&lt;best|nnnn&gt;<br>

--- a/source/Applewin.cpp
+++ b/source/Applewin.cpp
@@ -1179,6 +1179,12 @@ static bool DoDiskInsert(const UINT slot, const int nDrive, LPCSTR szFileName)
 {
 	Disk2InterfaceCard& disk2Card = dynamic_cast<Disk2InterfaceCard&>(GetCardMgr().GetRef(slot));
 
+	if (szFileName[0] == '\0')
+	{
+		disk2Card.EjectDisk(nDrive);
+		return true;
+	}
+
 	std::string strPathName = GetFullPath(szFileName);
 	if (strPathName.empty()) return false;
 
@@ -1191,6 +1197,12 @@ static bool DoDiskInsert(const UINT slot, const int nDrive, LPCSTR szFileName)
 
 static bool DoHardDiskInsert(const int nDrive, LPCSTR szFileName)
 {
+	if (szFileName[0] == '\0')
+	{
+		HD_Unplug(nDrive);
+		return true;
+	}
+
 	std::string strPathName = GetFullPath(szFileName);
 	if (strPathName.empty()) return false;
 
@@ -2099,7 +2111,10 @@ static void RepeatInitialization(void)
 			g_cmdLine.szImageName_harddisk[HARDDISK_1] = g_cmdLine.szImageName_harddisk[HARDDISK_2] = NULL;	// Don't insert on a restart
 
 			if (g_cmdLine.bSlotEmpty[7])
+			{
 				HD_SetEnabled(false);		// Disable HDD controller, but don't persist this to Registry/conf.ini (consistent with other '-sn empty' cmds)
+				Snapshot_UpdatePath();		// If save-state's filename is a harddisk, and the floppy is in the same path, then the filename won't be updated
+			}
 		}
 
 		// Set *after* InsertFloppyDisks() & InsertHardDisks(), which both update g_sCurrentDir

--- a/source/Applewin.cpp
+++ b/source/Applewin.cpp
@@ -835,7 +835,7 @@ void LoadConfiguration(void)
 
 //===========================================================================
 
-bool SetCurrentImageDir(const std::string& pszImageDir)
+bool SetCurrentImageDir(const std::string & pszImageDir)
 {
 	g_sCurrentDir = pszImageDir;
 

--- a/source/Applewin.cpp
+++ b/source/Applewin.cpp
@@ -786,6 +786,13 @@ void LoadConfiguration(void)
 
 	TCHAR szFilename[MAX_PATH];
 
+	// Load save-state pathname *before* inserting any harddisk/disk images (for both init & reinit cases)
+	// NB. inserting harddisk/disk can change snapshot pathname
+	RegLoadString(TEXT(REG_CONFIG), TEXT(REGVALUE_SAVESTATE_FILENAME), 1, szFilename, MAX_PATH, TEXT(""));	// Can be pathname or just filename
+	Snapshot_SetFilename(szFilename);	// If not in Registry than default will be used (ie. g_sCurrentDir + default filename)
+
+	//
+
 	RegLoadString(TEXT(REG_PREFS), TEXT(REGVALUE_PREF_HDV_START_DIR), 1, szFilename, MAX_PATH, TEXT(""));
 	if (szFilename[0] == '\0')
 		GetCurrentDirectory(sizeof(szFilename), szFilename);
@@ -803,11 +810,6 @@ void LoadConfiguration(void)
 	SetCurrentImageDir(szFilename);
 
 	GetCardMgr().GetDisk2CardMgr().LoadLastDiskImage();
-
-	//
-
-	RegLoadString(TEXT(REG_CONFIG), TEXT(REGVALUE_SAVESTATE_FILENAME), 1, szFilename, MAX_PATH, TEXT(""));	// Can be pathname or just filename
-	Snapshot_SetFilename(szFilename);	// If not in Registry than default will be used (ie. g_sCurrentDir + default filename)
 
 	//
 

--- a/source/CardManager.h
+++ b/source/CardManager.h
@@ -29,7 +29,7 @@ public:
 
 	void Insert(UINT slot, SS_CARDTYPE type);
 	void Remove(UINT slot);
-	SS_CARDTYPE QuerySlot(UINT slot) { return m_slot[slot]->QueryType(); }
+	SS_CARDTYPE QuerySlot(UINT slot) { _ASSERT(slot<NUM_SLOTS); return m_slot[slot]->QueryType(); }
 	Card& GetRef(UINT slot)
 	{
 		SS_CARDTYPE t=QuerySlot(slot); _ASSERT((t==CT_SSC || t==CT_MouseInterface || t==CT_Disk2) && m_slot[slot]);

--- a/source/Common.h
+++ b/source/Common.h
@@ -72,7 +72,7 @@ enum AppMode_e
 #define  REGVALUE_SOUND_EMULATION    "Sound Emulation"
 #define  REGVALUE_SPKR_VOLUME        "Speaker Volume"
 #define  REGVALUE_MB_VOLUME          "Mockingboard Volume"
-#define  REGVALUE_SAVESTATE_FILENAME "Save State Filename"
+#define  REGVALUE_SAVESTATE_FILENAME "Save State Filename"	// GH#691: Deprecated from 1.29.15
 #define  REGVALUE_SAVE_STATE_ON_EXIT "Save State On Exit"
 #define  REGVALUE_HDD_ENABLED        "Harddisk Enable"
 #define  REGVALUE_JOYSTICK0_EMU_TYPE		"Joystick0 Emu Type v3"	// GH#434: Added at 1.26.3.0 (previously was "Joystick0 Emu Type")
@@ -132,6 +132,8 @@ enum AppMode_e
 #define REGVALUE_PREF_HDV_START_DIR  "HDV Starting Directory"
 #define REGVALUE_PREF_LAST_HARDDISK_1 "Last Harddisk Image 1"
 #define REGVALUE_PREF_LAST_HARDDISK_2 "Last Harddisk Image 2"
+#define REGVALUE_PREF_SAVESTATE_START_DIR  "Save-state Starting Directory"	// GH#691: Added at 1.29.15
+#define REGVALUE_PREF_LAST_SAVESTATE "Last Save-state File"					// GH#691: Added at 1.29.15
 
 #define WM_USER_BENCHMARK	WM_USER+1
 #define WM_USER_RESTART		WM_USER+2

--- a/source/Common.h
+++ b/source/Common.h
@@ -72,7 +72,7 @@ enum AppMode_e
 #define  REGVALUE_SOUND_EMULATION    "Sound Emulation"
 #define  REGVALUE_SPKR_VOLUME        "Speaker Volume"
 #define  REGVALUE_MB_VOLUME          "Mockingboard Volume"
-#define  REGVALUE_SAVESTATE_FILENAME "Save State Filename"	// GH#691: Deprecated from 1.29.15
+#define  REGVALUE_SAVESTATE_FILENAME "Save State Filename"
 #define  REGVALUE_SAVE_STATE_ON_EXIT "Save State On Exit"
 #define  REGVALUE_HDD_ENABLED        "Harddisk Enable"
 #define  REGVALUE_JOYSTICK0_EMU_TYPE		"Joystick0 Emu Type v3"	// GH#434: Added at 1.26.3.0 (previously was "Joystick0 Emu Type")
@@ -132,8 +132,6 @@ enum AppMode_e
 #define REGVALUE_PREF_HDV_START_DIR  "HDV Starting Directory"
 #define REGVALUE_PREF_LAST_HARDDISK_1 "Last Harddisk Image 1"
 #define REGVALUE_PREF_LAST_HARDDISK_2 "Last Harddisk Image 2"
-#define REGVALUE_PREF_SAVESTATE_START_DIR  "Save-state Starting Directory"	// GH#691: Added at 1.29.15
-#define REGVALUE_PREF_LAST_SAVESTATE "Last Save-state File"					// GH#691: Added at 1.29.15
 
 #define WM_USER_BENCHMARK	WM_USER+1
 #define WM_USER_RESTART		WM_USER+2

--- a/source/Configuration/PageAdvanced.cpp
+++ b/source/Configuration/PageAdvanced.cpp
@@ -156,17 +156,8 @@ void CPageAdvanced::DlgOK(HWND hWnd)
 {
 	// Update save-state filename
 	{
-		char szFilename[MAX_PATH];
-		memset(szFilename, 0, sizeof(szFilename));
-		* (USHORT*) szFilename = sizeof(szFilename);
-
-		UINT nLineLength = SendDlgItemMessage(hWnd, IDC_SAVESTATE_FILENAME, EM_LINELENGTH, 0, 0);
-
-		SendDlgItemMessage(hWnd, IDC_SAVESTATE_FILENAME, EM_GETLINE, 0, (LPARAM)szFilename);
-
-		nLineLength = nLineLength > sizeof(szFilename)-1 ? sizeof(szFilename)-1 : nLineLength;
-		szFilename[nLineLength] = 0x00;
-
+		// NB. if SaveStateSelectImage() was called (by pressing the "Save State -> Browse..." button)
+		// and a new save-state file was selected ("OK" from the openfilename dialog) then m_bSSNewFilename etc. will have been set
 		m_PropertySheetHelper.SaveStateUpdate();
 	}
 

--- a/source/Configuration/PageAdvanced.cpp
+++ b/source/Configuration/PageAdvanced.cpp
@@ -140,8 +140,6 @@ BOOL CPageAdvanced::DlgProcInternal(HWND hWnd, UINT message, WPARAM wparam, LPAR
 
 			InitOptions(hWnd);
 
-			m_PropertySheetHelper.ClearSSNewDirectory();
-
 			// Need to specify cmd-line switch: -printer-real to enable this control
 			EnableWindow(GetDlgItem(hWnd, IDC_DUMPTOPRINTER), g_bEnableDumpToRealPrinter ? TRUE : FALSE);
 

--- a/source/Configuration/PageDisk.cpp
+++ b/source/Configuration/PageDisk.cpp
@@ -122,7 +122,6 @@ BOOL CPageDisk::DlgProcInternal(HWND hWnd, UINT message, WPARAM wparam, LPARAM l
 		case IDC_CIDERPRESS_BROWSE:
 			{
 				std::string CiderPressLoc = m_PropertySheetHelper.BrowseToFile(hWnd, TEXT("Select path to CiderPress"), REGVALUE_CIDERPRESSLOC, TEXT("Applications (*.exe)\0*.exe\0") TEXT("All Files\0*.*\0") );
-				RegSaveString(TEXT(REG_CONFIG), REGVALUE_CIDERPRESSLOC, 1, CiderPressLoc);
 				SendDlgItemMessage(hWnd, IDC_CIDERPRESS_FILENAME, WM_SETTEXT, 0, (LPARAM) CiderPressLoc.c_str());
 			}
 			break;
@@ -198,6 +197,22 @@ void CPageDisk::InitComboHDD(HWND hWnd, UINT /*slot*/)
 
 void CPageDisk::DlgOK(HWND hWnd)
 {
+	// Update CiderPress pathname
+	{
+		char szFilename[MAX_PATH];
+		memset(szFilename, 0, sizeof(szFilename));
+		* (USHORT*) szFilename = sizeof(szFilename);
+
+		UINT nLineLength = SendDlgItemMessage(hWnd, IDC_CIDERPRESS_FILENAME, EM_LINELENGTH, 0, 0);
+
+		SendDlgItemMessage(hWnd, IDC_CIDERPRESS_FILENAME, EM_GETLINE, 0, (LPARAM)szFilename);
+
+		nLineLength = nLineLength > sizeof(szFilename)-1 ? sizeof(szFilename)-1 : nLineLength;
+		szFilename[nLineLength] = 0x00;
+
+		RegSaveString(TEXT(REG_CONFIG), REGVALUE_CIDERPRESSLOC, 1, szFilename);
+	}
+
 	const bool bNewEnhanceDisk = SendDlgItemMessage(hWnd, IDC_DISKTYPE,CB_GETCURSEL, 0, 0) ? true : false;
 	if (bNewEnhanceDisk != GetCardMgr().GetDisk2CardMgr().GetEnhanceDisk())
 	{

--- a/source/Configuration/PropertySheet.cpp
+++ b/source/Configuration/PropertySheet.cpp
@@ -92,8 +92,6 @@ DWORD CPropertySheet::GetVolumeMax()
 // Called when F11/F12 is pressed
 bool CPropertySheet::SaveStateSelectImage(HWND hWindow, bool bSave)
 {
-	m_PropertySheetHelper.ClearSSNewDirectory();
-
 	if(m_PropertySheetHelper.SaveStateSelectImage(hWindow, bSave ? TEXT("Select Save State file")
 																 : TEXT("Select Load State file"), bSave))
 	{

--- a/source/Configuration/PropertySheetHelper.cpp
+++ b/source/Configuration/PropertySheetHelper.cpp
@@ -188,57 +188,18 @@ void CPropertySheetHelper::SaveStateUpdate()
 	}
 }
 
-// NB. OK'ing this property sheet will call Snapshot_SetFilename() with this new filename
+// NB. OK'ing this property sheet will call SaveStateUpdate()->Snapshot_SetFilename() with this new path & filename
 int CPropertySheetHelper::SaveStateSelectImage(HWND hWindow, TCHAR* pszTitle, bool bSave)
 {
-	// Attempt to get a default filename/path based on harddisk plugged-in or floppy disk inserted
-	// . Priority given to harddisk over floppy images
-	std::string defaultFilename;
-	std::string defaultPath;
+	// Whenever harddisks/disks are inserted and *if path has changed* then:
+	// . Snapshot's path & Snapshot's filename will be updated to reflect the new defaults.
 
-	HD_GetFilenameAndPathForSaveState(defaultFilename, defaultPath);
-	if (defaultFilename.empty())
-		GetCardMgr().GetDisk2CardMgr().GetFilenameAndPathForSaveState(defaultFilename, defaultPath);
-
-	if (!defaultFilename.empty())
-		defaultFilename += ".aws.yaml";
-
-	//
-
-	std::string szDirectory;
-	std::string tempFilename;
-
-	if (bSave)
-	{
-		// Attempt to use harddisk's or floppy disk's image name as the name for the .aws.yaml file
-		// Else Attempt to use the Prop Sheet's filename
-		tempFilename = defaultFilename;
-		szDirectory = defaultPath;
-
-		if (tempFilename.empty())
-		{
-			tempFilename = Snapshot_GetFilename();
-			szDirectory = Snapshot_GetPath();
-		}
-	}
-	else	// Load (or Browse)
-	{
-		// Attempt to use the Prop Sheet's filename first
-		// Else attempt to use harddisk's or floppy disk's image name as the name for the .aws.yaml file
-		tempFilename = Snapshot_GetFilename();
-		if (tempFilename.empty())
-			tempFilename = defaultFilename;
-
-		szDirectory = Snapshot_GetPath();
-	}
-
+	std::string szDirectory= Snapshot_GetPath();
 	if (szDirectory.empty())
 		szDirectory = g_sCurrentDir;
 
-	// convert tempFilename to char * for the rest of the function
-	TCHAR szFilename[MAX_PATH] = {0};
-	strcpy(szFilename, tempFilename.c_str());
-	tempFilename.clear(); // do NOT use this any longer
+	char szFilename[MAX_PATH] = {0};
+	strcpy(szFilename, Snapshot_GetFilename().c_str());
 
 	//
 

--- a/source/Configuration/PropertySheetHelper.cpp
+++ b/source/Configuration/PropertySheetHelper.cpp
@@ -184,9 +184,7 @@ void CPropertySheetHelper::SaveStateUpdate()
 	if (m_bSSNewFilename)
 	{
 		Snapshot_SetFilename(m_szSSNewFilename, m_szSSNewDirectory);
-
-		RegSaveString(TEXT(REG_PREFS), REGVALUE_PREF_LAST_SAVESTATE, 1, m_szSSNewFilename);
-		RegSaveString(TEXT(REG_PREFS), REGVALUE_PREF_SAVESTATE_START_DIR, 1, m_szSSNewDirectory);
+		RegSaveString(TEXT(REG_PREFS), TEXT(REGVALUE_SAVESTATE_FILENAME), 1, Snapshot_GetPathname());
 	}
 }
 
@@ -299,7 +297,6 @@ int CPropertySheetHelper::SaveStateSelectImage(HWND hWindow, TCHAR* pszTitle, bo
 		}
 
 		m_szSSNewFilename = &szFilename[ofn.nFileOffset];
-		m_szSSNewPathname = szFilename;
 
 		szFilename[ofn.nFileOffset] = 0;
 		m_szSSNewDirectory = szFilename;	// always set this, even if unchanged

--- a/source/Configuration/PropertySheetHelper.cpp
+++ b/source/Configuration/PropertySheetHelper.cpp
@@ -184,20 +184,20 @@ void CPropertySheetHelper::SaveStateUpdate()
 	if (m_bSSNewFilename)
 	{
 		Snapshot_SetFilename(m_szSSNewFilename, m_szSSNewDirectory);
-		RegSaveString(TEXT(REG_PREFS), TEXT(REGVALUE_SAVESTATE_FILENAME), 1, Snapshot_GetPathname());
+		RegSaveString(TEXT(REG_CONFIG), TEXT(REGVALUE_SAVESTATE_FILENAME), 1, Snapshot_GetPathname());
 	}
 }
 
-void CPropertySheetHelper::GetDiskBaseNameWithAWS(std::string & pszFilename)
+void CPropertySheetHelper::GetDiskBaseNameWithAWS(std::string & szFilename)
 {
-	if (GetCardMgr().QuerySlot(SLOT6) != CT_Disk2)
-		return;
+	szFilename.clear();
 
-	const std::string& diskName = dynamic_cast<Disk2InterfaceCard&>(GetCardMgr().GetRef(SLOT6)).GetBaseName(DRIVE_1);
-	if (!diskName.empty())
-	{
-		pszFilename = diskName + ".aws.yaml";
-	}
+	HD_GetFilenameForSaveState(szFilename);
+	if (szFilename.empty())
+		GetCardMgr().GetDisk2CardMgr().GetFilenameForSaveState(szFilename);
+
+	if (!szFilename.empty())
+		szFilename += ".aws.yaml";
 }
 
 // NB. OK'ing this property sheet will call Snapshot_SetFilename() with this new filename
@@ -208,18 +208,22 @@ int CPropertySheetHelper::SaveStateSelectImage(HWND hWindow, TCHAR* pszTitle, bo
 
 	if (bSave)
 	{
-		// Attempt to use drive1's image name as the name for the .aws file
+		// Attempt to use harddisk's or floppy disk's image name as the name for the .aws.yaml file
 		// Else Attempt to use the Prop Sheet's filename
 		GetDiskBaseNameWithAWS(tempFilename);
 		if (tempFilename.empty())
 		{
 			tempFilename = Snapshot_GetFilename();
 		}
+
+		HD_GetPathForSaveState(szDirectory);
+		if (szDirectory.empty())
+			GetCardMgr().GetDisk2CardMgr().GetPathForSaveState(szDirectory);
 	}
 	else	// Load (or Browse)
 	{
 		// Attempt to use the Prop Sheet's filename first
-		// Else attempt to use drive1's image name as the name for the .aws file
+		// Else attempt to use harddisk's or floppy disk's image name as the name for the .aws.yaml file
 		tempFilename = Snapshot_GetFilename();
 		if (tempFilename.empty())
 		{

--- a/source/Configuration/PropertySheetHelper.cpp
+++ b/source/Configuration/PropertySheetHelper.cpp
@@ -194,11 +194,11 @@ int CPropertySheetHelper::SaveStateSelectImage(HWND hWindow, TCHAR* pszTitle, bo
 	// Whenever harddisks/disks are inserted and *if path has changed* then:
 	// . Snapshot's path & Snapshot's filename will be updated to reflect the new defaults.
 
-	std::string szDirectory= Snapshot_GetPath();
+	std::string szDirectory = Snapshot_GetPath();
 	if (szDirectory.empty())
 		szDirectory = g_sCurrentDir;
 
-	char szFilename[MAX_PATH] = {0};
+	char szFilename[MAX_PATH];
 	strcpy(szFilename, Snapshot_GetFilename().c_str());
 
 	//
@@ -209,18 +209,10 @@ int CPropertySheetHelper::SaveStateSelectImage(HWND hWindow, TCHAR* pszTitle, bo
 	ofn.lStructSize     = sizeof(OPENFILENAME);
 	ofn.hwndOwner       = hWindow;
 	ofn.hInstance       = g_hInstance;
-	if (bSave)
-	{
-		ofn.lpstrFilter = TEXT("Save State files (*.aws.yaml)\0*.aws.yaml\0");
+	ofn.lpstrFilter     = TEXT("Save State files (*.aws.yaml)\0*.aws.yaml\0");
 						  TEXT("All Files\0*.*\0");
-	}
-	else
-	{
-		ofn.lpstrFilter = TEXT("Save State files (*.aws,*.aws.yaml)\0*.aws;*.aws.yaml\0");
-						  TEXT("All Files\0*.*\0");
-	}
 	ofn.lpstrFile       = szFilename;	// Dialog strips the last .EXT from this string (eg. file.aws.yaml is displayed as: file.aws
-	ofn.nMaxFile        = MAX_PATH;
+	ofn.nMaxFile        = sizeof(szFilename);
 	ofn.lpstrInitialDir = szDirectory.c_str();
 	ofn.Flags           = OFN_PATHMUSTEXIST | OFN_HIDEREADONLY;
 	ofn.lpstrTitle      = pszTitle;

--- a/source/Configuration/PropertySheetHelper.cpp
+++ b/source/Configuration/PropertySheetHelper.cpp
@@ -191,7 +191,7 @@ void CPropertySheetHelper::SaveStateUpdate()
 // NB. OK'ing this property sheet will call SaveStateUpdate()->Snapshot_SetFilename() with this new path & filename
 int CPropertySheetHelper::SaveStateSelectImage(HWND hWindow, TCHAR* pszTitle, bool bSave)
 {
-	// Whenever harddisks/disks are inserted and *if path has changed* then:
+	// Whenever harddisks/disks are inserted (or removed) and *if path has changed* then:
 	// . Snapshot's path & Snapshot's filename will be updated to reflect the new defaults.
 
 	std::string szDirectory = Snapshot_GetPath();

--- a/source/Configuration/PropertySheetHelper.cpp
+++ b/source/Configuration/PropertySheetHelper.cpp
@@ -183,12 +183,10 @@ void CPropertySheetHelper::SaveStateUpdate()
 {
 	if (m_bSSNewFilename)
 	{
-		Snapshot_SetFilename(m_szSSNewPathname);
+		Snapshot_SetFilename(m_szSSNewFilename, m_szSSNewDirectory);
 
-		RegSaveString(TEXT(REG_PREFS), REGVALUE_PREF_LAST_SAVESTATE, 1, m_szSSNewPathname);
-
-		if (!m_szSSNewDirectory.empty())
-			RegSaveString(TEXT(REG_PREFS), REGVALUE_PREF_SAVESTATE_START_DIR, 1, m_szSSNewDirectory);
+		RegSaveString(TEXT(REG_PREFS), REGVALUE_PREF_LAST_SAVESTATE, 1, m_szSSNewFilename);
+		RegSaveString(TEXT(REG_PREFS), REGVALUE_PREF_SAVESTATE_START_DIR, 1, m_szSSNewDirectory);
 	}
 }
 
@@ -304,8 +302,7 @@ int CPropertySheetHelper::SaveStateSelectImage(HWND hWindow, TCHAR* pszTitle, bo
 		m_szSSNewPathname = szFilename;
 
 		szFilename[ofn.nFileOffset] = 0;
-		if (_stricmp(szDirectory.c_str(), szFilename))
-			m_szSSNewDirectory = szFilename;
+		m_szSSNewDirectory = szFilename;	// always set this, even if unchanged
 	}
 
 	m_bSSNewFilename = nRes ? true : false;

--- a/source/Configuration/PropertySheetHelper.h
+++ b/source/Configuration/PropertySheetHelper.h
@@ -53,7 +53,6 @@ private:
 
 	PAGETYPE m_LastPage;
 	UINT32 m_bmPages;
-	std::string m_szNewFilename;
 	bool m_bSSNewFilename;
 	std::string m_szSSNewDirectory;
 	std::string m_szSSNewFilename;

--- a/source/Configuration/PropertySheetHelper.h
+++ b/source/Configuration/PropertySheetHelper.h
@@ -48,7 +48,6 @@ private:
 	void RestoreCurrentConfig(void);
 	std::string GetSlot(const UINT uSlot);
 	std::string GetCardName(const SS_CARDTYPE CardType);
-	void GetDiskBaseNameWithAWS(std::string & pszFilename);
 
 	PAGETYPE m_LastPage;
 	UINT32 m_bmPages;

--- a/source/Configuration/PropertySheetHelper.h
+++ b/source/Configuration/PropertySheetHelper.h
@@ -30,7 +30,6 @@ public:
 
 	void SaveCurrentConfig(void);
 	const std::string & GetSSNewFilename(void) { return m_szSSNewFilename; }
-	void ClearSSNewDirectory(void) { m_szSSNewDirectory.clear(); }
 //	const CConfigNeedingRestart& GetConfigOld(void) { return m_ConfigOld; }
 	CConfigNeedingRestart& GetConfigNew(void) { return m_ConfigNew; }
 	bool IsConfigChanged(void) { return m_ConfigNew != m_ConfigOld; }

--- a/source/Configuration/PropertySheetHelper.h
+++ b/source/Configuration/PropertySheetHelper.h
@@ -55,7 +55,6 @@ private:
 	bool m_bSSNewFilename;
 	std::string m_szSSNewDirectory;
 	std::string m_szSSNewFilename;
-	std::string m_szSSNewPathname;
 	CConfigNeedingRestart m_ConfigOld;
 	CConfigNeedingRestart m_ConfigNew;
 	bool m_bDoBenchmark;

--- a/source/Disk.cpp
+++ b/source/Disk.cpp
@@ -562,8 +562,9 @@ const std::string & Disk2InterfaceCard::GetBaseName(const int drive)
 	return m_floppyDrive[drive].m_disk.m_imagename;
 }
 
-void Disk2InterfaceCard::GetPathForSaveState(std::string& path)
+void Disk2InterfaceCard::GetFilenameAndPathForSaveState(std::string& filename, std::string& path)
 {
+	filename = "";
 	path = "";
 
 	for (UINT i=DRIVE_1; i<=DRIVE_2; i++)
@@ -571,6 +572,7 @@ void Disk2InterfaceCard::GetPathForSaveState(std::string& path)
 		if (IsDriveEmpty(i))
 			continue;
 
+		filename = GetBaseName(i);
 		std::string pathname = DiskGetFullPathName(i);
 
 		int idx = pathname.find_last_of('\\');
@@ -582,20 +584,6 @@ void Disk2InterfaceCard::GetPathForSaveState(std::string& path)
 
 		_ASSERT(0);
 		break;
-	}
-}
-
-void Disk2InterfaceCard::GetFilenameForSaveState(std::string& filename)
-{
-	filename = "";
-
-	for (UINT i=DRIVE_1; i<=DRIVE_2; i++)
-	{
-		if (IsDriveEmpty(i))
-			continue;
-
-		filename = GetBaseName(i);
-		return;
 	}
 }
 

--- a/source/Disk.cpp
+++ b/source/Disk.cpp
@@ -40,7 +40,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "Log.h"
 #include "Memory.h"
 #include "Registry.h"
-#include "SaveState.h"
 #include "Video.h"
 #include "YamlHelper.h"
 

--- a/source/Disk.cpp
+++ b/source/Disk.cpp
@@ -343,6 +343,7 @@ void Disk2InterfaceCard::EjectDisk(const int drive)
 		return;
 
 	EjectDiskInternal(drive);
+	Snapshot_UpdatePath();
 
 	SaveLastDiskImage(drive);
 	Video_ResetScreenshotCounter("");

--- a/source/Disk.cpp
+++ b/source/Disk.cpp
@@ -563,6 +563,43 @@ const std::string & Disk2InterfaceCard::GetBaseName(const int drive)
 	return m_floppyDrive[drive].m_disk.m_imagename;
 }
 
+void Disk2InterfaceCard::GetPathForSaveState(std::string& path)
+{
+	path = "";
+
+	for (UINT i=DRIVE_1; i<=DRIVE_2; i++)
+	{
+		if (IsDriveEmpty(i))
+			continue;
+
+		std::string pathname = DiskGetFullPathName(i);
+
+		int idx = pathname.find_last_of('\\');
+		if (idx >= 0 && idx+1 < (int)pathname.length())	// path exists?
+		{
+			path = pathname.substr(0, idx+1);
+			return;
+		}
+
+		_ASSERT(0);
+		break;
+	}
+}
+
+void Disk2InterfaceCard::GetFilenameForSaveState(std::string& filename)
+{
+	filename = "";
+
+	for (UINT i=DRIVE_1; i<=DRIVE_2; i++)
+	{
+		if (IsDriveEmpty(i))
+			continue;
+
+		filename = GetBaseName(i);
+		return;
+	}
+}
+
 const std::string & Disk2InterfaceCard::DiskGetFullPathName(const int drive)
 {
 	return ImageGetPathname(m_floppyDrive[drive].m_disk.m_imagehandle);
@@ -663,13 +700,6 @@ ImageError_e Disk2InterfaceCard::InsertDisk(const int drive, LPCTSTR pszImageFil
 	{
 		GetImageTitle(pszImageFilename, pFloppy->m_imagename, pFloppy->m_fullname);
 		Video_ResetScreenshotCounter(pFloppy->m_imagename);
-
-		{
-			char szCurrentPathname[MAX_PATH];
-			DWORD uNameLen = GetFullPathName(pszImageFilename, MAX_PATH, szCurrentPathname, NULL);
-			if (uNameLen)
-				Snapshot_UpdatePath(szCurrentPathname, true);
-		}
 
 		if (g_nAppMode == MODE_LOGO)
 			InitFirmware(GetCxRomPeripheral());

--- a/source/Disk.cpp
+++ b/source/Disk.cpp
@@ -40,6 +40,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "Log.h"
 #include "Memory.h"
 #include "Registry.h"
+#include "SaveState.h"
 #include "Video.h"
 #include "YamlHelper.h"
 
@@ -686,6 +687,8 @@ ImageError_e Disk2InterfaceCard::InsertDisk(const int drive, LPCTSTR pszImageFil
 	if (Error == eIMAGE_ERROR_NONE)
 	{
 		GetImageTitle(pszImageFilename, pFloppy->m_imagename, pFloppy->m_fullname);
+		Snapshot_UpdatePath();
+
 		Video_ResetScreenshotCounter(pFloppy->m_imagename);
 
 		if (g_nAppMode == MODE_LOGO)

--- a/source/Disk.h
+++ b/source/Disk.h
@@ -135,6 +135,8 @@ public:
 	const std::string & GetFullDiskFilename(const int drive);
 	const std::string & GetFullName(const int drive);
 	const std::string & GetBaseName(const int drive);
+	void GetPathForSaveState(std::string& path);
+	void GetFilenameForSaveState(std::string& filename);
 	void GetLightStatus (Disk_Status_e* pDisk1Status, Disk_Status_e* pDisk2Status);
 
 	ImageError_e InsertDisk(const int drive, LPCTSTR pszImageFilename, const bool bForceWriteProtected, const bool bCreateIfNecessary);

--- a/source/Disk.h
+++ b/source/Disk.h
@@ -135,8 +135,7 @@ public:
 	const std::string & GetFullDiskFilename(const int drive);
 	const std::string & GetFullName(const int drive);
 	const std::string & GetBaseName(const int drive);
-	void GetPathForSaveState(std::string& path);
-	void GetFilenameForSaveState(std::string& filename);
+	void GetFilenameAndPathForSaveState(std::string& filename, std::string& path);
 	void GetLightStatus (Disk_Status_e* pDisk1Status, Disk_Status_e* pDisk2Status);
 
 	ImageError_e InsertDisk(const int drive, LPCTSTR pszImageFilename, const bool bForceWriteProtected, const bool bCreateIfNecessary);

--- a/source/Disk2CardManager.cpp
+++ b/source/Disk2CardManager.cpp
@@ -133,25 +133,13 @@ bool Disk2CardManager::IsAnyFirmware13Sector(void)
 	return false;
 }
 
-void Disk2CardManager::GetPathForSaveState(std::string& path)
+void Disk2CardManager::GetFilenameAndPathForSaveState(std::string& filename, std::string& path)
 {
 	for (int i = NUM_SLOTS-1; i >= 0; i--)	// scan slots backwards: 7->0
 	{
 		if (GetCardMgr().QuerySlot(i) == CT_Disk2)
 		{
-			dynamic_cast<Disk2InterfaceCard&>(GetCardMgr().GetRef(i)).GetPathForSaveState(path);
-			return;
-		}
-	}
-}
-
-void Disk2CardManager::GetFilenameForSaveState(std::string& filename)
-{
-	for (int i = NUM_SLOTS-1; i >= 0; i--)	// scan slots backwards: 7->0
-	{
-		if (GetCardMgr().QuerySlot(i) == CT_Disk2)
-		{
-			dynamic_cast<Disk2InterfaceCard&>(GetCardMgr().GetRef(i)).GetFilenameForSaveState(filename);
+			dynamic_cast<Disk2InterfaceCard&>(GetCardMgr().GetRef(i)).GetFilenameAndPathForSaveState(filename, path);
 			return;
 		}
 	}

--- a/source/Disk2CardManager.cpp
+++ b/source/Disk2CardManager.cpp
@@ -140,7 +140,8 @@ void Disk2CardManager::GetFilenameAndPathForSaveState(std::string& filename, std
 		if (GetCardMgr().QuerySlot(i) == CT_Disk2)
 		{
 			dynamic_cast<Disk2InterfaceCard&>(GetCardMgr().GetRef(i)).GetFilenameAndPathForSaveState(filename, path);
-			return;
+			if (!filename.empty())
+				return;
 		}
 	}
 }

--- a/source/Disk2CardManager.cpp
+++ b/source/Disk2CardManager.cpp
@@ -132,3 +132,27 @@ bool Disk2CardManager::IsAnyFirmware13Sector(void)
 	}
 	return false;
 }
+
+void Disk2CardManager::GetPathForSaveState(std::string& path)
+{
+	for (int i = NUM_SLOTS-1; i >= 0; i--)	// scan slots backwards: 7->0
+	{
+		if (GetCardMgr().QuerySlot(i) == CT_Disk2)
+		{
+			dynamic_cast<Disk2InterfaceCard&>(GetCardMgr().GetRef(i)).GetPathForSaveState(path);
+			return;
+		}
+	}
+}
+
+void Disk2CardManager::GetFilenameForSaveState(std::string& filename)
+{
+	for (int i = NUM_SLOTS-1; i >= 0; i--)	// scan slots backwards: 7->0
+	{
+		if (GetCardMgr().QuerySlot(i) == CT_Disk2)
+		{
+			dynamic_cast<Disk2InterfaceCard&>(GetCardMgr().GetRef(i)).GetFilenameForSaveState(filename);
+			return;
+		}
+	}
+}

--- a/source/Disk2CardManager.h
+++ b/source/Disk2CardManager.h
@@ -14,6 +14,5 @@ public:
 	void LoadLastDiskImage(void);
 	void Destroy(void);
 	bool IsAnyFirmware13Sector(void);
-	void GetPathForSaveState(std::string& path);
-	void GetFilenameForSaveState(std::string& filename);
+	void GetFilenameAndPathForSaveState(std::string& filename, std::string& path);
 };

--- a/source/Disk2CardManager.h
+++ b/source/Disk2CardManager.h
@@ -14,4 +14,6 @@ public:
 	void LoadLastDiskImage(void);
 	void Destroy(void);
 	bool IsAnyFirmware13Sector(void);
+	void GetPathForSaveState(std::string& path);
+	void GetFilenameForSaveState(std::string& filename);
 };

--- a/source/Harddisk.cpp
+++ b/source/Harddisk.cpp
@@ -37,7 +37,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "Harddisk.h"
 #include "Memory.h"
 #include "Registry.h"
-#include "SaveState.h"
 #include "YamlHelper.h"
 
 #include "../resource/resource.h"

--- a/source/Harddisk.cpp
+++ b/source/Harddisk.cpp
@@ -313,8 +313,14 @@ const std::string & HD_GetFullPathName(const int iDrive)
 	return ImageGetPathname(g_HardDisk[iDrive].imagehandle);
 }
 
-void HD_GetPathForSaveState(std::string& path)
+static const std::string & HD_DiskGetBaseName(const int iDrive)
 {
+	return g_HardDisk[iDrive].imagename;
+}
+
+void HD_GetFilenameAndPathForSaveState(std::string& filename, std::string& path)
+{
+	filename = "";
 	path = "";
 
 	if (!g_bHD_Enabled)
@@ -325,6 +331,7 @@ void HD_GetPathForSaveState(std::string& path)
 		if (!g_HardDisk[i].hd_imageloaded)
 			continue;
 
+		filename = HD_DiskGetBaseName(i);
 		std::string pathname = HD_GetFullPathName(i);
 
 		int idx = pathname.find_last_of('\\');
@@ -336,28 +343,6 @@ void HD_GetPathForSaveState(std::string& path)
 
 		_ASSERT(0);
 		break;
-	}
-}
-
-static const std::string & HD_DiskGetBaseName(const int iDrive)
-{
-	return g_HardDisk[iDrive].imagename;
-}
-
-void HD_GetFilenameForSaveState(std::string& filename)
-{
-	filename = "";
-
-	if (!g_bHD_Enabled)
-		return;
-
-	for (UINT i=HARDDISK_1; i<=HARDDISK_2; i++)
-	{
-		if (!g_HardDisk[i].hd_imageloaded)
-			continue;
-
-		filename = HD_DiskGetBaseName(i);
-		return;
 	}
 }
 

--- a/source/Harddisk.cpp
+++ b/source/Harddisk.cpp
@@ -37,6 +37,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "Harddisk.h"
 #include "Memory.h"
 #include "Registry.h"
+#include "SaveState.h"
 #include "YamlHelper.h"
 
 #include "../resource/resource.h"
@@ -440,6 +441,7 @@ BOOL HD_Insert(const int iDrive, const std::string & pszImageFilename)
 	if (Error == eIMAGE_ERROR_NONE)
 	{
 		GetImageTitle(pszImageFilename.c_str(), g_HardDisk[iDrive].imagename, g_HardDisk[iDrive].fullname);
+		Snapshot_UpdatePath();
 	}
 
 	HD_SaveLastDiskImage(iDrive);

--- a/source/Harddisk.cpp
+++ b/source/Harddisk.cpp
@@ -144,7 +144,7 @@ struct HDD
 	}
 
 	// From FloppyDisk
-	std::string	imagename;	// <FILENAME> (ie. no extension)    [not used]
+	std::string	imagename;	// <FILENAME> (ie. no extension)
 	std::string fullname;	// <FILENAME.EXT> or <FILENAME.zip>
 	std::string strFilenameInZip;					// ""             or <FILENAME.EXT> [not used]
 	ImageInfo*	imagehandle;			// Init'd by HD_Insert() -> ImageOpen()
@@ -314,11 +314,53 @@ const std::string & HD_GetFullPathName(const int iDrive)
 	return ImageGetPathname(g_HardDisk[iDrive].imagehandle);
 }
 
-static const std::string & HD_DiskGetBaseName(const int iDrive)	// Not used
+void HD_GetPathForSaveState(std::string& path)
+{
+	path = "";
+
+	if (!g_bHD_Enabled)
+		return;
+
+	for (UINT i=HARDDISK_1; i<=HARDDISK_2; i++)
+	{
+		if (!g_HardDisk[i].hd_imageloaded)
+			continue;
+
+		std::string pathname = HD_GetFullPathName(i);
+
+		int idx = pathname.find_last_of('\\');
+		if (idx >= 0 && idx+1 < (int)pathname.length())	// path exists?
+		{
+			path = pathname.substr(0, idx+1);
+			return;
+		}
+
+		_ASSERT(0);
+		break;
+	}
+}
+
+static const std::string & HD_DiskGetBaseName(const int iDrive)
 {
 	return g_HardDisk[iDrive].imagename;
 }
 
+void HD_GetFilenameForSaveState(std::string& filename)
+{
+	filename = "";
+
+	if (!g_bHD_Enabled)
+		return;
+
+	for (UINT i=HARDDISK_1; i<=HARDDISK_2; i++)
+	{
+		if (!g_HardDisk[i].hd_imageloaded)
+			continue;
+
+		filename = HD_DiskGetBaseName(i);
+		return;
+	}
+}
 
 //-------------------------------------
 
@@ -414,7 +456,6 @@ BOOL HD_Insert(const int iDrive, const std::string & pszImageFilename)
 	if (Error == eIMAGE_ERROR_NONE)
 	{
 		GetImageTitle(pszImageFilename.c_str(), g_HardDisk[iDrive].imagename, g_HardDisk[iDrive].fullname);
-		Snapshot_UpdatePath(pszImageFilename, false);
 	}
 
 	HD_SaveLastDiskImage(iDrive);

--- a/source/Harddisk.cpp
+++ b/source/Harddisk.cpp
@@ -37,6 +37,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "Harddisk.h"
 #include "Memory.h"
 #include "Registry.h"
+#include "SaveState.h"
 #include "YamlHelper.h"
 
 #include "../resource/resource.h"
@@ -413,6 +414,7 @@ BOOL HD_Insert(const int iDrive, const std::string & pszImageFilename)
 	if (Error == eIMAGE_ERROR_NONE)
 	{
 		GetImageTitle(pszImageFilename.c_str(), g_HardDisk[iDrive].imagename, g_HardDisk[iDrive].fullname);
+		Snapshot_UpdatePath(pszImageFilename, false);
 	}
 
 	HD_SaveLastDiskImage(iDrive);

--- a/source/Harddisk.cpp
+++ b/source/Harddisk.cpp
@@ -503,7 +503,10 @@ bool HD_Select(const int iDrive)
 void HD_Unplug(const int iDrive)
 {
 	if (g_HardDisk[iDrive].hd_imageloaded)
+	{
 		HD_CleanupDrive(iDrive);
+		Snapshot_UpdatePath();
+	}
 }
 
 bool HD_IsDriveUnplugged(const int iDrive)

--- a/source/Harddisk.h
+++ b/source/Harddisk.h
@@ -35,8 +35,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 	void HD_SetEnabled(const bool bEnabled);
 	const std::string & HD_GetFullName(const int iDrive);
 	const std::string & HD_GetFullPathName(const int iDrive);
-	void HD_GetPathForSaveState(std::string& path);
-	void HD_GetFilenameForSaveState(std::string& filename);
+	void HD_GetFilenameAndPathForSaveState(std::string& filename, std::string& path);
 	void HD_Reset(void);
 	void HD_Load_Rom(const LPBYTE pCxRomPeripheral, const UINT uSlot);
 	bool HD_Select(const int iDrive);

--- a/source/Harddisk.h
+++ b/source/Harddisk.h
@@ -35,6 +35,8 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 	void HD_SetEnabled(const bool bEnabled);
 	const std::string & HD_GetFullName(const int iDrive);
 	const std::string & HD_GetFullPathName(const int iDrive);
+	void HD_GetPathForSaveState(std::string& path);
+	void HD_GetFilenameForSaveState(std::string& filename);
 	void HD_Reset(void);
 	void HD_Load_Rom(const LPBYTE pCxRomPeripheral, const UINT uSlot);
 	bool HD_Select(const int iDrive);

--- a/source/SaveState.cpp
+++ b/source/SaveState.cpp
@@ -150,6 +150,7 @@ void Snapshot_GetDefaultFilenameAndPath(std::string& defaultFilename, std::strin
 }
 
 // Called by Disk2InterfaceCard::InsertDisk() and HD_Insert() after a successful insertion
+// Called by Disk2InterfaceCard::EjectDisk() and HD_Unplug()
 void Snapshot_UpdatePath(void)
 {
 	std::string defaultFilename;

--- a/source/SaveState.cpp
+++ b/source/SaveState.cpp
@@ -139,6 +139,32 @@ const std::string& Snapshot_GetPathname(void)
 	return g_strSaveStatePathname;
 }
 
+// Called on successful insertion and on prompting to save/load a save-state
+void Snapshot_GetDefaultFilenameAndPath(std::string& defaultFilename, std::string& defaultPath)
+{
+	// Attempt to get a default filename/path based on harddisk plugged-in or floppy disk inserted
+	// . Priority given to harddisk over floppy images
+	HD_GetFilenameAndPathForSaveState(defaultFilename, defaultPath);
+	if (defaultFilename.empty())
+		GetCardMgr().GetDisk2CardMgr().GetFilenameAndPathForSaveState(defaultFilename, defaultPath);
+}
+
+// Called by Disk2InterfaceCard::InsertDisk() and HD_Insert() after a successful insertion
+void Snapshot_UpdatePath(void)
+{
+	std::string defaultFilename;
+	std::string defaultPath;
+	Snapshot_GetDefaultFilenameAndPath(defaultFilename, defaultPath);
+
+	if (g_strSaveStatePath == defaultPath)
+		return;
+
+	if (!defaultFilename.empty())
+		defaultFilename += ".aws.yaml";
+
+	Snapshot_SetFilename(defaultFilename, defaultPath);
+}
+
 //-----------------------------------------------------------------------------
 
 static HANDLE m_hFile = INVALID_HANDLE_VALUE;

--- a/source/SaveState.cpp
+++ b/source/SaveState.cpp
@@ -87,7 +87,7 @@ static void Snapshot_SetPathname(const std::string& strPathname)
 		g_strSaveStateFilename = DEFAULT_SNAPSHOT_NAME;
 
 		g_strSaveStatePathname = g_sCurrentDir;
-		if (g_strSaveStatePathname.length() && g_strSaveStatePathname[g_strSaveStatePathname.length()-1] != '\\')
+		if (!g_strSaveStatePathname.empty() && *g_strSaveStatePathname.rbegin() != '\\')
 			g_strSaveStatePathname += "\\";
 		g_strSaveStatePathname.append(DEFAULT_SNAPSHOT_NAME);
 
@@ -120,7 +120,7 @@ void Snapshot_SetFilename(const std::string& filename, const std::string& path/*
 	// Ensure path is suffixed with '\' before adding filename
 	std::string pathname = path;
 	if (*pathname.rbegin() != '\\')
-		pathname.append("\\");
+		pathname += "\\";
 
 	Snapshot_SetPathname(pathname+filename);
 }

--- a/source/SaveState.cpp
+++ b/source/SaveState.cpp
@@ -156,7 +156,7 @@ void Snapshot_UpdatePath(void)
 	std::string defaultPath;
 	Snapshot_GetDefaultFilenameAndPath(defaultFilename, defaultPath);
 
-	if (g_strSaveStatePath == defaultPath)
+	if (defaultPath.empty() || g_strSaveStatePath == defaultPath)
 		return;
 
 	if (!defaultFilename.empty())

--- a/source/SaveState.cpp
+++ b/source/SaveState.cpp
@@ -36,11 +36,9 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "Debug.h"
 #include "Disk.h"
 #include "Frame.h"
-#include "Harddisk.h"
 #include "Joystick.h"
 #include "Keyboard.h"
 #include "LanguageCard.h"
-#include "Log.h"
 #include "Memory.h"
 #include "Mockingboard.h"
 #include "MouseInterface.h"
@@ -94,8 +92,6 @@ static void Snapshot_SetPathname(const std::string& strPathname)
 		g_strSaveStatePathname.append(DEFAULT_SNAPSHOT_NAME);
 
 		g_strSaveStatePath = g_sCurrentDir;
-		LogOutput("Snapshot_SetPathname:(1) new path=%s (exit)\n", g_strSaveStatePath.c_str());
-
 		return;
 	}
 
@@ -107,7 +103,6 @@ static void Snapshot_SetPathname(const std::string& strPathname)
 	{
 		strFilename = &strPathname[nIdx+1];
 		g_strSaveStatePath = strPathname.substr(0, nIdx+1); // Bugfix: 1.25.0.2 // Snapshot_LoadState() -> SetCurrentImageDir() -> g_sCurrentDir 
-		LogOutput("Snapshot_SetPathname:(2) new path=%s (exit)\n", g_strSaveStatePath.c_str());
 	}
 
 	g_strSaveStateFilename = strFilename;
@@ -129,17 +124,17 @@ void Snapshot_SetFilename(const std::string& filename, const std::string& path/*
 	Snapshot_SetPathname(pathname+filename);
 }
 
-const std::string& Snapshot_GetFilename()
+const std::string& Snapshot_GetFilename(void)
 {
 	return g_strSaveStateFilename;
 }
 
-const std::string& Snapshot_GetPath()
+const std::string& Snapshot_GetPath(void)
 {
 	return g_strSaveStatePath;
 }
 
-const std::string& Snapshot_GetPathname()
+const std::string& Snapshot_GetPathname(void)
 {
 	return g_strSaveStatePathname;
 }

--- a/source/SaveState.cpp
+++ b/source/SaveState.cpp
@@ -151,6 +151,7 @@ void Snapshot_GetDefaultFilenameAndPath(std::string& defaultFilename, std::strin
 
 // Called by Disk2InterfaceCard::InsertDisk() and HD_Insert() after a successful insertion
 // Called by Disk2InterfaceCard::EjectDisk() and HD_Unplug()
+// Called by RepeatInitialization() when Harddisk Controller card is disabled
 void Snapshot_UpdatePath(void)
 {
 	std::string defaultFilename;

--- a/source/SaveState.cpp
+++ b/source/SaveState.cpp
@@ -80,7 +80,7 @@ static YamlHelper yamlHelper;
 
 //-----------------------------------------------------------------------------
 
-void Snapshot_SetFilename(const std::string & strPathname)
+static void Snapshot_SetPathname(const std::string& strPathname)
 {
 	if (strPathname.empty())
 	{
@@ -100,7 +100,7 @@ void Snapshot_SetFilename(const std::string & strPathname)
 	g_strSaveStatePath.clear();
 
 	int nIdx = strPathname.find_last_of('\\');
-	if (nIdx >= 0 && nIdx+1 < (int)strPathname.length())
+	if (nIdx >= 0 && nIdx+1 < (int)strPathname.length())	// path exists?
 	{
 		strFilename = &strPathname[nIdx+1];
 		g_strSaveStatePath = strPathname.substr(0, nIdx+1); // Bugfix: 1.25.0.2 // Snapshot_LoadState() -> SetCurrentImageDir() -> g_sCurrentDir 
@@ -110,12 +110,27 @@ void Snapshot_SetFilename(const std::string & strPathname)
 	g_strSaveStatePathname = strPathname;
 }
 
-const std::string & Snapshot_GetFilename()
+void Snapshot_SetFilename(const std::string& filename, const std::string& path/*=""*/)
+{
+	if (path.empty())
+		return Snapshot_SetPathname(filename);
+
+	_ASSERT(filename.find('\\') == std::string::npos);	// since we have a path, then filename mustn't contain a path too!
+
+	// Ensure path is suffixed with '\' before adding filename
+	std::string pathname = path;
+	if (*pathname.rbegin() != '\\')
+		pathname.append("\\");
+
+	Snapshot_SetPathname(pathname+filename);
+}
+
+const std::string& Snapshot_GetFilename()
 {
 	return g_strSaveStateFilename;
 }
 
-const std::string & Snapshot_GetPath()
+const std::string& Snapshot_GetPath()
 {
 	return g_strSaveStatePath;
 }

--- a/source/SaveState.cpp
+++ b/source/SaveState.cpp
@@ -129,51 +129,6 @@ void Snapshot_SetFilename(const std::string& filename, const std::string& path/*
 	Snapshot_SetPathname(pathname+filename);
 }
 
-// Logic:
-// . If isFloppyDisk and a harddisk is plugged in, then return.
-// . Derive path from input pathname with filename removed
-// . If path != existing snapshot path then set it as the new path, and set filename=DEFAULT
-void Snapshot_UpdatePath(const std::string& pathname, bool isFloppyDisk)
-{
-	if (isFloppyDisk && HD_CardIsEnabled())
-	{
-		LogOutput("Snapshot_UpdatePath: hdd priority over floppy (exit)\n");
-		return;	// harddisk images take priority over floppy images
-	}
-	else if (!isFloppyDisk && !HD_CardIsEnabled())
-	{
-		LogOutput("Snapshot_UpdatePath: hdd image, but hdd not enabled! (exit)\n");
-		return;
-	}
-
-	if (pathname.empty())
-	{
-		LogOutput("Snapshot_UpdatePath: pathname empty! (exit)\n");
-		return;
-	}
-
-	std::string path;
-	int idx = pathname.find_last_of('\\');
-	if (idx >= 0 && idx+1 < (int)pathname.length())	// path exists?
-		path = pathname.substr(0, idx+1);
-
-	if (path.empty())
-	{
-		LogOutput("Snapshot_UpdatePath: path empty! (pathname=%s) (exit)\n", pathname.c_str());
-		return;
-	}
-
-	if (path == g_strSaveStatePath)
-	{
-		LogOutput("Snapshot_UpdatePath: path the same (exit)\n");
-		return;
-	}
-
-	g_strSaveStatePath = path;
-	g_strSaveStateFilename = DEFAULT_SNAPSHOT_NAME;
-	LogOutput("Snapshot_UpdatePath: new path = %s\n", path.c_str());
-}
-
 const std::string& Snapshot_GetFilename()
 {
 	return g_strSaveStateFilename;

--- a/source/SaveState.h
+++ b/source/SaveState.h
@@ -3,9 +3,9 @@
 extern bool       g_bSaveStateOnExit;
 
 void Snapshot_SetFilename(const std::string& filename, const std::string& path="");
-const std::string& Snapshot_GetFilename();
-const std::string& Snapshot_GetPath();
-const std::string& Snapshot_GetPathname();
+const std::string& Snapshot_GetFilename(void);
+const std::string& Snapshot_GetPath(void);
+const std::string& Snapshot_GetPathname(void);
 void    Snapshot_LoadState();
 void    Snapshot_SaveState();
 void    Snapshot_Startup();

--- a/source/SaveState.h
+++ b/source/SaveState.h
@@ -2,9 +2,9 @@
 
 extern bool       g_bSaveStateOnExit;
 
-void    Snapshot_SetFilename(const std::string & strPathname);
-const std::string & Snapshot_GetFilename();
-const std::string & Snapshot_GetPath();
+void Snapshot_SetFilename(const std::string& filename, const std::string& path="");
+const std::string& Snapshot_GetFilename();
+const std::string& Snapshot_GetPath();
 void    Snapshot_LoadState();
 void    Snapshot_SaveState();
 void    Snapshot_Startup();

--- a/source/SaveState.h
+++ b/source/SaveState.h
@@ -5,6 +5,8 @@ extern bool       g_bSaveStateOnExit;
 void Snapshot_SetFilename(const std::string& filename, const std::string& path="");
 const std::string& Snapshot_GetFilename();
 const std::string& Snapshot_GetPath();
+const std::string& Snapshot_GetPathname();
+void Snapshot_UpdatePath(const std::string& pathname, bool isFloppyDisk);
 void    Snapshot_LoadState();
 void    Snapshot_SaveState();
 void    Snapshot_Startup();

--- a/source/SaveState.h
+++ b/source/SaveState.h
@@ -6,6 +6,8 @@ void Snapshot_SetFilename(const std::string& filename, const std::string& path="
 const std::string& Snapshot_GetFilename(void);
 const std::string& Snapshot_GetPath(void);
 const std::string& Snapshot_GetPathname(void);
+void Snapshot_GetDefaultFilenameAndPath(std::string& defaultFilename, std::string& defaultPath);
+void Snapshot_UpdatePath(void);
 void    Snapshot_LoadState();
 void    Snapshot_SaveState();
 void    Snapshot_Startup();

--- a/source/SaveState.h
+++ b/source/SaveState.h
@@ -6,7 +6,6 @@ void Snapshot_SetFilename(const std::string& filename, const std::string& path="
 const std::string& Snapshot_GetFilename();
 const std::string& Snapshot_GetPath();
 const std::string& Snapshot_GetPathname();
-void Snapshot_UpdatePath(const std::string& pathname, bool isFloppyDisk);
 void    Snapshot_LoadState();
 void    Snapshot_SaveState();
 void    Snapshot_Startup();


### PR DESCRIPTION
PR for #691.

Be smarter about both the path & filename when saving/loading a state-state file:

On save:
- Filename = (in priority order) try: S7D1-HDD or S7D2-HDD or S6D1-floppy or S6D2-floppy or S5D1-floppy...
  - if still empty, then use last save-state name
  - if still empty, then leave it empty
- Path = (in priority order) try: S7D1-HDD or S7D2-HDD or S6D1-floppy or S6D2-floppy or S5D1-floppy...
  - if still empty, then use last save-state path
  - if still empty, then use `g_sCurrentDir`

On load:
- Filename = last save-state name
  - if empty then (in priority order) try: S7D1-HDD or S7D2-HDD or S6D1-floppy or S6D2-floppy or S5D1-floppy...
  - if still empty, then leave it empty
- Path = last save-state path
  - if still empty, then use `g_sCurrentDir`
