### PR TITLE
Some small changes to ensure code compiles with gcc.

### DIFF
--- a/source/Core.cpp
+++ b/source/Core.cpp
@@ -44,7 +44,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "Speech.h"
 #endif
 
-static const UINT VERSIONSTRING_SIZE = 16; 
+static const UINT VERSIONSTRING_SIZE = 16;
 static UINT16 g_OldAppleWinVersion[4] = {0};
 UINT16 g_AppleWinVersion[4] = { 0 };
 TCHAR VERSIONSTRING[VERSIONSTRING_SIZE] = "xx.yy.zz.ww";

--- a/source/Memory.h
+++ b/source/Memory.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Common.h"
+#include "Card.h"
 
 // Memory Flag
 #define  MF_80STORE    0x00000001

--- a/source/NTSC.h
+++ b/source/NTSC.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Video.h"
+
 // Globals (Public)
 	extern uint16_t g_nVideoClockVert;
 	extern uint16_t g_nVideoClockHorz;

--- a/source/Utilities.cpp
+++ b/source/Utilities.cpp
@@ -45,7 +45,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "Mockingboard.h"
 #include "Windows/WinFrame.h"
 
-#include "Configuration/PropertySheet.h"
+#include "Configuration/IPropertySheet.h"
 #include "Tfe/Tfe.h"
 
 // Backwards compatibility with AppleWin <1.24.0

--- a/source/Video.cpp
+++ b/source/Video.cpp
@@ -100,7 +100,7 @@ static bool g_bVideoScannerNTSC = true;  // NTSC video scanning (or PAL)
 
 	// NOTE: KEEP IN SYNC: VideoType_e g_aVideoChoices g_apVideoModeDesc
 	// The window title will be set to this.
-	const char *g_apVideoModeDesc[ NUM_VIDEO_MODES ] =
+	static const char *g_apVideoModeDesc[ NUM_VIDEO_MODES ] =
 	{
 		  "Monochrome (Custom)"
 		, "Color (Composite Idealized)"


### PR DESCRIPTION
Added a couple of .h as enums cannot be fwd declared.
Just include IPropertySheet.h and not concrete classes.
Make g_apVideoModeDesc static as it is not used elsewhere.
Remove space at end of definition of VERSIONSTRING_SIZE.