### PR TITLE
Move interface into a class FrameBase.

### DIFF
--- a/AppleWinExpress2019.vcxproj
+++ b/AppleWinExpress2019.vcxproj
@@ -78,6 +78,7 @@
     <ClInclude Include="source\DiskImageHelper.h" />
     <ClInclude Include="source\DiskLog.h" />
     <ClInclude Include="source\Frame.h" />
+    <ClInclude Include="source\FrameBase.h" />
     <ClInclude Include="source\Harddisk.h" />
     <ClInclude Include="source\Interface.h" />
     <ClInclude Include="source\Joystick.h" />
@@ -120,6 +121,7 @@
     <ClInclude Include="source\Video.h" />
     <ClInclude Include="source\Windows\AppleWin.h" />
     <ClInclude Include="source\Windows\DirectInput.h" />
+    <ClInclude Include="source\Windows\Win32Frame.h" />
     <ClInclude Include="source\Windows\WinFrame.h" />
     <ClInclude Include="source\Windows\WinVideo.h" />
     <ClInclude Include="source\YamlHelper.h" />
@@ -155,6 +157,7 @@
     <ClCompile Include="source\Core.cpp" />
     <ClCompile Include="source\CPU.cpp" />
     <ClCompile Include="source\Disk2CardManager.cpp" />
+    <ClCompile Include="source\FrameBase.cpp" />
     <ClCompile Include="source\RGBMonitor.cpp" />
     <ClCompile Include="source\SAM.cpp" />
     <ClCompile Include="source\Debugger\Debug.cpp" />
@@ -240,6 +243,7 @@
     <ClCompile Include="source\Video.cpp" />
     <ClCompile Include="source\Windows\AppleWin.cpp" />
     <ClCompile Include="source\Windows\DirectInput.cpp" />
+    <ClCompile Include="source\Windows\Win32Frame.cpp" />
     <ClCompile Include="source\Windows\WinFrame.cpp" />
     <ClCompile Include="source\Windows\WinVideo.cpp" />
     <ClCompile Include="source\YamlHelper.cpp" />

--- a/AppleWinExpress2019.vcxproj.filters
+++ b/AppleWinExpress2019.vcxproj.filters
@@ -220,6 +220,12 @@
     <ClCompile Include="source\CmdLine.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="source\FrameBase.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="source\Windows\Win32Frame.cpp">
+      <Filter>Source Files\Windows</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="source\CommonVICE\6510core.h">
@@ -524,6 +530,12 @@
     </ClInclude>
     <ClInclude Include="source\Interface.h">
       <Filter>Source Files</Filter>
+    </ClInclude>
+    <ClInclude Include="source\FrameBase.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
+    <ClInclude Include="source\Windows\Win32Frame.h">
+      <Filter>Source Files\Windows</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/source/CmdLine.cpp
+++ b/source/CmdLine.cpp
@@ -214,13 +214,13 @@ bool ProcessCmdLine(LPSTR lpCmdLine)
 			bool bRes = false;
 			if (strcmp(lpTmp, "best") == 0)
 			{
-				bRes = GetBestDisplayResolutionForFullScreen(g_cmdLine.bestWidth, g_cmdLine.bestHeight);
+				bRes = GetFrame().GetBestDisplayResolutionForFullScreen(g_cmdLine.bestWidth, g_cmdLine.bestHeight);
 			}
 			else
 			{
 				UINT userSpecifiedHeight = atoi(lpTmp);
 				if (userSpecifiedHeight)
-					bRes = GetBestDisplayResolutionForFullScreen(g_cmdLine.bestWidth, g_cmdLine.bestHeight, userSpecifiedHeight);
+					bRes = GetFrame().GetBestDisplayResolutionForFullScreen(g_cmdLine.bestWidth, g_cmdLine.bestHeight, userSpecifiedHeight);
 				else
 					LogFileOutput("Invalid cmd-line parameter for -fs-height=x switch\n");
 			}
