### PR TITLE
Select a Alpha value that works in Windows and Linux (qt / sdl).

### DIFF
--- a/source/NTSC.cpp
+++ b/source/NTSC.cpp
@@ -173,8 +173,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 	#define NTSC_NUM_PHASES     4
 	#define NTSC_NUM_SEQUENCES  4096
 
-	const uint32_t ALPHA32_MASK = 0xFF000000; // Win32: aarrggbb
-
 /*extern*/ uint32_t g_nChromaSize = 0; // for NTSC_VideoGetChromaTable()
 	static bgra_t   g_aBnWMonitor                 [NTSC_NUM_SEQUENCES];
 	static bgra_t   g_aHueMonitor[NTSC_NUM_PHASES][NTSC_NUM_SEQUENCES];

--- a/source/RGBMonitor.cpp
+++ b/source/RGBMonitor.cpp
@@ -116,8 +116,6 @@ const BYTE DoubleHiresPalIndex[16] = {
 		ORANGE,  PINK,      YELLOW,    WHITE
 	};
 
-#define  SETRGBCOLOR(r,g,b) {b,g,r,0}
-
 static RGBQUAD* g_pPaletteRGB;
 
 static RGBQUAD PaletteRGB_NTSC[] =
@@ -540,7 +538,7 @@ static void CopyMixedSource(int x, int y, int sx, int sy, bgra_t *pVideoAddress)
 			if (bIsHalfScanLines && (h & 1))
 			{
 				// 50% Half Scan Line clears every odd scanline (and SHIFT+PrintScreen saves only the even rows)
-				*(pDst+nBytes) = 0;
+				*(pDst+nBytes) = OPAQUE_BLACK;
 			}
 			else
 			{
@@ -570,7 +568,7 @@ static void CopySource(int w, int h, int sx, int sy, bgra_t *pVideoAddress, cons
 		if (bIsHalfScanLines && !(h & 1))
 		{
 			// 50% Half Scan Line clears every odd scanline (and SHIFT+PrintScreen saves only the even rows)
-			std::fill(pDst, pDst + w, 0);
+			std::fill(pDst, pDst + w, OPAQUE_BLACK);
 		}
 		else
 		{
@@ -738,7 +736,7 @@ void UpdateHiResRGBCell(int x, int y, uint16_t addr, bgra_t* pVideoAddress)
 	if (bIsHalfScanLines)
 	{
 		// Scanlines
-		std::fill(pDst, pDst + 14, 0);
+		std::fill(pDst, pDst + 14, OPAQUE_BLACK);
 	}
 	else
 	{
@@ -953,7 +951,7 @@ void UpdateDHiResCellRGB(int x, int y, uint16_t addr, bgra_t* pVideoAddress, boo
 	if (bIsHalfScanLines)
 	{
 		// Scanlines
-		std::fill(pDst, pDst + 14, 0);
+		std::fill(pDst, pDst + 14, OPAQUE_BLACK);
 	}
 	else
 	{
@@ -1142,7 +1140,7 @@ void UpdateDuochromeCell(int h, int w, bgra_t* pVideoAddress, uint8_t bits, uint
 		if (bIsHalfScanLines && !(h & 1))
 		{
 			// 50% Half Scan Line clears every odd scanline (and SHIFT+PrintScreen saves only the even rows)
-			std::fill(pDst, pDst + w, 0);
+			std::fill(pDst, pDst + w, OPAQUE_BLACK);
 		}
 		else
 		{

--- a/source/Video.h
+++ b/source/Video.h
@@ -1,5 +1,16 @@
 #pragma once
 
+// in Windows it seems that the ALPHA value is irrelevant
+// we have selected 0xFF since it works everywhere
+// Windows
+// SDL (SDL_PIXELFORMAT_ARGB8888)
+// Qt (QImage::Format_ARGB32_Premultiplied)
+#define ALPHA 0xFF  // fully opaque
+#define ALPHA32_MASK (ALPHA << 24)
+#define SETRGBCOLOR(r, g, b) {b, g, r, ALPHA}  // to create a RGBQUAD
+#define OPAQUE_BLACK (0 | ALPHA32_MASK)  // Black is RGB 0 0 0
+
+
 // Types ____________________________________________________________
 
 	// NOTE: KEEP IN SYNC: VideoType_e g_aVideoChoices g_apVideoModeDesc


### PR DESCRIPTION
In Windows it does not seem to make any difference, so 0xFF is selected for maximum compatibility.

Alternatively, I could add an #ifdef _MSC_VER, but then I am not clear why NTSC.cpp and RGBMonitor.cpp set the alpha to different values (0xFF and 0x00 respectively).

See: https://github.com/AppleWin/AppleWin/blob/master/source/NTSC.cpp#L176 and related usage.

Ideally all the 3 #define should go to a common .h (Video.h?) to avoid they diverge.

Will improve the patch if I get feedback on the above.
