### PR TITLE
WOZ Metadata & crc32

### DIFF
--- a/source/DiskImage.cpp
+++ b/source/DiskImage.cpp
@@ -85,6 +85,9 @@ ImageError_e ImageOpen(	const std::string & pszImageFilename,
 
 	*pWriteProtected = pImageInfo->bWriteProtected;
 
+	// Calculate the CRC32 of the whole image for any image
+	pImageInfo->iCRC32 = crc32(0, pImageInfo->pImageBuffer, sizeof(pImageInfo->pImageBuffer));
+
 	return eIMAGE_ERROR_NONE;
 }
 

--- a/source/DiskImageHelper.cpp
+++ b/source/DiskImageHelper.cpp
@@ -1503,36 +1503,36 @@ eDetectResult CWOZHelper::ProcessChunks(ImageInfo* pImageInfo, DWORD& dwOffset)
 
 		switch(chunkId)
 		{
-		case INFO_CHUNK_ID:
-			m_pInfo = (InfoChunkv2*)pImage32;
-			if (m_pInfo->v1.diskType != InfoChunk::diskType5_25)
-				return eMismatch;
-			break;
-		case TMAP_CHUNK_ID:
-			pImageInfo->pWOZTrackMap = (BYTE*) pImage32;
-			break;
-		case TRKS_CHUNK_ID:
-			dwOffset = pImageInfo->uOffset = pImageInfo->uImageSize - imageSizeRemaining;	// offset into image of track data
-			break;
-		case WRIT_CHUNK_ID:	// WOZ v2 (optional)
-			break;
-		case META_CHUNK_ID:	// (optional)
-			// get all metadata into usWOZMetadata
-			// Multiple values are "|" separated
-			szMetadata = std::string((const char*)pImage32, chunkSize);
-			ssMetadata = std::stringstream(szMetadata);
-			while (std::getline(ssMetadata, szTmp, cRowDelim))
-			{
-				iTabPos = szTmp.find(szColDelim);
-				if (iTabPos && (iTabPos < szTmp.length()))
+			case INFO_CHUNK_ID:
+				m_pInfo = (InfoChunkv2*)pImage32;
+				if (m_pInfo->v1.diskType != InfoChunk::diskType5_25)
+					return eMismatch;
+				break;
+			case TMAP_CHUNK_ID:
+				pImageInfo->pWOZTrackMap = (BYTE*) pImage32;
+				break;
+			case TRKS_CHUNK_ID:
+				dwOffset = pImageInfo->uOffset = pImageInfo->uImageSize - imageSizeRemaining;	// offset into image of track data
+				break;
+			case WRIT_CHUNK_ID:	// WOZ v2 (optional)
+				break;
+			case META_CHUNK_ID:	// (optional)
+				// get all metadata into usWOZMetadata
+				// Multiple values are "|" separated
+				szMetadata = std::string((const char*)pImage32, chunkSize);
+				ssMetadata = std::stringstream(szMetadata);
+				while (std::getline(ssMetadata, szTmp, cRowDelim))
 				{
-					pImageInfo->umWOZMetadata[szTmp.substr(0, iTabPos)] = szTmp.substr(iTabPos+1);
+					iTabPos = szTmp.find(szColDelim);
+					if (iTabPos && (iTabPos < szTmp.length()))
+					{
+						pImageInfo->umWOZMetadata[szTmp.substr(0, iTabPos)] = szTmp.substr(iTabPos+1);
+					}
 				}
-			}
-			break;
-		default:	// no idea what this chunk is, so skip it
-			_ASSERT(0);
-			break;
+				break;
+			default:	// no idea what this chunk is, so skip it
+				_ASSERT(0);
+				break;
 		}
 
 		pImage32 = (UINT32*) ((BYTE*)pImage32 + chunkSize);

--- a/source/DiskImageHelper.cpp
+++ b/source/DiskImageHelper.cpp
@@ -1485,14 +1485,6 @@ eDetectResult CWOZHelper::ProcessChunks(ImageInfo* pImageInfo, DWORD& dwOffset)
 	if (imageSizeRemaining < 0)
 		return eMismatch;
 
-	std::string szMetadata;
-	std::stringstream ssMetadata;
-	std::string szTmp;
-	const char cRowDelim = '\n';
-	std::string szColDelim = "\t";
-	size_t iTabPos;
-	std::unordered_map<std::string, std::string>::const_iterator pTitlePos;
-
 	pImageInfo->iCRC32 = (UINT32)(pImageInfo->pImageBuffer + 8);	// The CRC32 of the image chunks, stored in the WOZ header
 
 	while(imageSizeRemaining >= sizeof(WOZChunkHdr))
@@ -1517,8 +1509,18 @@ eDetectResult CWOZHelper::ProcessChunks(ImageInfo* pImageInfo, DWORD& dwOffset)
 			case WRIT_CHUNK_ID:	// WOZ v2 (optional)
 				break;
 			case META_CHUNK_ID:	// (optional)
+			{
 				// get all metadata into usWOZMetadata
 				// Multiple values are "|" separated
+
+				std::string szMetadata;
+				std::stringstream ssMetadata;
+				std::string szTmp;
+				const char cRowDelim = '\n';
+				std::string szColDelim = "\t";
+				size_t iTabPos;
+				std::unordered_map<std::string, std::string>::const_iterator pTitlePos;
+
 				szMetadata = std::string((const char*)pImage32, chunkSize);
 				ssMetadata = std::stringstream(szMetadata);
 				while (std::getline(ssMetadata, szTmp, cRowDelim))
@@ -1526,10 +1528,11 @@ eDetectResult CWOZHelper::ProcessChunks(ImageInfo* pImageInfo, DWORD& dwOffset)
 					iTabPos = szTmp.find(szColDelim);
 					if (iTabPos && (iTabPos < szTmp.length()))
 					{
-						pImageInfo->umWOZMetadata[szTmp.substr(0, iTabPos)] = szTmp.substr(iTabPos+1);
+						pImageInfo->umWOZMetadata[szTmp.substr(0, iTabPos)] = szTmp.substr(iTabPos + 1);
 					}
 				}
 				break;
+			}
 			default:	// no idea what this chunk is, so skip it
 				_ASSERT(0);
 				break;

--- a/source/DiskImageHelper.h
+++ b/source/DiskImageHelper.h
@@ -2,6 +2,7 @@
 
 #include "DiskDefs.h"
 #include "zip.h"
+#include <unordered_map>
 
 #define GZ_SUFFIX ".gz"
 #define GZ_SUFFIX_LEN (sizeof(GZ_SUFFIX)-1)
@@ -32,12 +33,14 @@ struct ImageInfo
 	zip_fileinfo	zipFileInfo;
 	UINT			uNumEntriesInZip;
 	UINT			uNumValidImagesInZip;
+	UINT32			iCRC32;
 	// Floppy only
 	UINT			uNumTracks;
 	BYTE*			pImageBuffer;
 	BYTE*			pWOZTrackMap;		// WOZ only (points into pImageBuffer)
 	BYTE			optimalBitTiming;	// WOZ only
 	BYTE			bootSectorFormat;	// WOZ only
+	std::unordered_map<std::string, std::string>	umWOZMetadata;	// WOZ only
 	UINT			maxNibblesPerTrack;
 
 	ImageInfo();


### PR DESCRIPTION
Increased information available in pImageInfo:

- Added parsing and storing of WOZ metadata into the unordered map pImageInfo->umWOZMetadata.
- The full crc32 for any image is calculated and stored in pImageInfo->iCRC32.