### PR TITLE
Remove VirtualAlloc & Co.

### DIFF
--- a/source/Configuration/PropertySheetHelper.cpp
+++ b/source/Configuration/PropertySheetHelper.cpp
@@ -158,7 +158,7 @@ std::string CPropertySheetHelper::BrowseToFile(HWND hWindow, TCHAR* pszTitle, TC
 	std::string pathname = szFilename;
 
 	OPENFILENAME ofn;
-	ZeroMemory(&ofn,sizeof(OPENFILENAME));
+	memset(&ofn, 0, sizeof(OPENFILENAME));
 
 	ofn.lStructSize     = sizeof(OPENFILENAME);
 	ofn.hwndOwner       = hWindow;
@@ -205,7 +205,7 @@ int CPropertySheetHelper::SaveStateSelectImage(HWND hWindow, TCHAR* pszTitle, bo
 	//
 
 	OPENFILENAME ofn;
-	ZeroMemory(&ofn,sizeof(OPENFILENAME));
+	memset(&ofn, 0, sizeof(OPENFILENAME));
 
 	ofn.lStructSize     = sizeof(OPENFILENAME);
 	ofn.hwndOwner       = hWindow;

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -8831,7 +8831,7 @@ void DebugInitialize ()
 
 	GetConsoleFontDC(); // Load font
 
-	ZeroMemory( g_aConsoleDisplay, sizeof( g_aConsoleDisplay ) ); // CONSOLE_WIDTH * CONSOLE_HEIGHT );
+	memset( g_aConsoleDisplay, 0, sizeof( g_aConsoleDisplay ) ); // CONSOLE_WIDTH * CONSOLE_HEIGHT );
 	ConsoleInputReset();
 
 	for( int iWindow = 0; iWindow < NUM_WINDOWS; iWindow++ )
@@ -8853,9 +8853,9 @@ void DebugInitialize ()
 	WindowUpdateConsoleDisplayedSize();
 
 	// CLEAR THE BREAKPOINT AND WATCH TABLES
-	ZeroMemory( g_aBreakpoints     , MAX_BREAKPOINTS       * sizeof(Breakpoint_t));
-	ZeroMemory( g_aWatches         , MAX_WATCHES           * sizeof(Watches_t) );
-	ZeroMemory( g_aZeroPagePointers, MAX_ZEROPAGE_POINTERS * sizeof(ZeroPagePointers_t));
+	memset( g_aBreakpoints     , 0, MAX_BREAKPOINTS       * sizeof(Breakpoint_t));
+	memset( g_aWatches         , 0, MAX_WATCHES           * sizeof(Watches_t) );
+	memset( g_aZeroPagePointers, 0, MAX_ZEROPAGE_POINTERS * sizeof(ZeroPagePointers_t));
 
 	// Load Main, Applesoft, and User Symbols
 	extern bool g_bSymbolsDisplayMissingFile;

--- a/source/Debugger/Debugger_Console.cpp
+++ b/source/Debugger/Debugger_Console.cpp
@@ -462,7 +462,7 @@ bool ConsoleInputBackSpace ()
 //===========================================================================
 bool ConsoleInputClear ()
 {
-	ZeroMemory( g_aConsoleInput, CONSOLE_WIDTH );
+	memset( g_aConsoleInput, 0, CONSOLE_WIDTH );
 
 	if (g_nConsoleInputChars)
 	{

--- a/source/Debugger/Debugger_Display.cpp
+++ b/source/Debugger/Debugger_Display.cpp
@@ -557,7 +557,7 @@ HDC GetDebuggerMemDC(void)
 		g_hDebuggerMemDC = CreateCompatibleDC(hFrameDC);
 
 		// CREATE A BITMAPINFO STRUCTURE FOR THE FRAME BUFFER
-		g_pDebuggerMemFramebufferinfo = (LPBITMAPINFO)malloc(sizeof(BITMAPINFOHEADER) + 256 * sizeof(RGBQUAD));
+		g_pDebuggerMemFramebufferinfo = (LPBITMAPINFO) new BYTE[sizeof(BITMAPINFOHEADER) + 256 * sizeof(RGBQUAD)];
 
 		memset(g_pDebuggerMemFramebufferinfo, 0, sizeof(BITMAPINFOHEADER) + 256 * sizeof(RGBQUAD));
 		g_pDebuggerMemFramebufferinfo->bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
@@ -594,7 +594,7 @@ void ReleaseDebuggerMemDC(void)
 
 		FrameReleaseDC();
 
-		free(g_pDebuggerMemFramebufferinfo);
+		delete [] g_pDebuggerMemFramebufferinfo;
 		g_pDebuggerMemFramebufferinfo = NULL;
 		g_pDebuggerMemFramebits = NULL;
 	}
@@ -609,7 +609,7 @@ HDC GetConsoleFontDC(void)
 		g_hConsoleFontDC = CreateCompatibleDC(hFrameDC);
 
 		// CREATE A BITMAPINFO STRUCTURE FOR THE FRAME BUFFER
-		g_hConsoleFontFramebufferinfo = (LPBITMAPINFO)malloc(sizeof(BITMAPINFOHEADER) + 256 * sizeof(RGBQUAD));
+		g_hConsoleFontFramebufferinfo = (LPBITMAPINFO) new BYTE[sizeof(BITMAPINFOHEADER) + 256 * sizeof(RGBQUAD)];
 
 		memset(g_hConsoleFontFramebufferinfo, 0, sizeof(BITMAPINFOHEADER) + 256 * sizeof(RGBQUAD));
 		g_hConsoleFontFramebufferinfo->bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
@@ -656,7 +656,7 @@ void ReleaseConsoleFontDC(void)
 		DeleteObject( g_hConsoleFontBitmap );
 		g_hConsoleFontBitmap = NULL;
 
-		free(g_hConsoleFontFramebufferinfo);
+		delete [] g_hConsoleFontFramebufferinfo;
 		g_hConsoleFontFramebufferinfo = NULL;
 		g_hConsoleFontFramebits = NULL;
 	}

--- a/source/Debugger/Debugger_Display.cpp
+++ b/source/Debugger/Debugger_Display.cpp
@@ -557,13 +557,9 @@ HDC GetDebuggerMemDC(void)
 		g_hDebuggerMemDC = CreateCompatibleDC(hFrameDC);
 
 		// CREATE A BITMAPINFO STRUCTURE FOR THE FRAME BUFFER
-		g_pDebuggerMemFramebufferinfo = (LPBITMAPINFO)VirtualAlloc(
-			NULL,
-			sizeof(BITMAPINFOHEADER) + 256 * sizeof(RGBQUAD),
-			MEM_COMMIT,
-			PAGE_READWRITE);
+		g_pDebuggerMemFramebufferinfo = (LPBITMAPINFO)malloc(sizeof(BITMAPINFOHEADER) + 256 * sizeof(RGBQUAD));
 
-		ZeroMemory(g_pDebuggerMemFramebufferinfo, sizeof(BITMAPINFOHEADER) + 256 * sizeof(RGBQUAD));
+		memset(g_pDebuggerMemFramebufferinfo, 0, sizeof(BITMAPINFOHEADER) + 256 * sizeof(RGBQUAD));
 		g_pDebuggerMemFramebufferinfo->bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
 		g_pDebuggerMemFramebufferinfo->bmiHeader.biWidth = 560;
 		g_pDebuggerMemFramebufferinfo->bmiHeader.biHeight = 384;
@@ -598,7 +594,7 @@ void ReleaseDebuggerMemDC(void)
 
 		FrameReleaseDC();
 
-		VirtualFree(g_pDebuggerMemFramebufferinfo, 0, MEM_RELEASE);
+		free(g_pDebuggerMemFramebufferinfo);
 		g_pDebuggerMemFramebufferinfo = NULL;
 		g_pDebuggerMemFramebits = NULL;
 	}
@@ -613,13 +609,9 @@ HDC GetConsoleFontDC(void)
 		g_hConsoleFontDC = CreateCompatibleDC(hFrameDC);
 
 		// CREATE A BITMAPINFO STRUCTURE FOR THE FRAME BUFFER
-		 g_hConsoleFontFramebufferinfo = (LPBITMAPINFO)VirtualAlloc(
-			NULL,
-			sizeof(BITMAPINFOHEADER) + 256 * sizeof(RGBQUAD),
-			MEM_COMMIT,
-			PAGE_READWRITE);
+		g_hConsoleFontFramebufferinfo = (LPBITMAPINFO)malloc(sizeof(BITMAPINFOHEADER) + 256 * sizeof(RGBQUAD));
 
-		ZeroMemory(g_hConsoleFontFramebufferinfo, sizeof(BITMAPINFOHEADER) + 256 * sizeof(RGBQUAD));
+		memset(g_hConsoleFontFramebufferinfo, 0, sizeof(BITMAPINFOHEADER) + 256 * sizeof(RGBQUAD));
 		g_hConsoleFontFramebufferinfo->bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
 		g_hConsoleFontFramebufferinfo->bmiHeader.biWidth = CONSOLE_FONT_BITMAP_WIDTH;
 		g_hConsoleFontFramebufferinfo->bmiHeader.biHeight = CONSOLE_FONT_BITMAP_HEIGHT;
@@ -664,7 +656,7 @@ void ReleaseConsoleFontDC(void)
 		DeleteObject( g_hConsoleFontBitmap );
 		g_hConsoleFontBitmap = NULL;
 
-		VirtualFree(g_hConsoleFontFramebufferinfo, 0, MEM_RELEASE);
+		free(g_hConsoleFontFramebufferinfo);
 		g_hConsoleFontFramebufferinfo = NULL;
 		g_hConsoleFontFramebits = NULL;
 	}