@@ -310,7 +310,7 @@ bool ProcessCmdLine(LPSTR lpCmdLine)
 			{
 				std::string msg = "Failed to load video rom (not found or not exactly 2/4/8/16KiB)\n";
 				LogFileOutput("%s", msg.c_str());
-				MessageBox(g_hFrameWindow, msg.c_str(), TEXT("AppleWin Error"), MB_OK);
+				MessageBox(GetFrame().g_hFrameWindow, msg.c_str(), TEXT("AppleWin Error"), MB_OK);
 			}
 			else
 			{
@@ -387,7 +387,7 @@ bool ProcessCmdLine(LPSTR lpCmdLine)
 		}
 		else if (strcmp(lpCmdLine, "-multimon") == 0)
 		{
-			g_bMultiMon = true;
+			GetFrame().g_bMultiMon = true;
 		}
 		else if ((strcmp(lpCmdLine, "-dcd") == 0) || (strcmp(lpCmdLine, "-modem") == 0))	// GH#386
 		{
@@ -396,11 +396,11 @@ bool ProcessCmdLine(LPSTR lpCmdLine)
 		}
 		else if (strcmp(lpCmdLine, "-alt-enter=toggle-full-screen") == 0)	// GH#556
 		{
-			SetAltEnterToggleFullScreen(true);
+			GetFrame().SetAltEnterToggleFullScreen(true);
 		}
 		else if (strcmp(lpCmdLine, "-alt-enter=open-apple-enter") == 0)		// GH#556
 		{
-			SetAltEnterToggleFullScreen(false);
+			GetFrame().SetAltEnterToggleFullScreen(false);
 		}
 		else if (strcmp(lpCmdLine, "-video-mode=idealized") == 0)			// GH#616
 		{

--- a/source/Configuration/About.cpp
+++ b/source/Configuration/About.cpp
@@ -64,7 +64,7 @@ static BOOL CALLBACK DlgProcAbout(HWND hWnd, UINT message, WPARAM wparam, LPARAM
 
 	case WM_INITDIALOG:
 		{
-			HICON hIcon = LoadIcon(g_hInstance, TEXT("APPLEWIN_ICON"));
+			HICON hIcon = LoadIcon(GetFrame().g_hInstance, TEXT("APPLEWIN_ICON"));
 			SendDlgItemMessage(hWnd, IDC_APPLEWIN_ICON, STM_SETIMAGE, IMAGE_ICON, (LPARAM)hIcon);
 
 			TCHAR szAppleWinVersion[50];
@@ -81,5 +81,5 @@ static BOOL CALLBACK DlgProcAbout(HWND hWnd, UINT message, WPARAM wparam, LPARAM
 
 bool AboutDlg(void)
 {
-	return DialogBox(g_hInstance, (LPCTSTR)IDD_ABOUT, g_hFrameWindow, DlgProcAbout) ? true : false;
+	return DialogBox(GetFrame().g_hInstance, (LPCTSTR)IDD_ABOUT, GetFrame().g_hFrameWindow, DlgProcAbout) ? true : false;
 }

--- a/source/Configuration/PageConfig.cpp
+++ b/source/Configuration/PageConfig.cpp
@@ -199,7 +199,7 @@ BOOL CPageConfig::DlgProcInternal(HWND hWnd, UINT message, WPARAM wparam, LPARAM
 				m_PropertySheetHelper.FillComboBox(hWnd, IDC_COMPUTER, m_ComputerChoices, nCurrentChoice);
 			}
 
-			CheckDlgButton(hWnd, IDC_CHECK_CONFIRM_REBOOT, g_bConfirmReboot ? BST_CHECKED : BST_UNCHECKED );
+			CheckDlgButton(hWnd, IDC_CHECK_CONFIRM_REBOOT, GetFrame().g_bConfirmReboot ? BST_CHECKED : BST_UNCHECKED );
 
 			m_PropertySheetHelper.FillComboBox(hWnd,IDC_VIDEOTYPE, g_aVideoChoices, GetVideoType());
 			CheckDlgButton(hWnd, IDC_CHECK_HALF_SCAN_LINES, IsVideoStyle(VS_HALF_SCANLINES) ? BST_CHECKED : BST_UNCHECKED);
@@ -314,12 +314,12 @@ void CPageConfig::DlgOK(HWND hWnd)
 	{
 		Config_Save_Video();
 
-		FrameRefreshStatus(DRAW_TITLE, false);
+		GetFrame().FrameRefreshStatus(DRAW_TITLE, false);
 
 		VideoReinitialize();
 		if ((g_nAppMode != MODE_LOGO) && (g_nAppMode != MODE_DEBUG))
 		{
-			VideoRedrawScreen();
+			GetFrame().VideoRedrawScreen();
 		}
 	}
 
@@ -329,19 +329,19 @@ void CPageConfig::DlgOK(HWND hWnd)
 	if (GetFullScreenShowSubunitStatus() != bNewFSSubunitStatus)
 	{
 		REGSAVE(TEXT(REGVALUE_FS_SHOW_SUBUNIT_STATUS), bNewFSSubunitStatus ? 1 : 0);
-		SetFullScreenShowSubunitStatus(bNewFSSubunitStatus);
+		GetFrame().SetFullScreenShowSubunitStatus(bNewFSSubunitStatus);
 
 		if (IsFullScreen())
-			FrameRefreshStatus(DRAW_BACKGROUND | DRAW_LEDS | DRAW_DISK_STATUS);
+			GetFrame().FrameRefreshStatus(DRAW_BACKGROUND | DRAW_LEDS | DRAW_DISK_STATUS);
 	}
 
 	//
 
 	const BOOL bNewConfirmReboot = IsDlgButtonChecked(hWnd, IDC_CHECK_CONFIRM_REBOOT) ? 1 : 0;
-	if (g_bConfirmReboot != bNewConfirmReboot)
+	if (GetFrame().g_bConfirmReboot != bNewConfirmReboot)
 	{
 		REGSAVE(TEXT(REGVALUE_CONFIRM_REBOOT), bNewConfirmReboot);
-		g_bConfirmReboot = bNewConfirmReboot;
+		GetFrame().g_bConfirmReboot = bNewConfirmReboot;
 	}
 
 	//
@@ -405,7 +405,7 @@ void CPageConfig::EnableTrackbar(HWND hWnd, BOOL enable)
 
 void CPageConfig::ui_tfe_settings_dialog(HWND hwnd)
 {
-	DialogBox(g_hInstance, (LPCTSTR)IDD_TFE_SETTINGS_DIALOG, hwnd, CPageConfigTfe::DlgProc);
+	DialogBox(GetFrame().g_hInstance, (LPCTSTR)IDD_TFE_SETTINGS_DIALOG, hwnd, CPageConfigTfe::DlgProc);
 }
 
 bool CPageConfig::IsOkToBenchmark(HWND hWnd, const bool bConfigChanged)

--- a/source/Configuration/PageDisk.cpp
+++ b/source/Configuration/PageDisk.cpp
@@ -92,14 +92,14 @@ BOOL CPageDisk::DlgProcInternal(HWND hWnd, UINT message, WPARAM wparam, LPARAM l
 			if (HIWORD(wparam) == CBN_SELCHANGE)
 			{
 				HandleFloppyDriveCombo(hWnd, DRIVE_1, LOWORD(wparam));
-				FrameRefreshStatus(DRAW_BUTTON_DRIVES);
+				GetFrame().FrameRefreshStatus(DRAW_BUTTON_DRIVES);
 			}
 			break;
 		case IDC_COMBO_DISK2:
 			if (HIWORD(wparam) == CBN_SELCHANGE)
 			{
 				HandleFloppyDriveCombo(hWnd, DRIVE_2, LOWORD(wparam));
-				FrameRefreshStatus(DRAW_BUTTON_DRIVES);
+				GetFrame().FrameRefreshStatus(DRAW_BUTTON_DRIVES);
 			}
 			break;
 		case IDC_COMBO_HDD1:
@@ -413,7 +413,7 @@ UINT CPageDisk::RemovalConfirmation(UINT uCommand)
 
 	if (bMsgBox)
 	{
-		int nRes = MessageBox(g_hFrameWindow, szText, TEXT("Eject/Unplug Warning"), MB_ICONWARNING | MB_YESNO | MB_SETFOREGROUND);
+		int nRes = MessageBox(GetFrame().g_hFrameWindow, szText, TEXT("Eject/Unplug Warning"), MB_ICONWARNING | MB_YESNO | MB_SETFOREGROUND);
 		if (nRes == IDNO)
 			uCommand = 0;
 	}

--- a/source/Configuration/PropertySheet.cpp
+++ b/source/Configuration/PropertySheet.cpp
@@ -41,31 +41,31 @@ void CPropertySheet::Init(void)
 
 	PropSheetPages[PG_CONFIG].dwSize = sizeof(PROPSHEETPAGE);
 	PropSheetPages[PG_CONFIG].dwFlags = PSP_DEFAULT;
-	PropSheetPages[PG_CONFIG].hInstance = g_hInstance;
+	PropSheetPages[PG_CONFIG].hInstance = GetFrame().g_hInstance;
 	PropSheetPages[PG_CONFIG].pszTemplate = MAKEINTRESOURCE(IDD_PROPPAGE_CONFIG);
 	PropSheetPages[PG_CONFIG].pfnDlgProc = (DLGPROC)CPageConfig::DlgProc;
 
 	PropSheetPages[PG_INPUT].dwSize = sizeof(PROPSHEETPAGE);
 	PropSheetPages[PG_INPUT].dwFlags = PSP_DEFAULT;
-	PropSheetPages[PG_INPUT].hInstance = g_hInstance;
+	PropSheetPages[PG_INPUT].hInstance = GetFrame().g_hInstance;
 	PropSheetPages[PG_INPUT].pszTemplate = MAKEINTRESOURCE(IDD_PROPPAGE_INPUT);
 	PropSheetPages[PG_INPUT].pfnDlgProc = (DLGPROC)CPageInput::DlgProc;
 
 	PropSheetPages[PG_SOUND].dwSize = sizeof(PROPSHEETPAGE);
 	PropSheetPages[PG_SOUND].dwFlags = PSP_DEFAULT;
-	PropSheetPages[PG_SOUND].hInstance = g_hInstance;
+	PropSheetPages[PG_SOUND].hInstance = GetFrame().g_hInstance;
 	PropSheetPages[PG_SOUND].pszTemplate = MAKEINTRESOURCE(IDD_PROPPAGE_SOUND);
 	PropSheetPages[PG_SOUND].pfnDlgProc = (DLGPROC)CPageSound::DlgProc;
 
 	PropSheetPages[PG_DISK].dwSize = sizeof(PROPSHEETPAGE);
 	PropSheetPages[PG_DISK].dwFlags = PSP_DEFAULT;
-	PropSheetPages[PG_DISK].hInstance = g_hInstance;
+	PropSheetPages[PG_DISK].hInstance = GetFrame().g_hInstance;
 	PropSheetPages[PG_DISK].pszTemplate = MAKEINTRESOURCE(IDD_PROPPAGE_DISK);
 	PropSheetPages[PG_DISK].pfnDlgProc = (DLGPROC)CPageDisk::DlgProc;
 
 	PropSheetPages[PG_ADVANCED].dwSize = sizeof(PROPSHEETPAGE);
 	PropSheetPages[PG_ADVANCED].dwFlags = PSP_DEFAULT;
-	PropSheetPages[PG_ADVANCED].hInstance = g_hInstance;
+	PropSheetPages[PG_ADVANCED].hInstance = GetFrame().g_hInstance;
 	PropSheetPages[PG_ADVANCED].pszTemplate = MAKEINTRESOURCE(IDD_PROPPAGE_ADVANCED);
 	PropSheetPages[PG_ADVANCED].pfnDlgProc = (DLGPROC)CPageAdvanced::DlgProc;
 
@@ -73,7 +73,7 @@ void CPropertySheet::Init(void)
 
 	PropSheetHeader.dwSize = sizeof(PROPSHEETHEADER);
 	PropSheetHeader.dwFlags = PSH_NOAPPLYNOW | /* PSH_NOCONTEXTHELP | */ PSH_PROPSHEETPAGE;
-	PropSheetHeader.hwndParent = g_hFrameWindow;
+	PropSheetHeader.hwndParent = GetFrame().g_hFrameWindow;
 	PropSheetHeader.pszCaption = "AppleWin Configuration";
 	PropSheetHeader.nPages = PG_NUM_SHEETS;
 	PropSheetHeader.nStartPage = m_PropertySheetHelper.GetLastPage();

--- a/source/Configuration/PropertySheetHelper.cpp
+++ b/source/Configuration/PropertySheetHelper.cpp
@@ -163,7 +163,7 @@ std::string CPropertySheetHelper::BrowseToFile(HWND hWindow, TCHAR* pszTitle, TC
 
 	ofn.lStructSize     = sizeof(OPENFILENAME);
 	ofn.hwndOwner       = hWindow;
-	ofn.hInstance       = g_hInstance;
+	ofn.hInstance       = GetFrame().g_hInstance;
 	ofn.lpstrFilter     = FILEMASKS;
 	/*ofn.lpstrFilter     =	TEXT("Applications (*.exe)\0*.exe\0")
 							TEXT("Text files (*.txt)\0*.txt\0")
@@ -210,7 +210,7 @@ int CPropertySheetHelper::SaveStateSelectImage(HWND hWindow, TCHAR* pszTitle, bo
 
 	ofn.lStructSize     = sizeof(OPENFILENAME);
 	ofn.hwndOwner       = hWindow;
-	ofn.hInstance       = g_hInstance;
+	ofn.hInstance       = GetFrame().g_hInstance;
 	ofn.lpstrFilter     = TEXT("Save State files (*.aws.yaml)\0*.aws.yaml\0");
 						  TEXT("All Files\0*.*\0");
 	ofn.lpstrFile       = szFilename;	// Dialog strips the last .EXT from this string (eg. file.aws.yaml is displayed as: file.aws
@@ -276,14 +276,14 @@ void CPropertySheetHelper::PostMsgAfterClose(HWND hWnd, PAGETYPE page)
 	if (m_ConfigNew.m_uSaveLoadStateMsg && IsOkToSaveLoadState(hWnd, IsConfigChanged()))
 	{
 		// Drop any config change, and do load/save state
-		PostMessage(g_hFrameWindow, m_ConfigNew.m_uSaveLoadStateMsg, 0, 0);
+		PostMessage(GetFrame().g_hFrameWindow, m_ConfigNew.m_uSaveLoadStateMsg, 0, 0);
 		return;
 	}
 	
 	if (m_bDoBenchmark)
 	{
 		// Drop any config change, and do benchmark
-		PostMessage(g_hFrameWindow, WM_USER_BENCHMARK, 0, 0);	// NB. doesn't do WM_USER_RESTART
+		PostMessage(GetFrame().g_hFrameWindow, WM_USER_BENCHMARK, 0, 0);	// NB. doesn't do WM_USER_RESTART
 		return;
 	}
 
@@ -316,7 +316,7 @@ void CPropertySheetHelper::PostMsgAfterClose(HWND hWnd, PAGETYPE page)
 	}
 
 	if (uAfterClose)
-		PostMessage(g_hFrameWindow, uAfterClose, 0, 0);
+		PostMessage(GetFrame().g_hFrameWindow, uAfterClose, 0, 0);
 }
 
 bool CPropertySheetHelper::CheckChangesForRestart(HWND hWnd)

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -754,8 +754,8 @@ Update_t CmdBenchmarkStop (int nArgs)
 	g_bBenchmarking = false;
 	DebugEnd();
 	
-	FrameRefreshStatus(DRAW_TITLE);
-	VideoRedrawScreen();
+	GetFrame().FrameRefreshStatus(DRAW_TITLE);
+	GetFrame().VideoRedrawScreen();
 	DWORD currtime = GetTickCount();
 	while ((extbench = GetTickCount()) != currtime)
 		; // intentional busy-waiting
@@ -1964,7 +1964,7 @@ static Update_t CmdGo (int nArgs, const bool bFullSpeed)
 	g_bGoCmd_ReinitFlag = true;
 
 	g_nAppMode = MODE_STEPPING;
-	FrameRefreshStatus(DRAW_TITLE);
+	GetFrame().FrameRefreshStatus(DRAW_TITLE);
 
 	SoundCore_SetFade(FADE_IN);
 
@@ -2033,7 +2033,7 @@ Update_t CmdTrace (int nArgs)
 	g_nDebugStepStart = regs.pc;
 	g_nDebugStepUntil = -1;
 	g_nAppMode = MODE_STEPPING;
-	FrameRefreshStatus(DRAW_TITLE);
+	GetFrame().FrameRefreshStatus(DRAW_TITLE);
 	DebugContinueStepping(true);
 
 	return UPDATE_ALL; // TODO: Verify // 0
@@ -2093,7 +2093,7 @@ Update_t CmdTraceLine (int nArgs)
 	g_nDebugStepUntil = -1;
 
 	g_nAppMode = MODE_STEPPING;
-	FrameRefreshStatus(DRAW_TITLE);
+	GetFrame().FrameRefreshStatus(DRAW_TITLE);
 	DebugContinueStepping(true);
 
 	return UPDATE_ALL; // TODO: Verify // 0
@@ -2227,7 +2227,7 @@ void _CmdColorGet( const int iScheme, const int iColor )
 	{
 		TCHAR sText[ CONSOLE_WIDTH ];
 		wsprintf( sText, "Color: %d\nOut of range!", iColor );
-		MessageBox( g_hFrameWindow, sText, TEXT("ERROR"), MB_OK );
+		MessageBox(GetFrame().g_hFrameWindow, sText, TEXT("ERROR"), MB_OK );
 	}
 }
 
@@ -3042,7 +3042,7 @@ void DisasmCalcTopFromCurAddress( bool bUpdateTop )
 				"\tLen: %04X\n"
 				"\tMissed: %04X"),
 				g_nDisasmCurAddress - nLen, nLen, g_nDisasmCurAddress );
-			MessageBox( g_hFrameWindow, sText, "ERROR", MB_OK );
+			MessageBox( GetFrame().g_hFrameWindow, sText, "ERROR", MB_OK );
 #endif
 	}
 }
@@ -3773,7 +3773,7 @@ Update_t CmdDisk ( int nArgs)
 			return HelpLastCommand();
 
 		diskCard.EjectDisk( iDrive );
-		FrameRefreshStatus(DRAW_LEDS | DRAW_BUTTON_DRIVES);
+		GetFrame().FrameRefreshStatus(DRAW_LEDS | DRAW_BUTTON_DRIVES);
 	}
 	else
 	if (iParam == PARAM_DISK_PROTECT)
@@ -3787,7 +3787,7 @@ Update_t CmdDisk ( int nArgs)
 			bProtect = g_aArgs[ 3 ].nValue ? true : false;
 
 		diskCard.SetProtect( iDrive, bProtect );
-		FrameRefreshStatus(DRAW_LEDS | DRAW_BUTTON_DRIVES);
+		GetFrame().FrameRefreshStatus(DRAW_LEDS | DRAW_BUTTON_DRIVES);
 	}
 	else
 	{
@@ -3798,7 +3798,7 @@ Update_t CmdDisk ( int nArgs)
 
 		// DISK # "Diskname"
 		diskCard.InsertDisk( iDrive, pDiskName, IMAGE_FORCE_WRITE_PROTECTED, IMAGE_DONT_CREATE );
-		FrameRefreshStatus(DRAW_LEDS | DRAW_BUTTON_DRIVES);
+		GetFrame().FrameRefreshStatus(DRAW_LEDS | DRAW_BUTTON_DRIVES);
 	}
 
 	return UPDATE_CONSOLE_DISPLAY;
@@ -7448,7 +7448,7 @@ Update_t CmdWindowViewData (int nArgs)
 //===========================================================================
 Update_t CmdWindowViewOutput (int nArgs)
 {
-	VideoRedrawScreen();
+	GetFrame().VideoRedrawScreen();
 
 	DebugVideoMode::Instance().Set(g_uVideoMode);
 
@@ -8549,7 +8549,7 @@ void DebugBegin ()
 	GetDebuggerMemDC();
 
 	g_nAppMode = MODE_DEBUG;
-	FrameRefreshStatus(DRAW_TITLE);
+	GetFrame().FrameRefreshStatus(DRAW_TITLE);
 
 	if (GetMainCpu() == CPU_6502)
 	{
@@ -8736,7 +8736,7 @@ void DebugContinueStepping(const bool bCallerWillUpdateDisplay/*=false*/)
 		SoundCore_SetFade(FADE_OUT);	// NB. Call when MODE_STEPPING (not MODE_DEBUG) - see function
 
 		g_nAppMode = MODE_DEBUG;
-		FrameRefreshStatus(DRAW_TITLE);
+		GetFrame().FrameRefreshStatus(DRAW_TITLE);
 // BUG: PageUp, Trace - doesn't center cursor
 
 		g_nDisasmCurAddress = regs.pc;
@@ -9064,7 +9064,7 @@ void DebuggerInputConsoleChar( TCHAR ch )
 		if (!IsClipboardFormatAvailable(CF_TEXT)) 
 			return;
 
-		if (!OpenClipboard( g_hFrameWindow )) 
+		if (!OpenClipboard(GetFrame().g_hFrameWindow ))
 			return;
 
 		HGLOBAL hClipboard;

--- a/source/Debugger/Debugger_Assembler.cpp
+++ b/source/Debugger/Debugger_Assembler.cpp
@@ -471,7 +471,7 @@ int  _6502_GetOpmodeOpbyte ( const int nBaseAddress, int & iOpmode_, int & nOpby
 #if _DEBUG
 	if (! g_aOpcodes)
 	{
-		MessageBox( g_hFrameWindow, "Debugger not properly initialized", "ERROR", MB_OK );
+		MessageBox(GetFrame().g_hFrameWindow, "Debugger not properly initialized", "ERROR", MB_OK );
 
 		g_aOpcodes = & g_aOpcodes65C02[ 0 ];	// Enhanced Apple //e
 		g_aOpmodes[ AM_2 ].m_nBytes = 2;

--- a/source/Debugger/Debugger_Commands.cpp
+++ b/source/Debugger/Debugger_Commands.cpp
@@ -518,7 +518,7 @@ void VerifyDebuggerCommandTable()
 		if ( g_aCommands[ iCmd ].iCommand != iCmd)
 		{
 			sprintf( sText, "*** ERROR *** Enumerated Commands mis-matched at #%d!", iCmd );
-			MessageBoxA( g_hFrameWindow, sText, TEXT("ERROR"), MB_OK );
+			MessageBoxA(GetFrame().g_hFrameWindow, sText, TEXT("ERROR"), MB_OK );
 			PostQuitMessage( 1 );
 		}
 	}
@@ -527,14 +527,14 @@ void VerifyDebuggerCommandTable()
 	if (strcmp( g_aCommands[ NUM_COMMANDS ].m_sName, DEBUGGER__COMMANDS_VERIFY_TXT__))
 	{
 		sprintf( sText, "*** ERROR *** Total Commands mis-matched!" );
-		MessageBoxA( g_hFrameWindow, sText, TEXT("ERROR"), MB_OK );
+		MessageBoxA(GetFrame().g_hFrameWindow, sText, TEXT("ERROR"), MB_OK );
 		PostQuitMessage( 1 );
 	}
 
 	if (strcmp( g_aParameters[ NUM_PARAMS ].m_sName, DEBUGGER__PARAMS_VERIFY_TXT__))
 	{
 		sprintf( sText, "*** ERROR *** Total Parameters mis-matched!" );
-		MessageBoxA( g_hFrameWindow, sText, TEXT("ERROR"), MB_OK );
+		MessageBoxA(GetFrame().g_hFrameWindow, sText, TEXT("ERROR"), MB_OK );
 		PostQuitMessage( 2 );
 	}
 }

--- a/source/Debugger/Debugger_Display.cpp
+++ b/source/Debugger/Debugger_Display.cpp
@@ -633,7 +633,7 @@ HDC GetConsoleFontDC(void)
 		// DRAW THE SOURCE IMAGE INTO THE SOURCE BIT BUFFER
 		HDC tmpDC = CreateCompatibleDC(hFrameDC);
 		// Pre-scaled bitmap
-		HBITMAP tmpFont = LoadBitmap(g_hInstance, TEXT("IDB_DEBUG_FONT_7x8"));  // Bitmap must be 112x128 as defined above
+		HBITMAP tmpFont = LoadBitmap(GetFrame().g_hInstance, TEXT("IDB_DEBUG_FONT_7x8"));  // Bitmap must be 112x128 as defined above
 		SelectObject(tmpDC, tmpFont);
 		BitBlt(g_hConsoleFontDC, 0, 0, CONSOLE_FONT_BITMAP_WIDTH, CONSOLE_FONT_BITMAP_HEIGHT,
 			tmpDC, 0, 0,
@@ -754,7 +754,7 @@ static void PrintGlyph( const int xDst, const int yDst, const int glyph )
 	{
 #if _DEBUG
 		if ((xDst < 0) || (yDst < 0))
-			MessageBox( g_hFrameWindow, "X or Y out of bounds!", "PrintGlyph()", MB_OK );
+			MessageBox(GetFrame().g_hFrameWindow, "X or Y out of bounds!", "PrintGlyph()", MB_OK );
 #endif
 		int col = xDst / CONSOLE_FONT_WIDTH ;
 		int row = yDst / CONSOLE_FONT_HEIGHT;
@@ -870,7 +870,7 @@ int PrintText ( const char * pText, RECT & rRect )
 {
 #if _DEBUG
 	if (! pText)
-		MessageBox( g_hFrameWindow, "pText = NULL!", "DrawText()", MB_OK );
+		MessageBox(GetFrame().g_hFrameWindow, "pText = NULL!", "DrawText()", MB_OK );
 #endif
 
 	int nLen = strlen( pText );
@@ -4116,7 +4116,7 @@ void UpdateDisplay (Update_t bUpdate)
 	if (spDrawMutex)
 	{
 #if DEBUG
-		MessageBox( g_hFrameWindow, "Already drawing!", "!", MB_OK );
+		MessageBox( GetFrame().g_hFrameWindow, "Already drawing!", "!", MB_OK );
 #endif
 	}
 	spDrawMutex = true;

--- a/source/Disk.cpp
+++ b/source/Disk.cpp
@@ -219,7 +219,7 @@ void Disk2InterfaceCard::CheckSpinning(const bool stateChanged, const ULONG uExe
 		m_floppyDrive[m_currDrive].m_spinning = SPINNING_CYCLES;
 
 	if (modeChanged)
-		FrameDrawDiskLEDS( (HDC)0 );
+		GetFrame().FrameDrawDiskLEDS( (HDC)0 );
 
 	if (modeChanged)
 	{
@@ -511,7 +511,7 @@ void __stdcall Disk2InterfaceCard::ControlStepper(WORD, WORD address, BYTE, BYTE
 		pDrive->m_phasePrecise = newPhasePrecise;
 		pFloppy->m_trackimagedata = false;
 		m_formatTrack.DriveNotWritingTrack();
-		FrameDrawDiskStatus((HDC)0);	// Show track status (GH#201)
+		GetFrame().FrameDrawDiskStatus((HDC)0);	// Show track status (GH#201)
 	}
 
 #if LOG_DISK_PHASES
@@ -683,7 +683,7 @@ ImageError_e Disk2InterfaceCard::InsertDisk(const int drive, LPCTSTR pszImageFil
 		if (!strcmp(pszOtherPathname.c_str(), szCurrentPathname))
 		{
 			EjectDisk(!drive);
-			FrameRefreshStatus(DRAW_LEDS | DRAW_BUTTON_DRIVES);
+			GetFrame().FrameRefreshStatus(DRAW_LEDS | DRAW_BUTTON_DRIVES);
 		}
 	}
 
@@ -697,7 +697,7 @@ ImageError_e Disk2InterfaceCard::InsertDisk(const int drive, LPCTSTR pszImageFil
 	{
 		TCHAR szText[100+MAX_PATH];
 		StringCbPrintf(szText, sizeof(szText), "Only the first file in a multi-file zip is supported\nUse disk image '%s' ?", pFloppy->m_strFilenameInZip.c_str());
-		int nRes = MessageBox(g_hFrameWindow, szText, TEXT("Multi-Zip Warning"), MB_ICONWARNING | MB_YESNO | MB_SETFOREGROUND);
+		int nRes = MessageBox(GetFrame().g_hFrameWindow, szText, TEXT("Multi-Zip Warning"), MB_ICONWARNING | MB_YESNO | MB_SETFOREGROUND);
 		if (nRes == IDNO)
 		{
 			EjectDisk(drive);
@@ -827,7 +827,7 @@ void Disk2InterfaceCard::NotifyInvalidImage(const int drive, LPCTSTR pszImageFil
 	}
 
 	MessageBox(
-		g_hFrameWindow,
+		GetFrame().g_hFrameWindow,
 		szBuffer,
 		g_pAppTitle.c_str(),
 		MB_ICONEXCLAMATION | MB_SETFOREGROUND);
@@ -1033,7 +1033,7 @@ void __stdcall Disk2InterfaceCard::ReadWrite(WORD pc, WORD addr, BYTE bWrite, BY
 
 	// Show track status (GH#201) - NB. Prevent flooding of forcing UI to redraw!!!
 	if ((pFloppy->m_byte & 0xFF) == 0)
-		FrameDrawDiskStatus( (HDC)0 );
+		GetFrame().FrameDrawDiskStatus( (HDC)0 );
 }
 
 //===========================================================================
@@ -1184,7 +1184,7 @@ void __stdcall Disk2InterfaceCard::DataLatchReadWriteWOZ(WORD pc, WORD addr, BYT
 
 	// Show track status (GH#201) - NB. Prevent flooding of forcing UI to redraw!!!
 	if ((floppy.m_byte & 0xFF) == 0)
-		FrameDrawDiskStatus((HDC)0);
+		GetFrame().FrameDrawDiskStatus((HDC)0);
 }
 
 void Disk2InterfaceCard::DataLatchReadWOZ(WORD pc, WORD addr, UINT bitCellRemainder)
@@ -1543,11 +1543,11 @@ void Disk2InterfaceCard::Reset(const bool bIsPowerCycle)
 		m_floppyDrive[DRIVE_2].m_spinning   = 0;
 		m_floppyDrive[DRIVE_2].m_writelight = 0;
 
-		FrameRefreshStatus(DRAW_LEDS, false);
+		GetFrame().FrameRefreshStatus(DRAW_LEDS, false);
 	}
 
 	InitFirmware(GetCxRomPeripheral());
-	FrameRefreshStatus(DRAW_TITLE, false);
+	GetFrame().FrameRefreshStatus(DRAW_TITLE, false);
 }
 
 void Disk2InterfaceCard::ResetSwitches(void)
@@ -1564,7 +1564,7 @@ bool Disk2InterfaceCard::UserSelectNewDiskImage(const int drive, LPCSTR pszFilen
 {
 	if (!IsDriveConnected(drive))
 	{
-		MessageBox(g_hFrameWindow, "Drive not connected!", "Insert disk", MB_ICONEXCLAMATION|MB_SETFOREGROUND|MB_OK);
+		MessageBox(GetFrame().g_hFrameWindow, "Drive not connected!", "Insert disk", MB_ICONEXCLAMATION|MB_SETFOREGROUND|MB_OK);
 		return false;
 	}
 
@@ -1582,8 +1582,8 @@ bool Disk2InterfaceCard::UserSelectNewDiskImage(const int drive, LPCSTR pszFilen
 	OPENFILENAME ofn;
 	memset(&ofn, 0, sizeof(OPENFILENAME));
 	ofn.lStructSize     = sizeof(OPENFILENAME);
-	ofn.hwndOwner       = g_hFrameWindow;
-	ofn.hInstance       = g_hInstance;
+	ofn.hwndOwner       = GetFrame().g_hFrameWindow;
+	ofn.hInstance       = GetFrame().g_hInstance;
 	ofn.lpstrFilter     = TEXT("All Images\0*.bin;*.do;*.dsk;*.nib;*.po;*.gz;*.woz;*.zip;*.2mg;*.2img;*.iie;*.apl\0")
 						  TEXT("Disk Images (*.bin,*.do,*.dsk,*.nib,*.po,*.gz,*.woz,*.zip,*.2mg,*.2img,*.iie)\0*.bin;*.do;*.dsk;*.nib;*.po;*.gz;*.woz;*.zip;*.2mg;*.2img;*.iie\0")
 						  TEXT("All Files\0*.*\0");
@@ -1687,7 +1687,7 @@ void __stdcall Disk2InterfaceCard::SetWriteMode(WORD, WORD, BYTE, BYTE, ULONG uE
 	m_floppyDrive[m_currDrive].m_writelight = WRITELIGHT_CYCLES;
 
 	if (modechange)
-		FrameDrawDiskLEDS( (HDC)0 );
+		GetFrame().FrameDrawDiskLEDS( (HDC)0 );
 }
 
 //===========================================================================
@@ -1703,8 +1703,8 @@ void Disk2InterfaceCard::UpdateDriveState(DWORD cycles)
 		{
 			if (!(pDrive->m_spinning -= MIN(pDrive->m_spinning, cycles)))
 			{
-				FrameDrawDiskLEDS( (HDC)0 );
-				FrameDrawDiskStatus( (HDC)0 );
+				GetFrame().FrameDrawDiskLEDS( (HDC)0 );
+				GetFrame().FrameDrawDiskStatus( (HDC)0 );
 			}
 		}
 
@@ -1716,8 +1716,8 @@ void Disk2InterfaceCard::UpdateDriveState(DWORD cycles)
 		{
 			if (!(pDrive->m_writelight -= MIN(pDrive->m_writelight, cycles)))
 			{
-				FrameDrawDiskLEDS( (HDC)0 );
-				FrameDrawDiskStatus( (HDC)0 );
+				GetFrame().FrameDrawDiskLEDS( (HDC)0 );
+				GetFrame().FrameDrawDiskStatus( (HDC)0 );
 			}
 		}
 	}
@@ -1733,7 +1733,7 @@ bool Disk2InterfaceCard::DriveSwap(void)
 	{
 		// 1.26.2.4 Prompt when trying to swap disks while drive is on instead of silently failing
 		int status = MessageBox(
-			g_hFrameWindow,
+			GetFrame().g_hFrameWindow,
 			"WARNING:\n"
 				"\n"
 				"\tAttempting to swap a disk while a drive is on\n"
@@ -1773,7 +1773,7 @@ bool Disk2InterfaceCard::DriveSwap(void)
 	SaveLastDiskImage(DRIVE_1);
 	SaveLastDiskImage(DRIVE_2);
 
-	FrameRefreshStatus(DRAW_LEDS | DRAW_BUTTON_DRIVES, false);
+	GetFrame().FrameRefreshStatus(DRAW_LEDS | DRAW_BUTTON_DRIVES, false);
 
 	return true;
 }
@@ -2264,7 +2264,7 @@ bool Disk2InterfaceCard::LoadSnapshot(class YamlLoadHelper& yamlLoadHelper, UINT
 	LoadSnapshotDriveUnit(yamlLoadHelper, DRIVE_1, version);
 	LoadSnapshotDriveUnit(yamlLoadHelper, DRIVE_2, version);
 
-	FrameRefreshStatus(DRAW_LEDS | DRAW_BUTTON_DRIVES);
+	GetFrame().FrameRefreshStatus(DRAW_LEDS | DRAW_BUTTON_DRIVES);
 
 	return true;
 }

--- a/source/FrameBase.cpp
+++ b/source/FrameBase.cpp
@@ -1,0 +1,17 @@
+#include "StdAfx.h"
+
+#include "FrameBase.h"
+
+FrameBase::FrameBase()
+{
+	g_hFrameWindow = (HWND)0;
+	g_bConfirmReboot = 1; // saved PageConfig REGSAVE
+	g_bMultiMon = 0; // OFF = load window position & clamp initial frame to screen, ON = use window position as is
+	g_bFreshReset = false;
+	g_hInstance = (HINSTANCE)0;
+}
+
+FrameBase::~FrameBase()
+{
+
+}

--- a/source/FrameBase.h
+++ b/source/FrameBase.h
@@ -1,0 +1,29 @@
+#pragma once
+
+class FrameBase
+{
+public:
+	FrameBase();
+
+	virtual ~FrameBase();
+
+	HINSTANCE  g_hInstance;
+	HWND       g_hFrameWindow;
+	BOOL       g_bConfirmReboot; // saved PageConfig REGSAVE
+	BOOL       g_bMultiMon;
+	bool       g_bFreshReset;
+
+	virtual void FrameDrawDiskLEDS(HDC hdc) = 0;
+	virtual void FrameDrawDiskStatus(HDC hdc) = 0;
+	virtual void FrameRefreshStatus(int, bool bUpdateDiskStatus = true) = 0;
+	virtual void FrameUpdateApple2Type() = 0;
+	virtual void FrameSetCursorPosByMousePos() = 0;
+
+	virtual void VideoRedrawScreen() = 0;
+	virtual void SetFullScreenShowSubunitStatus(bool bShow) = 0;
+	virtual bool GetBestDisplayResolutionForFullScreen(UINT& bestWidth, UINT& bestHeight, UINT userSpecifiedHeight = 0) = 0;
+	virtual int SetViewportScale(int nNewScale, bool bForce = false) = 0;
+	virtual void SetAltEnterToggleFullScreen(bool mode) = 0;
+
+	virtual void SetLoadedSaveStateFlag(const bool bFlag) = 0;
+};

--- a/source/Harddisk.cpp
+++ b/source/Harddisk.cpp
@@ -417,7 +417,7 @@ BOOL HD_Insert(const int iDrive, const std::string & pszImageFilename)
 		if (!strcmp(pszOtherPathname.c_str(), szCurrentPathname))
 		{
 			HD_Unplug(!iDrive);
-			FrameRefreshStatus(DRAW_LEDS);
+			GetFrame().FrameRefreshStatus(DRAW_LEDS);
 		}
 	}
 
@@ -465,8 +465,8 @@ static bool HD_SelectImage(const int drive, LPCSTR pszFilename)
 	OPENFILENAME ofn;
 	memset(&ofn, 0, sizeof(OPENFILENAME));
 	ofn.lStructSize     = sizeof(OPENFILENAME);
-	ofn.hwndOwner       = g_hFrameWindow;
-	ofn.hInstance       = g_hInstance;
+	ofn.hwndOwner       = GetFrame().g_hFrameWindow;
+	ofn.hInstance       = GetFrame().g_hInstance;
 	ofn.lpstrFilter     = TEXT("Hard Disk Images (*.hdv,*.po,*.2mg,*.2img,*.gz,*.zip)\0*.hdv;*.po;*.2mg;*.2img;*.gz;*.zip\0")
 						  TEXT("All Files\0*.*\0");
 	ofn.lpstrFile       = filename;
@@ -713,7 +713,7 @@ static BYTE __stdcall HD_IO_EMUL(WORD pc, WORD addr, BYTE bWrite, BYTE d, ULONG 
 	if( pHDD->hd_status_prev != pHDD->hd_status_next ) // Update LEDs if state changes
 	{
 		pHDD->hd_status_prev = pHDD->hd_status_next;
-		FrameRefreshStatus(DRAW_LEDS);
+		GetFrame().FrameRefreshStatus(DRAW_LEDS);
 	}
 #endif
 
@@ -742,7 +742,7 @@ bool HD_ImageSwap(void)
 	HD_SaveLastDiskImage(HARDDISK_1);
 	HD_SaveLastDiskImage(HARDDISK_2);
 
-	FrameRefreshStatus(DRAW_LEDS, false);
+	GetFrame().FrameRefreshStatus(DRAW_LEDS, false);
 
 	return true;
 }
@@ -902,7 +902,7 @@ bool HD_LoadSnapshot(YamlLoadHelper& yamlLoadHelper, UINT slot, UINT version, co
 
 	HD_SetEnabled(true);
 
-	FrameRefreshStatus(DRAW_LEDS);
+	GetFrame().FrameRefreshStatus(DRAW_LEDS);
 
 	return true;
 }

--- a/source/Interface.h
+++ b/source/Interface.h
@@ -1,25 +1,15 @@
 #pragma once
 
-class IPropertySheet;
+// an AppleWin frontend must provide the implementation of these 2 methods
+//
+// once this is done,
+// the core emulator files (i.e. almost all the .cpp directly in Source)
+// can compile, link and run properly
+// this does not include the main event loop which is left in the arch specific area
+// nor the actual rendering of the video buffer to screen
 
-extern HINSTANCE  g_hInstance;
-extern HWND       g_hFrameWindow;
-extern BOOL       g_bConfirmReboot; // saved PageConfig REGSAVE
-extern BOOL       g_bMultiMon;
-extern bool       g_bFreshReset;
-
-void	FrameDrawDiskLEDS(HDC hdc);
-void	FrameDrawDiskStatus(HDC hdc);
-void	FrameRefreshStatus(int, bool bUpdateDiskStatus = true);
-void	FrameUpdateApple2Type();
-void    FrameSetCursorPosByMousePos();
-
-void	VideoRedrawScreen();
-void	SetFullScreenShowSubunitStatus(bool bShow);
-bool	GetBestDisplayResolutionForFullScreen(UINT& bestWidth, UINT& bestHeight, UINT userSpecifiedHeight = 0);
-int		SetViewportScale(int nNewScale, bool bForce = false);
-void	SetAltEnterToggleFullScreen(bool mode);
-
-void	SetLoadedSaveStateFlag(const bool bFlag);
-
+#include "Configuration/PropertySheet.h"
 IPropertySheet& GetPropertySheet();
+
+#include "FrameBase.h"
+FrameBase& GetFrame();

--- a/source/Keyboard.cpp
+++ b/source/Keyboard.cpp
@@ -126,13 +126,13 @@ void KeybQueueKeypress (WPARAM key, Keystroke_e bASCII)
 {
 	if (bASCII == ASCII)	// WM_CHAR
 	{
-		if (g_bFreshReset && key == VK_CANCEL) // OLD HACK: 0x03
+		if (GetFrame().g_bFreshReset && key == VK_CANCEL) // OLD HACK: 0x03
 		{
-			g_bFreshReset = false;
+			GetFrame().g_bFreshReset = false;
 			return; // Swallow spurious CTRL-C caused by CTRL-BREAK
 		}
 
-		g_bFreshReset = false;
+		GetFrame().g_bFreshReset = false;
 		if ((key > 0x7F) && !g_bTK3KModeKey) // When in TK3000 mode, we have special keys which need remapping
 			return;
 
@@ -285,7 +285,7 @@ void KeybQueueKeypress (WPARAM key, Keystroke_e bASCII)
 		// Note: VK_CANCEL is Control-Break
 		if ((key == VK_CANCEL) && (GetKeyState(VK_CONTROL) < 0))
 		{
-			g_bFreshReset = true;
+			GetFrame().g_bFreshReset = true;
 			CtrlReset();
 			return;
 		}
@@ -302,8 +302,8 @@ void KeybQueueKeypress (WPARAM key, Keystroke_e bASCII)
 			if (g_Apple2Type == A2TYPE_TK30002E)
 			{
 				g_bTK3KModeKey = (GetKeyState(VK_SCROLL) & 1) ? true : false;	// Sync with the Scroll Lock status
-				FrameRefreshStatus(DRAW_LEDS);	// TODO: Implement |Mode| LED in the UI; make it appear only when in TK3000 mode
-				VideoRedrawScreen();	// TODO: Still need to implement page mode switching and 'whatnot'
+				GetFrame().FrameRefreshStatus(DRAW_LEDS);	// TODO: Implement |Mode| LED in the UI; make it appear only when in TK3000 mode
+				GetFrame().VideoRedrawScreen();	// TODO: Still need to implement page mode switching and 'whatnot'
 			}
 			return;
 		}
@@ -332,7 +332,7 @@ void KeybQueueKeypress (WPARAM key, Keystroke_e bASCII)
 						newKey -= 'A' - 1;		// convert to control-key
 				}
 
-				PostMessage(g_hFrameWindow, WM_CHAR, newKey, 0);
+				PostMessage(GetFrame().g_hFrameWindow, WM_CHAR, newKey, 0);
 			}
 
 			return;
@@ -378,7 +378,7 @@ static void ClipboardInit()
 	if (!IsClipboardFormatAvailable(CF_TEXT))
 		return;
 	
-	if (!OpenClipboard(g_hFrameWindow))
+	if (!OpenClipboard(GetFrame().g_hFrameWindow))
 		return;
 	
 	hglb = GetClipboardData(CF_TEXT);
@@ -538,7 +538,7 @@ void KeybToggleCapsLock ()
 	if (!IS_APPLE2)
 	{
 		g_bCapsLock = (GetKeyState(VK_CAPITAL) & 1);
-		FrameRefreshStatus(DRAW_LEDS);
+		GetFrame().FrameRefreshStatus(DRAW_LEDS);
 	}
 }
 
@@ -547,7 +547,7 @@ void KeybToggleP8ACapsLock ()
 {
 	_ASSERT(g_Apple2Type == A2TYPE_PRAVETS8A);
 	P8CAPS_ON = !P8CAPS_ON;
-	FrameRefreshStatus(DRAW_LEDS);
+	GetFrame().FrameRefreshStatus(DRAW_LEDS);
 	// g_bP8CapsLock= g_bP8CapsLock?false:true; //The same as the upper, but slower
 }
 

--- a/source/Memory.cpp
+++ b/source/Memory.cpp
@@ -1646,7 +1646,7 @@ void MemInitializeCustomF8ROM(void)
 		}
 		catch (bool)
 		{
-			MessageBox( g_hFrameWindow, "Failed to read F8 (auto-start) ROM for language card in original Apple][", TEXT("AppleWin Error"), MB_OK );
+			MessageBox( GetFrame().g_hFrameWindow, "Failed to read F8 (auto-start) ROM for language card in original Apple][", TEXT("AppleWin Error"), MB_OK );
 		}
 	}
 
@@ -1667,7 +1667,7 @@ void MemInitializeCustomF8ROM(void)
 
 		if (!bRes)
 		{
-			MessageBox( g_hFrameWindow, "Failed to read custom F8 rom", TEXT("AppleWin Error"), MB_OK );
+			MessageBox( GetFrame().g_hFrameWindow, "Failed to read custom F8 rom", TEXT("AppleWin Error"), MB_OK );
 			CloseHandle(g_hCustomRomF8);
 			g_hCustomRomF8 = INVALID_HANDLE_VALUE;
 			// Failed, so use default rom...
@@ -1723,7 +1723,7 @@ void MemInitializeCustomROM(void)
 
 	if (!bRes)
 	{
-		MessageBox( g_hFrameWindow, "Failed to read custom rom", TEXT("AppleWin Error"), MB_OK );
+		MessageBox( GetFrame().g_hFrameWindow, "Failed to read custom rom", TEXT("AppleWin Error"), MB_OK );
 		CloseHandle(g_hCustomRom);
 		g_hCustomRom = INVALID_HANDLE_VALUE;
 		// Failed, so use default rom...

--- a/source/MouseInterface.cpp
+++ b/source/MouseInterface.cpp
@@ -588,7 +588,7 @@ void CMouseInterface::SetPositionAbs(int x, int y)
 {
 	m_iX = x;
 	m_iY = y;
-	FrameSetCursorPosByMousePos();
+	GetFrame().FrameSetCursorPosByMousePos();
 }
 
 void CMouseInterface::SetPositionRel(long dX, long dY, int* pOutOfBoundsX, int* pOutOfBoundsY)

--- a/source/NTSC_CharSet.cpp
+++ b/source/NTSC_CharSet.cpp
@@ -77,7 +77,7 @@ static void get_csbits(csbits_t csbits, const char* resourceName, const UINT cy0
 	const UINT bufferSize = bitmapWidthBytes*bitmapHeight;
 	BYTE* pBuffer = new BYTE [bufferSize];
 
-	HBITMAP hCharBitmap = LoadBitmap(g_hInstance, resourceName);
+	HBITMAP hCharBitmap = LoadBitmap(GetFrame().g_hInstance, resourceName);
 	GetBitmapBits(hCharBitmap, bufferSize, pBuffer);
 
 	for (UINT cy=cy0, ch=0; cy<cy0+16; cy++)

--- a/source/Pravets.cpp
+++ b/source/Pravets.cpp
@@ -44,6 +44,6 @@ void PravetsReset(void)
 	{
 		P8CAPS_ON = false; 
 		TapeWrite(0, 0, 0, 0 ,0);
-		FrameRefreshStatus(DRAW_LEDS);
+		GetFrame().FrameRefreshStatus(DRAW_LEDS);
 	}
 }

--- a/source/SaveState.cpp
+++ b/source/SaveState.cpp
@@ -289,7 +289,7 @@ static void ParseUnitApple2(YamlLoadHelper& yamlLoadHelper, UINT version)
 
 	// g_Apple2Type may've changed: so redraw frame (title, buttons, leds, etc)
 	VideoReinitialize();	// g_CharsetType changed
-	FrameUpdateApple2Type();	// Calls VideoRedrawScreen() before the aux mem has been loaded (so if DHGR is enabled, then aux mem will be zeros at this stage)
+	GetFrame().FrameUpdateApple2Type();	// Calls VideoRedrawScreen() before the aux mem has been loaded (so if DHGR is enabled, then aux mem will be zeros at this stage)
 }
 
 //---
@@ -508,7 +508,7 @@ static void Snapshot_LoadState_v2(void)
 		}
 
 		MB_SetCumulativeCycles();
-		SetLoadedSaveStateFlag(true);
+		GetFrame().SetLoadedSaveStateFlag(true);
 
 		// NB. The following disparity should be resolved:
 		// . A change in h/w via the Configuration property sheets results in a the VM completely restarting (via WM_USER_RESTART)
@@ -531,13 +531,13 @@ static void Snapshot_LoadState_v2(void)
 	}
 	catch(std::string szMessage)
 	{
-		MessageBox(	g_hFrameWindow,
+		MessageBox(	GetFrame().g_hFrameWindow,
 					szMessage.c_str(),
 					TEXT("Load State"),
 					MB_ICONEXCLAMATION | MB_SETFOREGROUND);
 
 		if (restart)
-			PostMessage(g_hFrameWindow, WM_USER_RESTART, 0, 0);		// Power-cycle VM (undoing all the new state just loaded)
+			PostMessage(GetFrame().g_hFrameWindow, WM_USER_RESTART, 0, 0);		// Power-cycle VM (undoing all the new state just loaded)
 	}
 
 	SetCursor(oldcursor);
@@ -550,7 +550,7 @@ void Snapshot_LoadState()
 	const size_t pos = g_strSaveStatePathname.size() - ext_aws.size();
 	if (g_strSaveStatePathname.find(ext_aws, pos) != std::string::npos)	// find ".aws" at end of pathname
 	{
-		MessageBox(	g_hFrameWindow,
+		MessageBox(	GetFrame().g_hFrameWindow,
 					"Save-state v1 no longer supported.\n"
 					"Please load using AppleWin 1.27, and re-save as a v2 state file.",
 					TEXT("Load State"),
@@ -647,7 +647,7 @@ void Snapshot_SaveState(void)
 	}
 	catch(std::string szMessage)
 	{
-		MessageBox(	g_hFrameWindow,
+		MessageBox(	GetFrame().g_hFrameWindow,
 					szMessage.c_str(),
 					TEXT("Save State"),
 					MB_ICONEXCLAMATION | MB_SETFOREGROUND);

--- a/source/SerialComms.cpp
+++ b/source/SerialComms.cpp
@@ -243,7 +243,7 @@ bool CSuperSerialCard::CheckComm()
 			// now send async events to our app's message handler
 			if (WSAAsyncSelect(
 					/* SOCKET s */ m_hCommListenSocket,
-					/* HWND hWnd */ g_hFrameWindow,
+					/* HWND hWnd */ GetFrame().g_hFrameWindow,
 					/* unsigned int wMsg */ WM_USER_TCP_SERIAL,
 					/* long lEvent */ (FD_ACCEPT | FD_CONNECT | FD_READ | FD_CLOSE)) != 0)
 			{
@@ -315,7 +315,7 @@ void CSuperSerialCard::CommTcpSerialCleanup()
 {
 	if (m_hCommListenSocket != INVALID_SOCKET)
 	{
-		WSAAsyncSelect(m_hCommListenSocket, g_hFrameWindow, 0, 0); // Stop event messages
+		WSAAsyncSelect(m_hCommListenSocket, GetFrame().g_hFrameWindow, 0, 0); // Stop event messages
 		closesocket(m_hCommListenSocket);
 		m_hCommListenSocket = INVALID_SOCKET;
 

--- a/source/SoundCore.cpp
+++ b/source/SoundCore.cpp
@@ -522,7 +522,7 @@ bool DSInit()
 		return false;
 	}
 
-	hr = g_lpDS->SetCooperativeLevel(g_hFrameWindow, DSSCL_NORMAL);
+	hr = g_lpDS->SetCooperativeLevel(GetFrame().g_hFrameWindow, DSSCL_NORMAL);
 	if(FAILED(hr))
 	{
 		if(g_fh) fprintf(g_fh, "SetCooperativeLevel failed (%08X)\n",hr);

--- a/source/Speaker.cpp
+++ b/source/Speaker.cpp
@@ -97,13 +97,13 @@ static void    Spkr_DSUninit();
 static void DisplayBenchmarkResults ()
 {
   DWORD totaltime = GetTickCount()-extbench;
-  VideoRedrawScreen();
+  GetFrame().VideoRedrawScreen();
   TCHAR buffer[64];
   wsprintf(buffer,
            TEXT("This benchmark took %u.%02u seconds."),
            (unsigned)(totaltime / 1000),
            (unsigned)((totaltime / 10) % 100));
-  MessageBox(g_hFrameWindow,
+  MessageBox(GetFrame().g_hFrameWindow,
              buffer,
              TEXT("Benchmark Results"),
              MB_ICONINFORMATION | MB_SETFOREGROUND);

--- a/source/Utilities.cpp
+++ b/source/Utilities.cpp
@@ -208,7 +208,7 @@ void LoadConfiguration(void)
 	DWORD dwTmp = 0;
 
 	if(REGLOAD(TEXT(REGVALUE_FS_SHOW_SUBUNIT_STATUS), &dwTmp))
-		SetFullScreenShowSubunitStatus(dwTmp ? true : false);
+		GetFrame().SetFullScreenShowSubunitStatus(dwTmp ? true : false);
 
 	if(REGLOAD(TEXT(REGVALUE_THE_FREEZES_F8_ROM), &dwTmp))
 		GetPropertySheet().SetTheFreezesF8Rom(dwTmp);
@@ -313,10 +313,10 @@ void LoadConfiguration(void)
 	Printer_SetIdleLimit(dwTmp);
 
 	if (REGLOAD(TEXT(REGVALUE_WINDOW_SCALE), &dwTmp))
-		SetViewportScale(dwTmp);
+		GetFrame().SetViewportScale(dwTmp);
 
 	if (REGLOAD(TEXT(REGVALUE_CONFIRM_REBOOT), &dwTmp))
-		g_bConfirmReboot = dwTmp;
+		GetFrame().g_bConfirmReboot = dwTmp;
 }
 
 static std::string GetFullPath(LPCSTR szFileName)
@@ -403,7 +403,7 @@ void InsertFloppyDisks(const UINT slot, LPSTR szImageName_drive[NUM_DRIVES], boo
 	{
 		bRes = DoDiskInsert(slot, DRIVE_1, szImageName_drive[DRIVE_1]);
 		LogFileOutput("Init: S%d, DoDiskInsert(D1), res=%d\n", slot, bRes);
-		FrameRefreshStatus(DRAW_LEDS | DRAW_BUTTON_DRIVES);	// floppy activity LEDs and floppy buttons
+		GetFrame().FrameRefreshStatus(DRAW_LEDS | DRAW_BUTTON_DRIVES);	// floppy activity LEDs and floppy buttons
 		bBoot = true;
 	}
 
@@ -418,7 +418,7 @@ void InsertFloppyDisks(const UINT slot, LPSTR szImageName_drive[NUM_DRIVES], boo
 	}
 
 	if (!bRes)
-		MessageBox(g_hFrameWindow, "Failed to insert floppy disk(s) - see log file", "Warning", MB_ICONASTERISK | MB_OK);
+		MessageBox(GetFrame().g_hFrameWindow, "Failed to insert floppy disk(s) - see log file", "Warning", MB_ICONASTERISK | MB_OK);
 }
 
 void InsertHardDisks(LPSTR szImageName_harddisk[NUM_HARDDISKS], bool& bBoot)
@@ -443,7 +443,7 @@ void InsertHardDisks(LPSTR szImageName_harddisk[NUM_HARDDISKS], bool& bBoot)
 	{
 		bRes = DoHardDiskInsert(HARDDISK_1, szImageName_harddisk[HARDDISK_1]);
 		LogFileOutput("Init: DoHardDiskInsert(HDD1), res=%d\n", bRes);
-		FrameRefreshStatus(DRAW_LEDS);	// harddisk activity LED
+		GetFrame().FrameRefreshStatus(DRAW_LEDS);	// harddisk activity LED
 		bBoot = true;
 	}
 
@@ -454,7 +454,7 @@ void InsertHardDisks(LPSTR szImageName_harddisk[NUM_HARDDISKS], bool& bBoot)
 	}
 
 	if (!bRes)
-		MessageBox(g_hFrameWindow, "Failed to insert harddisk(s) - see log file", "Warning", MB_ICONASTERISK | MB_OK);
+		MessageBox(GetFrame().g_hFrameWindow, "Failed to insert harddisk(s) - see log file", "Warning", MB_ICONASTERISK | MB_OK);
 }
 
 void UnplugHardDiskControllerCard(void)
@@ -593,5 +593,5 @@ void CtrlReset()
 #endif
 
 	CpuReset();
-	g_bFreshReset = true;
+	GetFrame().g_bFreshReset = true;
 }

--- a/source/Video.cpp
+++ b/source/Video.cpp
@@ -476,7 +476,7 @@ void Video_TakeScreenShot( const VideoScreenShot_e ScreenShotType )
 		{
 			TCHAR msg[512];
 			StringCbPrintf( msg, 512, "You have more then %d screenshot filenames!  They will no longer be saved.\n\nEither move some of your screenshots or increase the maximum in video.cpp\n", nMaxScreenShot );
-			MessageBox( g_hFrameWindow, msg, "Warning", MB_OK );
+			MessageBox( GetFrame().g_hFrameWindow, msg, "Warning", MB_OK );
 			g_nLastScreenShot = 0;
 			return;
 		}
@@ -574,9 +574,9 @@ static void Video_MakeScreenShot(FILE *pFile, const VideoScreenShot_e ScreenShot
 
 //	char sText[256];
 //	sprintf( sText, "sizeof: BITMAPFILEHEADER = %d\n", sizeof(BITMAPFILEHEADER) ); // = 14
-//	MessageBox( g_hFrameWindow, sText, "Info 1", MB_OK );
+//	MessageBox( GetFrame().g_hFrameWindow, sText, "Info 1", MB_OK );
 //	sprintf( sText, "sizeof: BITMAPINFOHEADER = %d\n", sizeof(BITMAPINFOHEADER) ); // = 40
-//	MessageBox( g_hFrameWindow, sText, "Info 2", MB_OK );
+//	MessageBox( GetFrame().g_hFrameWindow, sText, "Info 2", MB_OK );
 
 	char sIfSizeZeroOrUnknown_BadWinBmpHeaderPackingSize54[ sizeof( WinBmpHeader_t ) == (14 + 40) ];
 	/**/ sIfSizeZeroOrUnknown_BadWinBmpHeaderPackingSize54[0]=0;
@@ -661,7 +661,7 @@ void Video_SaveScreenShot( const VideoScreenShot_e ScreenShotType, const TCHAR *
 
 	if( g_bDisplayPrintScreenFileName )
 	{
-		MessageBox( g_hFrameWindow, pScreenShotFileName, "Screen Captured", MB_OK );
+		MessageBox( GetFrame().g_hFrameWindow, pScreenShotFileName, "Screen Captured", MB_OK );
 	}
 }
 

--- a/source/Windows/AppleWin.cpp
+++ b/source/Windows/AppleWin.cpp
@@ -47,6 +47,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "Speech.h"
 #endif
 #include "Windows/WinVideo.h"
+#include "Windows/Win32Frame.h"
 #include "Windows/WinFrame.h"
 #include "RGBMonitor.h"
 #include "NTSC.h"
@@ -56,9 +57,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "Tfe/Tfe.h"
 
 //=================================================
-
-// Win32
-HINSTANCE g_hInstance          = (HINSTANCE)0;
 
 static bool g_bLoadedSaveState = false;
 static bool g_bSysClkOK = false;
@@ -72,7 +70,7 @@ bool GetLoadedSaveStateFlag(void)
 	return g_bLoadedSaveState;
 }
 
-void SetLoadedSaveStateFlag(const bool bFlag)
+void Win32Frame::SetLoadedSaveStateFlag(const bool bFlag)
 {
 	g_bLoadedSaveState = bFlag;
 }
@@ -85,7 +83,7 @@ bool GetHookAltGrControl(void)
 static void ResetToLogoMode(void)
 {
 	g_nAppMode = MODE_LOGO;
-	SetLoadedSaveStateFlag(false);
+	GetFrame().SetLoadedSaveStateFlag(false);
 }
 
 //---------------------------------------------------------------------------
@@ -453,21 +451,21 @@ static void RegisterHotKeys(void)
 	BOOL bStatus[3] = {0,0,0};
 
 	bStatus[0] = RegisterHotKey( 
-		g_hFrameWindow , // HWND hWnd
+		GetFrame().g_hFrameWindow , // HWND hWnd
 		VK_SNAPSHOT_560, // int id (user/custom id)
 		0              , // UINT fsModifiers
 		VK_SNAPSHOT      // UINT vk = PrintScreen
 	);
 
 	bStatus[1] = RegisterHotKey( 
-		g_hFrameWindow , // HWND hWnd
+		GetFrame().g_hFrameWindow , // HWND hWnd
 		VK_SNAPSHOT_280, // int id (user/custom id)
 		MOD_SHIFT      , // UINT fsModifiers
 		VK_SNAPSHOT      // UINT vk = PrintScreen
 	);
 
 	bStatus[2] = RegisterHotKey( 
-		g_hFrameWindow  , // HWND hWnd
+		GetFrame().g_hFrameWindow  , // HWND hWnd
 		VK_SNAPSHOT_TEXT, // int id (user/custom id)
 		MOD_CONTROL     , // UINT fsModifiers
 		VK_SNAPSHOT       // UINT vk = PrintScreen
@@ -485,7 +483,7 @@ static void RegisterHotKeys(void)
 			msg += "\n. Ctrl+PrintScreen";
 
 		if (g_bShowPrintScreenWarningDialog)
-			MessageBox( g_hFrameWindow, msg.c_str(), "Warning", MB_ICONASTERISK | MB_OK );
+			MessageBox( GetFrame().g_hFrameWindow, msg.c_str(), "Warning", MB_ICONASTERISK | MB_OK );
 
 		msg += "\n";
 		LogFileOutput(msg.c_str());
@@ -505,12 +503,12 @@ static bool HookFilterForKeyboard()
 {
 	g_hinstDLL = LoadLibrary(TEXT("HookFilter.dll"));
 
-	_ASSERT(g_hFrameWindow);
+	_ASSERT(GetFrame().g_hFrameWindow);
 
 	typedef void (*RegisterHWNDProc)(HWND, bool, bool);
 	RegisterHWNDProc RegisterHWND = (RegisterHWNDProc) GetProcAddress(g_hinstDLL, "RegisterHWND");
 	if (RegisterHWND)
-		RegisterHWND(g_hFrameWindow, g_bHookAltTab, g_bHookAltGrControl);
+		RegisterHWND(GetFrame().g_hFrameWindow, g_bHookAltTab, g_bHookAltGrControl);
 
 	HOOKPROC hkprcLowLevelKeyboardProc = (HOOKPROC) GetProcAddress(g_hinstDLL, "LowLevelKeyboardProc");
 
@@ -520,7 +518,7 @@ static bool HookFilterForKeyboard()
 						g_hinstDLL,
 						0);
 
-	if (g_hhook != 0 && g_hFrameWindow != 0)
+	if (g_hhook != 0 && GetFrame().g_hFrameWindow != 0)
 		return true;
 
 	std::string msg("Failed to install hook filter for system keys");
@@ -603,7 +601,7 @@ static void UninitHookThread()
 
 static void ExceptionHandler(const char* pError)
 {
-	MessageBox(	g_hFrameWindow,
+	MessageBox(	GetFrame().g_hFrameWindow,
 				pError,
 				TEXT("Runtime Exception"),
 				MB_ICONEXCLAMATION | MB_SETFOREGROUND);
@@ -760,7 +758,7 @@ static void OneTimeInitialization(HINSTANCE passinstance)
 	DDInit();	// For WaitForVerticalBlank()
 #endif
 
-	g_hInstance = passinstance;
+	GetFrame().g_hInstance = passinstance;
 	GdiSetBatchLimit(512);
 	LogFileOutput("Init: GdiSetBatchLimit()\n");
 
@@ -848,7 +846,7 @@ static void RepeatInitialization(void)
 		LogFileOutput("Main: VideoInitialize()\n");
 
 		LogFileOutput("Main: FrameCreateWindow() - pre\n");
-		FrameCreateWindow();	// g_hFrameWindow is now valid
+		FrameCreateWindow();	// GetFrame().g_hFrameWindow is now valid
 		LogFileOutput("Main: FrameCreateWindow() - post\n");
 
 		// Init palette color
@@ -936,7 +934,7 @@ static void RepeatInitialization(void)
 
 		if (!g_bSysClkOK)
 		{
-			MessageBox(g_hFrameWindow, "DirectX failed to create SystemClock instance", TEXT("AppleWin Error"), MB_OK);
+			MessageBox(GetFrame().g_hFrameWindow, "DirectX failed to create SystemClock instance", TEXT("AppleWin Error"), MB_OK);
 			g_cmdLine.bShutdown = true;
 		}
 
@@ -947,7 +945,7 @@ static void RepeatInitialization(void)
 							: "Unsupported -rom and -f8rom being used at the same time\n";
 
 			LogFileOutput("%s", msg.c_str());
-			MessageBox(g_hFrameWindow, msg.c_str(), TEXT("AppleWin Error"), MB_OK);
+			MessageBox(GetFrame().g_hFrameWindow, msg.c_str(), TEXT("AppleWin Error"), MB_OK);
 			g_cmdLine.bShutdown = true;
 		}
 
@@ -985,7 +983,7 @@ static void RepeatInitialization(void)
 
 		if (g_cmdLine.bShutdown)
 		{
-			PostMessage(g_hFrameWindow, WM_DESTROY, 0, 0);	// Close everything down
+			PostMessage(GetFrame().g_hFrameWindow, WM_DESTROY, 0, 0);	// Close everything down
 			// NB. If shutting down, then don't post any other messages (GH#286)
 		}
 		else
@@ -1007,13 +1005,13 @@ static void RepeatInitialization(void)
 
 			if (g_cmdLine.bSetFullScreen)
 			{
-				PostMessage(g_hFrameWindow, WM_USER_FULLSCREEN, 0, 0);
+				PostMessage(GetFrame().g_hFrameWindow, WM_USER_FULLSCREEN, 0, 0);
 				g_cmdLine.bSetFullScreen = false;
 			}
 
 			if (g_cmdLine.bBoot)
 			{
-				PostMessage(g_hFrameWindow, WM_USER_BOOT, 0, 0);
+				PostMessage(GetFrame().g_hFrameWindow, WM_USER_BOOT, 0, 0);
 				g_cmdLine.bBoot = false;
 			}
 		}
@@ -1053,4 +1051,10 @@ IPropertySheet& GetPropertySheet()
 {
 	static CPropertySheet sg_PropertySheet;
 	return sg_PropertySheet;
+}
+
+FrameBase& GetFrame()
+{
+	static Win32Frame sg_Win32Frame;
+	return sg_Win32Frame;
 }

--- a/source/Windows/Win32Frame.cpp
+++ b/source/Windows/Win32Frame.cpp
@@ -1,0 +1,6 @@
+#include "StdAfx.h"
+
+#include "Windows/Win32Frame.h"
+
+// Win32Frame methods are implemented in AppleWin, WinFrame and WinVideo.
+// in time they should be brought together and more freestanding functions added to Win32Frame.

--- a/source/Windows/Win32Frame.h
+++ b/source/Windows/Win32Frame.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "FrameBase.h"
+
+class Win32Frame : public FrameBase
+{
+public:
+	virtual void FrameDrawDiskLEDS(HDC hdc);
+	virtual void FrameDrawDiskStatus(HDC hdc);
+	virtual void FrameRefreshStatus(int, bool bUpdateDiskStatus = true);
+	virtual void FrameUpdateApple2Type();
+	virtual void FrameSetCursorPosByMousePos();
+
+	virtual void VideoRedrawScreen();
+	virtual void SetFullScreenShowSubunitStatus(bool bShow);
+	virtual bool GetBestDisplayResolutionForFullScreen(UINT& bestWidth, UINT& bestHeight, UINT userSpecifiedHeight = 0);
+	virtual int SetViewportScale(int nNewScale, bool bForce = false);
+	virtual void SetAltEnterToggleFullScreen(bool mode);
+
+	virtual void SetLoadedSaveStateFlag(const bool bFlag);
+};


### PR DESCRIPTION
Move the Win32 implementation into ``Win32Frame``.

The logic behind all of this is
- if it is called by core emulator code (i.e. portable .cpp in ``source),`` then it **must** go to ``FrameBase`` (do not ``#include "Windows/..."`` there)
- otherwise it can go either to a global variable or as a member variable of ``Win32Frame`` (**not** in ``FrameBase``, as it would force it to all other archs)
- should the main event loop be moved into ``Win32Frame``? Yes and No. I would vote for No at the moment. Put in ``Win32Frame`` some more closely related functions, but draw the line somewhere.
- why are ``g_hInstance`` and ``g_hFrameWindow`` in? They do not belong there, but if I remove them, then I need to add many more functions to ``FrameBase`` (``MessageBox``, ``LoadBitmap``... too much work for today)
- why files called ``WinFrame.cpp`` and ``Win32Frame.cpp``? I run out of imagination
- why ``Win32Frame.cpp`` is empty? Because it would take a lot of work at this stage to move all necessary related functions from ``AppleWin.cpp``, ``WinFrame.cpp`` and ``WinVideo.cpp`` there.
- this PR makes the code in ``source`` cleaner, but makes a mess of ``Windows``? I disagree, but I see your point. This just another step, more are needed.

This PR does not attempt to move relevant global variables and functions from ``AppleWin.cpp``, ``WinFrame.cpp`` and ``WinVideo.cpp`` to ``Win32Frame``.
