### PR TITLE
Cleanup types and #include to ease gcc compilation.

### DIFF
--- a/source/CommonVICE/types.h
+++ b/source/CommonVICE/types.h
@@ -30,34 +30,8 @@
 #ifndef _TYPES_H
 #define _TYPES_H
 
-#ifndef BYTE
-#define BYTE unsigned char
-#endif
-
-#ifndef WORD
-#define WORD unsigned short
-#endif
-
-#ifndef DWORD
-   //#ifdef DWORD_IS_LONG
-   #define DWORD unsigned long
-   //#else
-   //#define DWORD unsigned int
-   //#endif
-#endif
-
-/* RGJ added for AppleWin */
-#ifndef ULONG 
-typedef unsigned long ULONG;
-#endif
-/* TC added for AppleWin */
-#ifndef LPVOID
-typedef void *LPVOID;
-#endif
-
-typedef signed char SIGNED_CHAR;
-typedef signed short SWORD;
-typedef signed int SDWORD;
+// do not redefine windows.h types here to avoid inconsistencies
+// include StdAfx.h before this file
 
 typedef DWORD CLOCK;
 /* Maximum value of a CLOCK.  */

--- a/source/Configuration/PageConfigTfe.h
+++ b/source/Configuration/PageConfigTfe.h
@@ -21,10 +21,10 @@ protected:
 	virtual void DlgCANCEL(HWND window);
 
 private:
-	BOOL CPageConfigTfe::get_tfename(int number, char **ppname, char **ppdescription);
-	int CPageConfigTfe::gray_ungray_items(HWND hwnd);
-	void CPageConfigTfe::init_tfe_dialog(HWND hwnd);
-	void CPageConfigTfe::save_tfe_dialog(HWND hwnd);
+	BOOL get_tfename(int number, char **ppname, char **ppdescription);
+	int gray_ungray_items(HWND hwnd);
+	void init_tfe_dialog(HWND hwnd);
+	void save_tfe_dialog(HWND hwnd);
 
 	static CPageConfigTfe* ms_this;
 	static uilib_localize_dialog_param ms_dialog[];

--- a/source/Tfe/Uilib.h
+++ b/source/Tfe/Uilib.h
@@ -29,9 +29,6 @@
 #ifndef _UILIB_H
 #define _UILIB_H
 
-#include <windows.h>
-#include <tchar.h>
-
 typedef struct {
     unsigned int idc;
     int element_type;

--- a/source/Z80VICE/daa.cpp
+++ b/source/Z80VICE/daa.cpp
@@ -24,6 +24,7 @@
  *
  */
 
+#include "StdAfx.h"
 #include "daa.h"
 #include "../CommonVICE/types.h"	// [AppleWin-TC]
 

--- a/source/Z80VICE/z80.cpp
+++ b/source/Z80VICE/z80.cpp
@@ -39,7 +39,7 @@
 #include <stdlib.h>
 
 #include "../CommonVICE/6510core.h"	// [AppleWin-TC]
-#include "../CommonVICE/alarm.h"
+//#include "../CommonVICE/alarm.h"  // [AppleWin-TC]
 #include "daa.h"
 //#include "debug.h"				// [AppleWin-TC]
 #include "../CommonVICE/interrupt.h"

--- a/source/Z80VICE/z80mem.cpp
+++ b/source/Z80VICE/z80mem.cpp
@@ -26,8 +26,7 @@
 
 //#include "vice.h"
 
-#include <stdio.h>
-#include <string.h>
+#include "StdAfx.h"
 
 //#include "c128mem.h"					// [AppleWin-TC]
 //#include "c128mmu.h"


### PR DESCRIPTION
Some small commits to ease compilation with gcc.

Most of it is around duplicate definitions or #include of types from ``windows.h``.
In Linux a windows.h compatibility layer is required and it becomes harder if different files redefine some of it independently.
