### PR TITLE
Use _stat64() to support file size >2G

### DIFF
--- a/source/Windows/WinFrame.cpp
+++ b/source/Windows/WinFrame.cpp
@@ -58,7 +58,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "../resource/resource.h"
 #include "Configuration/PropertySheet.h"
 #include "Debugger/Debug.h"
-#if _MSC_VER <= 1500	// VS2008 only (cl.exe v15.00)
+#if _MSC_VER < 1900	// VS2013 or before (cl.exe v18.x or before)
 #include <sys/stat.h>
 #endif
 
@@ -2746,10 +2746,15 @@ void FrameRegisterClass () {
 //===========================================================================
 // TODO: FIXME: Util_TestFileExists()
 static bool FileExists(std::string strFilename) 
-{ 
-	struct stat stFileInfo; 
-	int intStat = stat(strFilename.c_str(),&stFileInfo); 
-	return (intStat == 0) ? true : false;
+{
+#ifdef _MSC_VER
+	struct _stat64 stFileInfo; 
+	int intStat = _stat64(strFilename.c_str(), &stFileInfo);
+#else
+	struct stat stFileInfo;
+	int intStat = stat(strFilename.c_str(), &stFileInfo);
+#endif
+	return (intStat == 0);
 }
 
 //===========================================================================

--- a/source/Windows/WinFrame.cpp
+++ b/source/Windows/WinFrame.cpp
@@ -2747,13 +2747,8 @@ void FrameRegisterClass () {
 // TODO: FIXME: Util_TestFileExists()
 static bool FileExists(std::string strFilename) 
 {
-#ifdef _MSC_VER
 	struct _stat64 stFileInfo; 
 	int intStat = _stat64(strFilename.c_str(), &stFileInfo);
-#else
-	struct stat stFileInfo;
-	int intStat = stat(strFilename.c_str(), &stFileInfo);
-#endif
 	return (intStat == 0);
 }
 


### PR DESCRIPTION
1. Newer VC runtime stat(), when using 32-bit file size, returns error if file size is >2G. For file existence check, using 64-bit file size is more accurate as files bigger than 2G would be reported as non-existing otherwise.
2. <sys/stat.h> is required for VS2013 or before. Keeping backward compatibility is nice.