### PR TITLE
Move GetAppleWindowTitle() to Utilities.cpp as it is generic.

### DIFF
--- a/source/Utilities.cpp
+++ b/source/Utilities.cpp
@@ -453,3 +453,49 @@ void UnplugHardDiskControllerCard(void)
 	if (!res || dwTmp)
 		REGSAVE(TEXT(REGVALUE_HDD_ENABLED), 0);	// Config: HDD Disabled
 }
+
+void GetAppleWindowTitle()
+{
+	switch (g_Apple2Type)
+	{
+	default:
+	case A2TYPE_APPLE2:			 g_pAppTitle = TITLE_APPLE_2; break;
+	case A2TYPE_APPLE2PLUS:		 g_pAppTitle = TITLE_APPLE_2_PLUS; break;
+	case A2TYPE_APPLE2JPLUS:	 g_pAppTitle = TITLE_APPLE_2_JPLUS; break;
+	case A2TYPE_APPLE2E:		 g_pAppTitle = TITLE_APPLE_2E; break;
+	case A2TYPE_APPLE2EENHANCED: g_pAppTitle = TITLE_APPLE_2E_ENHANCED; break;
+	case A2TYPE_PRAVETS82:		 g_pAppTitle = TITLE_PRAVETS_82; break;
+	case A2TYPE_PRAVETS8M:		 g_pAppTitle = TITLE_PRAVETS_8M; break;
+	case A2TYPE_PRAVETS8A:		 g_pAppTitle = TITLE_PRAVETS_8A; break;
+	case A2TYPE_TK30002E:		 g_pAppTitle = TITLE_TK3000_2E; break;
+	case A2TYPE_BASE64A:		 g_pAppTitle = TITLE_BASE64A; break;
+	}
+
+#if _DEBUG
+	g_pAppTitle += " *DEBUG* ";
+#endif
+
+	if (g_nAppMode == MODE_LOGO)
+		return;
+
+	g_pAppTitle += " - ";
+
+	if (IsVideoStyle(VS_HALF_SCANLINES))
+		g_pAppTitle += " 50% ";
+
+	g_pAppTitle += VideoGetAppWindowTitle();
+
+	if (GetCardMgr().GetDisk2CardMgr().IsAnyFirmware13Sector())
+		g_pAppTitle += " (S6-13) ";
+
+	if (g_hCustomRomF8 != INVALID_HANDLE_VALUE)
+		g_pAppTitle += TEXT(" (custom rom)");
+	else if (sg_PropertySheet.GetTheFreezesF8Rom() && IS_APPLE2)
+		g_pAppTitle += TEXT(" (The Freeze's non-autostart F8 rom)");
+
+	switch (g_nAppMode)
+	{
+	case MODE_PAUSED: g_pAppTitle += std::string(TEXT(" [")) + TITLE_PAUSED + TEXT("]"); break;
+	case MODE_STEPPING: g_pAppTitle += std::string(TEXT(" [")) + TITLE_STEPPING + TEXT("]"); break;
+	}
+}

--- a/source/Utilities.h
+++ b/source/Utilities.h
@@ -10,3 +10,4 @@ bool DoHardDiskInsert(const int nDrive, LPCSTR szFileName);
 void InsertFloppyDisks(const UINT slot, LPSTR szImageName_drive[NUM_DRIVES], bool& bBoot);
 void InsertHardDisks(LPSTR szImageName_harddisk[NUM_HARDDISKS], bool& bBoot);
 void UnplugHardDiskControllerCard(void);
+void GetAppleWindowTitle();

--- a/source/Windows/WinFrame.cpp
+++ b/source/Windows/WinFrame.cpp
@@ -50,6 +50,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "SoundCore.h"
 #include "Speaker.h"
 #include "Frame.h"
+#include "Utilities.h"
 #ifdef USE_SPEECH_API
 #include "Speech.h"
 #endif
@@ -213,54 +214,6 @@ UINT Get3DBorderWidth(void)
 UINT Get3DBorderHeight(void)
 {
 	return IsFullScreen() ? 0 : VIEWPORTY;
-}
-
-// ==========================================================================
-
-static void GetAppleWindowTitle()
-{
-	switch (g_Apple2Type)
-	{
-		default:
-		case A2TYPE_APPLE2:			 g_pAppTitle = TITLE_APPLE_2          ; break;
-		case A2TYPE_APPLE2PLUS:		 g_pAppTitle = TITLE_APPLE_2_PLUS     ; break;
-		case A2TYPE_APPLE2JPLUS:	 g_pAppTitle = TITLE_APPLE_2_JPLUS    ; break;
-		case A2TYPE_APPLE2E:		 g_pAppTitle = TITLE_APPLE_2E         ; break;
-		case A2TYPE_APPLE2EENHANCED: g_pAppTitle = TITLE_APPLE_2E_ENHANCED; break;
-		case A2TYPE_PRAVETS82:		 g_pAppTitle = TITLE_PRAVETS_82       ; break;
-		case A2TYPE_PRAVETS8M:		 g_pAppTitle = TITLE_PRAVETS_8M       ; break;
-		case A2TYPE_PRAVETS8A:		 g_pAppTitle = TITLE_PRAVETS_8A       ; break;
-		case A2TYPE_TK30002E:		 g_pAppTitle = TITLE_TK3000_2E        ; break;
-		case A2TYPE_BASE64A:		 g_pAppTitle = TITLE_BASE64A          ; break;
-	}
-
-#if _DEBUG
-	g_pAppTitle += " *DEBUG* ";
-#endif
-
-	if (g_nAppMode == MODE_LOGO)
-		return;
-
-	g_pAppTitle += " - ";
-
-	if( IsVideoStyle(VS_HALF_SCANLINES) )
-		g_pAppTitle += " 50% ";
-
-	g_pAppTitle += VideoGetAppWindowTitle();
-
-	if (GetCardMgr().GetDisk2CardMgr().IsAnyFirmware13Sector())
-		g_pAppTitle += " (S6-13) ";
-
-	if (g_hCustomRomF8 != INVALID_HANDLE_VALUE)
-		g_pAppTitle += TEXT(" (custom rom)");
-	else if (sg_PropertySheet.GetTheFreezesF8Rom() && IS_APPLE2)
-		g_pAppTitle += TEXT(" (The Freeze's non-autostart F8 rom)");
-
-	switch (g_nAppMode)
-	{
-		case MODE_PAUSED  : g_pAppTitle += std::string(TEXT(" [")) + TITLE_PAUSED   + TEXT("]"); break;
-		case MODE_STEPPING: g_pAppTitle += std::string(TEXT(" [")) + TITLE_STEPPING + TEXT("]"); break;
-	}
 }
 
 //===========================================================================


### PR DESCRIPTION
and useful to other archs.