@@ -3204,7 +3196,7 @@ void DrawSoftSwitches( int iSoftSwitch )
 void DrawSourceLine( int iSourceLine, RECT &rect )
 {
 	char sLine[ CONSOLE_WIDTH ];
-	ZeroMemory( sLine, CONSOLE_WIDTH );
+	memset( sLine, 0, CONSOLE_WIDTH );
 
 	if ((iSourceLine >=0) && (iSourceLine < g_AssemblerSourceBuffer.GetNumLines() ))
 	{

--- a/source/Debugger/Debugger_Help.cpp
+++ b/source/Debugger/Debugger_Help.cpp
@@ -571,8 +571,8 @@ Update_t CmdHelpSpecific (int nArgs)
 	int iArg;
 	char sText[ CONSOLE_WIDTH * 2 ];
 	char sTemp[ CONSOLE_WIDTH * 2 ];
-	ZeroMemory( sText, CONSOLE_WIDTH*2 );
-	ZeroMemory( sTemp, CONSOLE_WIDTH*2 );
+	memset( sText, 0, CONSOLE_WIDTH*2 );
+	memset( sTemp, 0, CONSOLE_WIDTH*2 );
 
 	if (! nArgs)
 	{

--- a/source/Debugger/Util_MemoryTextFile.cpp
+++ b/source/Debugger/Util_MemoryTextFile.cpp
@@ -67,7 +67,7 @@ void MemoryTextFile_t::GetLine( const int iLine, char *pLine, const int nMaxLine
 		GetLinePointers();
 	}		
 
-	ZeroMemory( pLine, nMaxLineChars );
+	memset( pLine, 0, nMaxLineChars );
 	strncpy( pLine, m_vLines[ iLine ], nMaxLineChars-1 );
 }
 

--- a/source/Disk.cpp
+++ b/source/Disk.cpp
@@ -1540,7 +1540,7 @@ bool Disk2InterfaceCard::UserSelectNewDiskImage(const int drive, LPCSTR pszFilen
 	_ASSERT(sizeof(OPENFILENAME) == sizeof(OPENFILENAME_NT4));	// Required for Win98/ME support (selected by _WIN32_WINNT=0x0400 in stdafx.h)
 
 	OPENFILENAME ofn;
-	ZeroMemory(&ofn,sizeof(OPENFILENAME));
+	memset(&ofn, 0, sizeof(OPENFILENAME));
 	ofn.lStructSize     = sizeof(OPENFILENAME);
 	ofn.hwndOwner       = g_hFrameWindow;
 	ofn.hInstance       = g_hInstance;

--- a/source/DiskImage.cpp
+++ b/source/DiskImage.cpp
@@ -46,9 +46,6 @@ ImageError_e ImageOpen(	const std::string & pszImageFilename,
 						std::string& strFilenameInZip,
 						const bool bExpectFloppy /*=true*/)
 {
-	if (bExpectFloppy && sg_DiskImageHelper.GetWorkBuffer() == NULL)
-		return eIMAGE_ERROR_BAD_POINTER;
-
 	if (!(!pszImageFilename.empty() && ppImageInfo && pWriteProtected))
 		return eIMAGE_ERROR_BAD_POINTER;
 
@@ -110,22 +107,6 @@ BOOL ImageBoot(ImageInfo* const pImageInfo)
 		pImageInfo->bWriteProtected = 1;
 
 	return result;
-}
-
-//===========================================================================
-
-void ImageDestroy(void)
-{
-	VirtualFree(sg_DiskImageHelper.GetWorkBuffer(), 0, MEM_RELEASE);
-	sg_DiskImageHelper.SetWorkBuffer(NULL);
-}
-
-//===========================================================================
-
-void ImageInitialize(void)
-{
-	LPBYTE pBuffer = (LPBYTE) VirtualAlloc(NULL, TRACK_DENIBBLIZED_SIZE*2, MEM_COMMIT, PAGE_READWRITE);
-	sg_DiskImageHelper.SetWorkBuffer(pBuffer);
 }
 
 //===========================================================================

--- a/source/DiskImage.h
+++ b/source/DiskImage.h
@@ -79,8 +79,6 @@ struct ImageInfo;
 ImageError_e ImageOpen(const std::string & pszImageFilename, ImageInfo** ppImageInfo, bool* pWriteProtected, const bool bCreateIfNecessary, std::string& strFilenameInZip, const bool bExpectFloppy=true);
 void ImageClose(ImageInfo* const pImageInfo);
 BOOL ImageBoot(ImageInfo* const pImageInfo);
-void ImageDestroy(void);
-void ImageInitialize(void);
 
 void ImageReadTrack(ImageInfo* const pImageInfo, float phase, LPBYTE pTrackImageBuffer, int* pNibbles, UINT* pBitCount, bool enhanceDisk);
 void ImageWriteTrack(ImageInfo* const pImageInfo, float phase, LPBYTE pTrackImageBuffer, int nNibbles);

--- a/source/DiskImageHelper.cpp
+++ b/source/DiskImageHelper.cpp
@@ -52,7 +52,7 @@ ImageInfo::ImageInfo()
 	uOffset = 0;
 	bWriteProtected = false;
 	uImageSize = 0;
-	ZeroMemory(&zipFileInfo, sizeof(zipFileInfo));
+	memset(&zipFileInfo, 0, sizeof(zipFileInfo));
 	uNumEntriesInZip = 0;
 	uNumValidImagesInZip = 0;
 	uNumTracks = 0;
@@ -363,7 +363,7 @@ void CImageBase::Decode62(LPBYTE imageptr)
 	static BYTE sixbitbyte[0x80];
 	if (!tablegenerated)
 	{
-		ZeroMemory(sixbitbyte,0x80);
+		memset(sixbitbyte, 0, 0x80);
 		int loop = 0;
 		while (loop < 0x40) {
 			sixbitbyte[ms_DiskByte[loop]-0x80] = loop << 2;
@@ -899,7 +899,7 @@ class CIIeImage : public CImageBase
 {
 public:
 	CIIeImage(void) : m_pHeader(NULL) {}
-	virtual ~CIIeImage(void) { delete [] m_pHeader; }
+	virtual ~CIIeImage(void) { free(m_pHeader); }
 
 	virtual eDetectResult Detect(const LPBYTE pImage, const DWORD dwImageSize, const TCHAR* pszExt)
 	{
@@ -917,13 +917,13 @@ public:
 		// IF WE HAVEN'T ALREADY DONE SO, READ THE IMAGE FILE HEADER
 		if (!m_pHeader)
 		{
-			m_pHeader = (LPBYTE) VirtualAlloc(NULL, 88, MEM_COMMIT, PAGE_READWRITE);
+			m_pHeader = (LPBYTE) malloc(88);
 			if (!m_pHeader)
 			{
 				*pNibbles = 0;
 				return;
 			}
-			ZeroMemory(m_pHeader, 88);
+			memset(m_pHeader, 0, 88);
 			DWORD dwBytesRead;
 			SetFilePointer(pImageInfo->hFile, 0, NULL,FILE_BEGIN);
 			ReadFile(pImageInfo->hFile, m_pHeader, 88, &dwBytesRead, NULL);
@@ -947,7 +947,7 @@ public:
 			while (track--)
 				Offset += *(LPWORD)(m_pHeader+track*2+14);
 			SetFilePointer(pImageInfo->hFile, Offset, NULL,FILE_BEGIN);
-			ZeroMemory(pTrackImageBuffer, *pNibbles);
+			memset(pTrackImageBuffer, 0, *pNibbles);
 			DWORD dwBytesRead;
 			ReadFile(pImageInfo->hFile, pTrackImageBuffer, *pNibbles, &dwBytesRead, NULL);
 		}
@@ -1867,7 +1867,7 @@ ImageError_e CImageHelperBase::CheckNormalFile(LPCTSTR pszImageFilename, ImageIn
 				}
 				else
 				{
-					ZeroMemory(pImageInfo->pImageBuffer, dwSize);
+					memset(pImageInfo->pImageBuffer, 0, dwSize);
 				}
 			}
 

--- a/source/DiskImageHelper.cpp
+++ b/source/DiskImageHelper.cpp
@@ -67,12 +67,12 @@ CImageBase::CImageBase()
 	: m_uNumTracksInImage(0)
 	, m_uVolumeNumber(DEFAULT_VOLUME_NUMBER)
 {
-	ms_pWorkBuffer = (LPBYTE)malloc(TRACK_DENIBBLIZED_SIZE * 2);
+	ms_pWorkBuffer = new BYTE[TRACK_DENIBBLIZED_SIZE * 2];
 }
 
 CImageBase::~CImageBase()
 {
-	free(ms_pWorkBuffer);
+	delete [] ms_pWorkBuffer;
 	ms_pWorkBuffer = NULL;
 }
 
@@ -899,7 +899,7 @@ class CIIeImage : public CImageBase
 {
 public:
 	CIIeImage(void) : m_pHeader(NULL) {}
-	virtual ~CIIeImage(void) { free(m_pHeader); }
+	virtual ~CIIeImage(void) { delete [] m_pHeader; }
 
 	virtual eDetectResult Detect(const LPBYTE pImage, const DWORD dwImageSize, const TCHAR* pszExt)
 	{
@@ -917,12 +917,7 @@ public:
 		// IF WE HAVEN'T ALREADY DONE SO, READ THE IMAGE FILE HEADER
 		if (!m_pHeader)
 		{
-			m_pHeader = (LPBYTE) malloc(88);
-			if (!m_pHeader)
-			{
-				*pNibbles = 0;
-				return;
-			}
+			m_pHeader = new BYTE[88];
 			memset(m_pHeader, 0, 88);
 			DWORD dwBytesRead;
 			SetFilePointer(pImageInfo->hFile, 0, NULL,FILE_BEGIN);

--- a/source/DiskImageHelper.cpp
+++ b/source/DiskImageHelper.cpp
@@ -63,6 +63,20 @@ ImageInfo::ImageInfo()
 	maxNibblesPerTrack = 0;
 }
 
+CImageBase::CImageBase()
+	: m_uNumTracksInImage(0)
+	, m_uVolumeNumber(DEFAULT_VOLUME_NUMBER)
+{
+	ms_pWorkBuffer = (LPBYTE)malloc(TRACK_DENIBBLIZED_SIZE * 2);
+}
+
+CImageBase::~CImageBase()
+{
+	free(ms_pWorkBuffer);
+	ms_pWorkBuffer = NULL;
+}
+
+
 /* DO logical order  0 1 2 3 4 5 6 7 8 9 A B C D E F */
 /*    physical order 0 D B 9 7 5 3 1 E C A 8 6 4 2 F */
 
@@ -87,8 +101,6 @@ BYTE CImageBase::ms_SectorNumber[NUM_SECTOR_ORDERS][0x10] =
 	{0x00,0x07,0x0E,0x06,0x0D,0x05,0x0C,0x04, 0x0B,0x03,0x0A,0x02,0x09,0x01,0x08,0x0F},
 	{0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00, 0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00}
 };
-
-LPBYTE CImageBase::ms_pWorkBuffer = NULL;
 
 //-----------------------------------------------------------------------------
 
@@ -417,7 +429,7 @@ void CImageBase::Decode62(LPBYTE imageptr)
 
 void CImageBase::DenibblizeTrack(LPBYTE trackimage, SectorOrder_e SectorOrder, int nibbles)
 {
-	ZeroMemory(ms_pWorkBuffer, TRACK_DENIBBLIZED_SIZE);
+	memset(ms_pWorkBuffer, 0, TRACK_DENIBBLIZED_SIZE);
 
 	// SEARCH THROUGH THE TRACK IMAGE FOR EACH SECTOR.  FOR EVERY SECTOR
 	// WE FIND, COPY THE NIBBLIZED DATA FOR THAT SECTOR INTO THE WORK
@@ -494,7 +506,7 @@ void CImageBase::DenibblizeTrack(LPBYTE trackimage, SectorOrder_e SectorOrder, i
 
 DWORD CImageBase::NibblizeTrack(LPBYTE trackimagebuffer, SectorOrder_e SectorOrder, int track)
 {
-	ZeroMemory(ms_pWorkBuffer+TRACK_DENIBBLIZED_SIZE, TRACK_DENIBBLIZED_SIZE);
+	memset(ms_pWorkBuffer+TRACK_DENIBBLIZED_SIZE, 0, TRACK_DENIBBLIZED_SIZE);
 	LPBYTE imageptr = trackimagebuffer;
 	BYTE   sector   = 0;
 
@@ -922,7 +934,7 @@ public:
 		{
 			ConvertSectorOrder(m_pHeader+14);
 			SetFilePointer(pImageInfo->hFile, track*TRACK_DENIBBLIZED_SIZE+30, NULL, FILE_BEGIN);
-			ZeroMemory(ms_pWorkBuffer, TRACK_DENIBBLIZED_SIZE);
+			memset(ms_pWorkBuffer, 0, TRACK_DENIBBLIZED_SIZE);
 			DWORD bytesread;
 			ReadFile(pImageInfo->hFile, ms_pWorkBuffer, TRACK_DENIBBLIZED_SIZE, &bytesread, NULL);
 			*pNibbles = NibblizeTrack(pTrackImageBuffer, eSIMSYSTEMOrder, track);

--- a/source/DiskImageHelper.h
+++ b/source/DiskImageHelper.h
@@ -56,8 +56,8 @@ struct ImageInfo
 class CImageBase
 {
 public:
-	CImageBase(void) : m_uNumTracksInImage(0), m_uVolumeNumber(DEFAULT_VOLUME_NUMBER) {}
-	virtual ~CImageBase(void) {}
+	CImageBase(void);
+	virtual ~CImageBase(void);
 
 	virtual bool Boot(ImageInfo* pImageInfo) { return false; }
 	virtual eDetectResult Detect(const LPBYTE pImage, const DWORD dwImageSize, const TCHAR* pszExt) = 0;
@@ -99,8 +99,9 @@ protected:
 	DWORD NibblizeTrack (LPBYTE trackimagebuffer, SectorOrder_e SectorOrder, int track);
 	void SkewTrack (const int nTrack, const int nNumNibbles, const LPBYTE pTrackImageBuffer);
 
+	LPBYTE ms_pWorkBuffer;
+
 public:
-	static LPBYTE ms_pWorkBuffer;
 	UINT m_uNumTracksInImage;	// Init'd by CDiskImageHelper.Detect()/GetImageForCreation() & possibly updated by IsValidImageSize()
 
 protected:
@@ -424,9 +425,6 @@ public:
 
 	UINT GetNumTracksInImage(CImageBase* pImageType) { return pImageType->m_uNumTracksInImage; }
 	void SetNumTracksInImage(CImageBase* pImageType, UINT uNumTracks) { pImageType->m_uNumTracksInImage = uNumTracks; }
-
-	LPBYTE GetWorkBuffer(void) { return CImageBase::ms_pWorkBuffer; }
-	void SetWorkBuffer(LPBYTE pBuffer) { CImageBase::ms_pWorkBuffer = pBuffer; }
 
 private:
 	void SkipMacBinaryHdr(LPBYTE& pImage, DWORD& dwSize, DWORD& dwOffset);

--- a/source/Harddisk.cpp
+++ b/source/Harddisk.cpp
@@ -125,7 +125,7 @@ struct HDD
 	void clear()
 	{
 		// This is not a POD (there is a std::string)
-		// ZeroMemory does not work
+		// memset(0) does not work
 		imagename.clear();
 		fullname.clear();
 		strFilenameInZip.clear();
@@ -136,7 +136,7 @@ struct HDD
 		hd_diskblock = 0;
 		hd_buf_ptr = 0;
 		hd_imageloaded = false;
-		ZeroMemory(hd_buf, sizeof(hd_buf));
+		memset(hd_buf, 0, sizeof(hd_buf));
 #if HD_LED
 		hd_status_next = DISK_STATUS_OFF;
 		hd_status_prev = DISK_STATUS_OFF;
@@ -463,7 +463,7 @@ static bool HD_SelectImage(const int drive, LPCSTR pszFilename)
 	_ASSERT(sizeof(OPENFILENAME) == sizeof(OPENFILENAME_NT4));	// Required for Win98/ME support (selected by _WIN32_WINNT=0x0400 in stdafx.h)
 
 	OPENFILENAME ofn;
-	ZeroMemory(&ofn,sizeof(OPENFILENAME));
+	memset(&ofn, 0, sizeof(OPENFILENAME));
 	ofn.lStructSize     = sizeof(OPENFILENAME);
 	ofn.hwndOwner       = g_hFrameWindow;
 	ofn.hInstance       = g_hInstance;
@@ -584,7 +584,7 @@ static BYTE __stdcall HD_IO_EMUL(WORD pc, WORD addr, BYTE bWrite, BYTE d, ULONG 
 
 								if (bAppendBlocks)
 								{
-									ZeroMemory(pHDD->hd_buf, HD_BLOCK_SIZE);
+									memset(pHDD->hd_buf, 0, HD_BLOCK_SIZE);
 
 									// Inefficient (especially for gzip/zip files!)
 									UINT uBlock = ImageGetImageSize(pHDD->imagehandle) / HD_BLOCK_SIZE;

--- a/source/LanguageCard.cpp
+++ b/source/LanguageCard.cpp
@@ -139,13 +139,13 @@ bool LanguageCardUnit::IsOpcodeRMWabs(WORD addr)
 LanguageCardSlot0::LanguageCardSlot0(SS_CARDTYPE type/*=CT_LanguageCard*/)
 	: LanguageCardUnit(type)
 {
-	m_pMemory = (LPBYTE)VirtualAlloc(NULL, kMemBankSize, MEM_COMMIT, PAGE_READWRITE);
+	m_pMemory = (LPBYTE)malloc(kMemBankSize);
 	SetMemMainLanguageCard(m_pMemory);
 }
 
 LanguageCardSlot0::~LanguageCardSlot0(void)
 {
-	VirtualFree(m_pMemory, 0, MEM_RELEASE);
+	free(m_pMemory);
 	m_pMemory = NULL;
 }
 
@@ -218,7 +218,7 @@ bool LanguageCardSlot0::LoadSnapshot(YamlLoadHelper& yamlLoadHelper, UINT slot, 
 
 	if (!m_pMemory)
 	{
-		m_pMemory = (LPBYTE) VirtualAlloc(NULL, kMemBankSize, MEM_COMMIT, PAGE_READWRITE);
+		m_pMemory = (LPBYTE) malloc(kMemBankSize);
 		if (!m_pMemory)
 			throw std::string("Card: mem alloc failed");
 	}
@@ -249,7 +249,7 @@ Saturn128K::Saturn128K(UINT banks)
 	m_aSaturnBanks[0] = m_pMemory;	// Reuse memory allocated in base ctor
 
 	for (UINT i = 1; i < m_uSaturnTotalBanks; i++)
-		m_aSaturnBanks[i] = (LPBYTE) VirtualAlloc(NULL, kMemBankSize, MEM_COMMIT, PAGE_READWRITE); // Saturn banks are 16K, max 8 banks/card
+		m_aSaturnBanks[i] = (LPBYTE) malloc(kMemBankSize); // Saturn banks are 16K, max 8 banks/card
 
 	SetMemMainLanguageCard( m_aSaturnBanks[ m_uSaturnActiveBank ] );
 }
@@ -262,7 +262,7 @@ Saturn128K::~Saturn128K(void)
 	{
 		if (m_aSaturnBanks[i])
 		{
-			VirtualFree(m_aSaturnBanks[i], 0, MEM_RELEASE);
+			free(m_aSaturnBanks[i]);
 			m_aSaturnBanks[i] = NULL;
 		}
 	}
@@ -438,7 +438,7 @@ bool Saturn128K::LoadSnapshot(YamlLoadHelper& yamlLoadHelper, UINT slot, UINT ve
 		LPBYTE pBank = m_aSaturnBanks[uBank];
 		if (!pBank)
 		{
-			pBank = m_aSaturnBanks[uBank] = (LPBYTE) VirtualAlloc(NULL, kMemBankSize, MEM_COMMIT, PAGE_READWRITE);
+			pBank = m_aSaturnBanks[uBank] = (LPBYTE) malloc(kMemBankSize);
 			if (!pBank)
 				throw std::string("Card: mem alloc failed");
 		}

--- a/source/LanguageCard.cpp
+++ b/source/LanguageCard.cpp
@@ -139,13 +139,13 @@ bool LanguageCardUnit::IsOpcodeRMWabs(WORD addr)
 LanguageCardSlot0::LanguageCardSlot0(SS_CARDTYPE type/*=CT_LanguageCard*/)
 	: LanguageCardUnit(type)
 {
-	m_pMemory = (LPBYTE)malloc(kMemBankSize);
+	m_pMemory = new BYTE[kMemBankSize];
 	SetMemMainLanguageCard(m_pMemory);
 }
 
 LanguageCardSlot0::~LanguageCardSlot0(void)
 {
-	free(m_pMemory);
+	delete [] m_pMemory;
 	m_pMemory = NULL;
 }
 
@@ -218,9 +218,7 @@ bool LanguageCardSlot0::LoadSnapshot(YamlLoadHelper& yamlLoadHelper, UINT slot, 
 
 	if (!m_pMemory)
 	{
-		m_pMemory = (LPBYTE) malloc(kMemBankSize);
-		if (!m_pMemory)
-			throw std::string("Card: mem alloc failed");
+		m_pMemory = new BYTE[kMemBankSize];
 	}
 
 	if (!yamlLoadHelper.GetSubMap(GetSnapshotMemStructName()))
@@ -249,7 +247,7 @@ Saturn128K::Saturn128K(UINT banks)
 	m_aSaturnBanks[0] = m_pMemory;	// Reuse memory allocated in base ctor
 
 	for (UINT i = 1; i < m_uSaturnTotalBanks; i++)
-		m_aSaturnBanks[i] = (LPBYTE) malloc(kMemBankSize); // Saturn banks are 16K, max 8 banks/card
+		m_aSaturnBanks[i] = new BYTE[kMemBankSize]; // Saturn banks are 16K, max 8 banks/card
 
 	SetMemMainLanguageCard( m_aSaturnBanks[ m_uSaturnActiveBank ] );
 }
@@ -262,7 +260,7 @@ Saturn128K::~Saturn128K(void)
 	{
 		if (m_aSaturnBanks[i])
 		{
-			free(m_aSaturnBanks[i]);
+			delete [] m_aSaturnBanks[i];
 			m_aSaturnBanks[i] = NULL;
 		}
 	}
@@ -435,12 +433,9 @@ bool Saturn128K::LoadSnapshot(YamlLoadHelper& yamlLoadHelper, UINT slot, UINT ve
 
 	for(UINT uBank = 0; uBank < m_uSaturnTotalBanks; uBank++)
 	{
-		LPBYTE pBank = m_aSaturnBanks[uBank];
-		if (!pBank)
+		if (!m_aSaturnBanks[uBank])
 		{
-			pBank = m_aSaturnBanks[uBank] = (LPBYTE) malloc(kMemBankSize);
-			if (!pBank)
-				throw std::string("Card: mem alloc failed");
+			m_aSaturnBanks[uBank] = new BYTE[kMemBankSize];
 		}
 
 		// "Memory Bankxx"
@@ -451,7 +446,7 @@ bool Saturn128K::LoadSnapshot(YamlLoadHelper& yamlLoadHelper, UINT slot, UINT ve
 		if (!yamlLoadHelper.GetSubMap(memName))
 			throw std::string("Memory: Missing map name: " + memName);
 
-		yamlLoadHelper.LoadMemory(pBank, kMemBankSize);
+		yamlLoadHelper.LoadMemory(m_aSaturnBanks[uBank], kMemBankSize);
 
 		yamlLoadHelper.PopMap();
 	}

--- a/source/RGBMonitor.cpp
+++ b/source/RGBMonitor.cpp
@@ -215,7 +215,7 @@ static void V_CreateLookup_DoubleHires ()
     int coloffs = SIZE * column;
     for (unsigned byteval = 0; byteval < 256; byteval++) {
       int color[SIZE];
-      ZeroMemory(color,sizeof(color));
+      memset(color, 0, sizeof(color));
       unsigned pattern = MAKEWORD(byteval,column);
       int pixel;
       for (pixel = 1; pixel < 15; pixel++) {
@@ -1175,7 +1175,7 @@ static void V_CreateDIBSections(void)
 		g_aSourceStartofLine[ y ] = g_pSourcePixels + SRCOFFS_TOTAL*((MAX_SOURCE_Y-1) - y);
 
 	// DRAW THE SOURCE IMAGE INTO THE SOURCE BIT BUFFER
-	ZeroMemory(g_pSourcePixels, SRCOFFS_TOTAL*MAX_SOURCE_Y);
+	memset(g_pSourcePixels, 0, SRCOFFS_TOTAL*MAX_SOURCE_Y);
 
 	V_CreateLookup_Lores();
 	V_CreateLookup_HiResHalfPixel_Authentic(VT_COLOR_IDEALIZED);

--- a/source/SerialComms.cpp
+++ b/source/SerialComms.cpp
@@ -175,7 +175,7 @@ void CSuperSerialCard::UpdateCommState()
 		return;
 
 	DCB dcb;
-	ZeroMemory(&dcb,sizeof(DCB));
+	memset(&dcb, 0, sizeof(DCB));
 	dcb.DCBlength = sizeof(DCB);
 	GetCommState(m_hCommHandle,&dcb);
 	dcb.BaudRate = m_uBaudRate;
@@ -280,7 +280,7 @@ bool CSuperSerialCard::CheckComm()
 			// Read operation is to return immediately with the bytes that have already been received,
 			// even if no bytes have been received.
 			COMMTIMEOUTS ct;
-			ZeroMemory(&ct,sizeof(COMMTIMEOUTS));
+			memset(&ct, 0, sizeof(COMMTIMEOUTS));
 			ct.ReadIntervalTimeout = MAXDWORD;
 			SetCommTimeouts(m_hCommHandle,&ct);
 

--- a/source/SoundCore.cpp
+++ b/source/SoundCore.cpp
@@ -530,7 +530,7 @@ bool DSInit()
 	}
 
 	DSCAPS DSCaps;
-    ZeroMemory(&DSCaps, sizeof(DSCAPS));
+    memset(&DSCaps, 0, sizeof(DSCAPS));
     DSCaps.dwSize = sizeof(DSCAPS);
 	hr = g_lpDS->GetCaps(&DSCaps);
 	if(FAILED(hr))

--- a/source/Windows/AppleWin.cpp
+++ b/source/Windows/AppleWin.cpp
@@ -770,9 +770,6 @@ static void OneTimeInitialization(HINSTANCE passinstance)
 
 	FrameRegisterClass();
 	LogFileOutput("Init: FrameRegisterClass()\n");
-
-	ImageInitialize();
-	LogFileOutput("Init: ImageInitialize()\n");
 }
 
 // DO INITIALIZATION THAT MUST BE REPEATED FOR A RESTART

--- a/source/Windows/DirectInput.cpp
+++ b/source/Windows/DirectInput.cpp
@@ -222,7 +222,7 @@ namespace DIMouse
 			return S_OK;
 
 		// Get the input's device state, and put the state in dims
-		ZeroMemory( &dims2, sizeof(dims2) );
+		memset( &dims2, 0, sizeof(dims2) );
 		hr = g_pMouse->GetDeviceState( sizeof(DIMOUSESTATE2), &dims2 );
 		if( FAILED(hr) ) 
 		{

--- a/source/Windows/WinFrame.cpp
+++ b/source/Windows/WinFrame.cpp
@@ -1059,7 +1059,6 @@ LRESULT CALLBACK FrameWndProc (
       DebugDestroy();
       if (!g_bRestart) {
 		GetCardMgr().GetDisk2CardMgr().Destroy();
-        ImageDestroy();
         HD_Destroy();
       }
       PrintDestroy();

--- a/source/Windows/WinFrame.cpp
+++ b/source/Windows/WinFrame.cpp
@@ -284,7 +284,7 @@ static void FullScreenRevealCursor(void)
 
 static void CreateGdiObjects(void)
 {
-	ZeroMemory(buttonbitmap, BUTTONS*sizeof(HBITMAP));
+	memset(buttonbitmap, 0, BUTTONS*sizeof(HBITMAP));
 
 	buttonbitmap[BTN_HELP] = (HBITMAP)LOADBUTTONBITMAP(TEXT("HELP_BUTTON"));
 
@@ -2583,7 +2583,7 @@ void FrameRefreshStatus (int drawflags, bool bUpdateDiskStatus) {
 //===========================================================================
 void FrameRegisterClass () {
   WNDCLASSEX wndclass;
-  ZeroMemory(&wndclass,sizeof(WNDCLASSEX));
+  memset(&wndclass, 0, sizeof(WNDCLASSEX));
   wndclass.cbSize        = sizeof(WNDCLASSEX);
   wndclass.style         = CS_OWNDC | CS_BYTEALIGNCLIENT;
   wndclass.lpfnWndProc   = FrameWndProc;

--- a/source/Windows/WinVideo.cpp
+++ b/source/Windows/WinVideo.cpp
@@ -92,7 +92,7 @@ void WinVideoInitialize()
 	g_hLogoBitmap = LoadBitmap(g_hInstance, MAKEINTRESOURCE(IDB_APPLEWIN));
 
 	// CREATE A BITMAPINFO STRUCTURE FOR THE FRAME BUFFER
-	g_pFramebufferinfo = (LPBITMAPINFO)malloc(sizeof(BITMAPINFOHEADER) + 256 * sizeof(RGBQUAD));
+	g_pFramebufferinfo = (LPBITMAPINFO) new BYTE[sizeof(BITMAPINFOHEADER) + 256 * sizeof(RGBQUAD)];
 
 	memset(g_pFramebufferinfo, 0, sizeof(BITMAPINFOHEADER) + 256 * sizeof(RGBQUAD));
 	g_pFramebufferinfo->bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
@@ -110,7 +110,7 @@ void WinVideoDestroy()
 {
 
 	// DESTROY BUFFERS
-	free(g_pFramebufferinfo);
+	delete [] g_pFramebufferinfo;
 	g_pFramebufferinfo = NULL;
 
 	// DESTROY FRAME BUFFER

--- a/source/Windows/WinVideo.cpp
+++ b/source/Windows/WinVideo.cpp
@@ -73,7 +73,7 @@ static void videoCreateDIBSection()
 	SelectObject(g_hDeviceDC, g_hDeviceBitmap);
 
 	// DRAW THE SOURCE IMAGE INTO THE SOURCE BIT BUFFER
-	ZeroMemory(g_pFramebufferbits, GetFrameBufferWidth() * GetFrameBufferHeight() * sizeof(bgra_t));
+	memset(g_pFramebufferbits, 0, GetFrameBufferWidth() * GetFrameBufferHeight() * sizeof(bgra_t));
 
 	// CREATE THE OFFSET TABLE FOR EACH SCAN LINE IN THE FRAME BUFFER
 	NTSC_VideoInit(g_pFramebufferbits);
@@ -92,13 +92,9 @@ void WinVideoInitialize()
 	g_hLogoBitmap = LoadBitmap(g_hInstance, MAKEINTRESOURCE(IDB_APPLEWIN));
 
 	// CREATE A BITMAPINFO STRUCTURE FOR THE FRAME BUFFER
-	g_pFramebufferinfo = (LPBITMAPINFO)VirtualAlloc(
-		NULL,
-		sizeof(BITMAPINFOHEADER) + 256 * sizeof(RGBQUAD),
-		MEM_COMMIT,
-		PAGE_READWRITE);
+	g_pFramebufferinfo = (LPBITMAPINFO)malloc(sizeof(BITMAPINFOHEADER) + 256 * sizeof(RGBQUAD));
 
-	ZeroMemory(g_pFramebufferinfo, sizeof(BITMAPINFOHEADER) + 256 * sizeof(RGBQUAD));
+	memset(g_pFramebufferinfo, 0, sizeof(BITMAPINFOHEADER) + 256 * sizeof(RGBQUAD));
 	g_pFramebufferinfo->bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
 	g_pFramebufferinfo->bmiHeader.biWidth = GetFrameBufferWidth();
 	g_pFramebufferinfo->bmiHeader.biHeight = GetFrameBufferHeight();
@@ -114,7 +110,7 @@ void WinVideoDestroy()
 {
 
 	// DESTROY BUFFERS
-	VirtualFree(g_pFramebufferinfo, 0, MEM_RELEASE);
+	free(g_pFramebufferinfo);
 	g_pFramebufferinfo = NULL;
 
 	// DESTROY FRAME BUFFER
@@ -312,7 +308,7 @@ void VideoBenchmark () {
 void VideoChooseMonochromeColor ()
 {
 	CHOOSECOLOR cc;
-	ZeroMemory(&cc,sizeof(CHOOSECOLOR));
+	memset(&cc, 0, sizeof(CHOOSECOLOR));
 	cc.lStructSize     = sizeof(CHOOSECOLOR);
 	cc.hwndOwner       = g_hFrameWindow;
 	cc.rgbResult       = g_nMonochromeRGB;

--- a/test/TestCPU6502/TestCPU6502.cpp
+++ b/test/TestCPU6502/TestCPU6502.cpp
@@ -112,7 +112,8 @@ void NTSC_VideoUpdateCycles( long cycles6502 )
 
 void init(void)
 {
-	mem = (LPBYTE)VirtualAlloc(NULL,64*1024,MEM_COMMIT,PAGE_READWRITE);
+	// memory must be zero initialised like MemInitiaize() does.
+	mem = (LPBYTE)calloc(64, 1024);
 
 	for (UINT i=0; i<256; i++)
 		memwrite[i] = mem+i*256;


### PR DESCRIPTION
Replaced by malloc, free & memset.

The only tricky bit has been the fact that MEM_COMMIT implies zero-initialisation (which I had completely forgotten).

This was apparently only ever required in TestCPU6502.cpp (replaced by calloc), while other parts of the code were ignoring this feature and calling ZeroMemory just after a MEM_COMMIT.
