### PR TITLE
WinVideo: share some generic code

### DIFF
--- a/source/FrameBase.cpp
+++ b/source/FrameBase.cpp
@@ -1,6 +1,7 @@
 #include "StdAfx.h"
 
 #include "FrameBase.h"
+#include "Interface.h"
 
 FrameBase::FrameBase()
 {
@@ -14,4 +15,10 @@ FrameBase::FrameBase()
 FrameBase::~FrameBase()
 {
 
+}
+
+void FrameBase::VideoRedrawScreen(void)
+{
+	// NB. Can't rely on g_uVideoMode being non-zero (ie. so it can double up as a flag) since 'GR,PAGE1,non-mixed' mode == 0x00.
+	GetVideo().VideoRefreshScreen(GetVideo().GetVideoMode(), true);
 }

--- a/source/FrameBase.h
+++ b/source/FrameBase.h
@@ -13,13 +13,14 @@ public:
 	BOOL       g_bMultiMon;
 	bool       g_bFreshReset;
 
+	void VideoRedrawScreen();
+
 	virtual void FrameDrawDiskLEDS(HDC hdc) = 0;
 	virtual void FrameDrawDiskStatus(HDC hdc) = 0;
 	virtual void FrameRefreshStatus(int, bool bUpdateDiskStatus = true) = 0;
 	virtual void FrameUpdateApple2Type() = 0;
 	virtual void FrameSetCursorPosByMousePos() = 0;
 
-	virtual void VideoRedrawScreen() = 0;
 	virtual void SetFullScreenShowSubunitStatus(bool bShow) = 0;
 	virtual bool GetBestDisplayResolutionForFullScreen(UINT& bestWidth, UINT& bestHeight, UINT userSpecifiedHeight = 0) = 0;
 	virtual int SetViewportScale(int nNewScale, bool bForce = false) = 0;

--- a/source/Video.h
+++ b/source/Video.h
@@ -210,13 +210,15 @@ public:
 	{
 	}
 
-	virtual void VideoRedrawScreenDuringFullSpeed(DWORD dwCyclesThisFrame, bool bInit = false) = 0;
-	virtual void VideoRedrawScreenAfterFullSpeed(DWORD dwCyclesThisFrame) = 0;
-	virtual void VideoRefreshScreen(uint32_t uRedrawWholeScreenVideoMode = 0, bool bRedrawWholeScreen = false) = 0;
-	virtual void Video_RedrawAndTakeScreenShot(const char* pScreenshotFilename) = 0;
+	virtual void VideoPresentScreen(void) = 0;
 	virtual void ChooseMonochromeColor(void) = 0;
 	virtual void Benchmark(void) = 0;
 	virtual void DisplayLogo(void) = 0;
+
+	void VideoRefreshScreen(uint32_t uRedrawWholeScreenVideoMode, bool bRedrawWholeScreen);
+	void VideoRedrawScreenDuringFullSpeed(DWORD dwCyclesThisFrame, bool bInit = false);
+	void VideoRedrawScreenAfterFullSpeed(DWORD dwCyclesThisFrame);
+	void Video_RedrawAndTakeScreenShot(const char* pScreenshotFilename);
 
 	uint8_t* GetFrameBuffer(void) { return g_pFramebufferbits; }
 	void SetFrameBuffer(uint8_t* frameBuffer) { g_pFramebufferbits = frameBuffer; }
@@ -330,6 +332,8 @@ private:
 	BYTE g_videoRom[kVideoRomSizeMax];
 	UINT g_videoRomSize;
 	bool g_videoRomRockerSwitch;
+
+	DWORD dwFullSpeedStartTime;
 
 	static const char g_aVideoChoices[];
 

--- a/source/Windows/AppleWin.cpp
+++ b/source/Windows/AppleWin.cpp
@@ -253,7 +253,7 @@ static void ContinueExecution(void)
 		if (g_bFullSpeed)
 			GetVideo().VideoRedrawScreenDuringFullSpeed(g_dwCyclesThisFrame);
 		else
-			GetVideo().VideoRefreshScreen(); // Just copy the output of our Apple framebuffer to the system Back Buffer
+			GetVideo().VideoPresentScreen(); // Just copy the output of our Apple framebuffer to the system Back Buffer
 	}
 
 #ifdef LOG_PERF_TIMINGS

--- a/source/Windows/Win32Frame.h
+++ b/source/Windows/Win32Frame.h
@@ -11,7 +11,6 @@ public:
 	virtual void FrameUpdateApple2Type();
 	virtual void FrameSetCursorPosByMousePos();
 
-	virtual void VideoRedrawScreen();
 	virtual void SetFullScreenShowSubunitStatus(bool bShow);
 	virtual bool GetBestDisplayResolutionForFullScreen(UINT& bestWidth, UINT& bestHeight, UINT userSpecifiedHeight = 0);
 	virtual int SetViewportScale(int nNewScale, bool bForce = false);

--- a/source/Windows/WinFrame.cpp
+++ b/source/Windows/WinFrame.cpp
@@ -1256,11 +1256,11 @@ LRESULT CALLBACK FrameWndProc (
 					if ( DebugGetVideoMode(&debugVideoMode) )
 						GetVideo().VideoRefreshScreen(debugVideoMode, true);
 					else
-						GetVideo().VideoRefreshScreen();
+						GetVideo().VideoPresentScreen();
 				}
 				else
 				{
-					GetVideo().VideoRefreshScreen();
+					GetVideo().VideoPresentScreen();
 				}
 			}
 

--- a/source/Windows/WinVideo.cpp
+++ b/source/Windows/WinVideo.cpp
@@ -29,7 +29,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "StdAfx.h"
 
 #include "Windows/WinVideo.h"
-#include "Windows/Win32Frame.h"
 #include "Windows/WinFrame.h"
 #include "Windows/AppleWin.h"
 #include "Interface.h"
@@ -524,10 +523,3 @@ void WinVideo::DDUninit(void)
 #undef SAFE_RELEASE
 
 //===========================================================================
-
-// NB. Win32Frame, not WinVideo
-void Win32Frame::VideoRedrawScreen(void)
-{
-	// NB. Can't rely on g_uVideoMode being non-zero (ie. so it can double up as a flag) since 'GR,PAGE1,non-mixed' mode == 0x00.
-	GetVideo().VideoRefreshScreen( GetVideo().GetVideoMode(), true );
-}

--- a/source/Windows/WinVideo.cpp
+++ b/source/Windows/WinVideo.cpp
@@ -162,7 +162,7 @@ void WinVideo::Benchmark(void)
       memset(mem+0x400,0x14,0x400);
     else
       memcpy(mem+0x400,mem+((cycle & 2) ? 0x4000 : 0x6000),0x400);
-    VideoRefreshScreen();
+    VideoPresentScreen();
     if (cycle++ >= 3)
       cycle = 0;
     totaltextfps++;
@@ -184,7 +184,7 @@ void WinVideo::Benchmark(void)
       memset(mem+0x2000,0x14,0x2000);
     else
       memcpy(mem+0x2000,mem+((cycle & 2) ? 0x4000 : 0x6000),0x2000);
-    VideoRefreshScreen();
+    VideoPresentScreen();
     if (cycle++ >= 3)
       cycle = 0;
     totalhiresfps++;
@@ -421,53 +421,8 @@ void WinVideo::DisplayLogo(void)
 
 //===========================================================================
 
-void WinVideo::VideoRedrawScreenDuringFullSpeed(DWORD dwCyclesThisFrame, bool bInit /*=false*/)
+void WinVideo::VideoPresentScreen(void)
 {
-	static DWORD dwFullSpeedStartTime = 0;
-
-	if (bInit)
-	{
-		// Just entered full-speed mode
-		dwFullSpeedStartTime = GetTickCount();
-		return;
-	}
-
-	DWORD dwFullSpeedDuration = GetTickCount() - dwFullSpeedStartTime;
-	if (dwFullSpeedDuration <= 16)	// Only update after every realtime ~17ms of *continuous* full-speed
-		return;
-
-	dwFullSpeedStartTime += dwFullSpeedDuration;
-
-	VideoRedrawScreenAfterFullSpeed(dwCyclesThisFrame);
-}
-
-//===========================================================================
-
-void WinVideo::VideoRedrawScreenAfterFullSpeed(DWORD dwCyclesThisFrame)
-{
-	NTSC_VideoClockResync(dwCyclesThisFrame);
-	GetFrame().VideoRedrawScreen();	// Better (no flicker) than using: NTSC_VideoReinitialize() or VideoReinitialize()
-}
-
-//===========================================================================
-
-void WinVideo::VideoRefreshScreen(uint32_t uRedrawWholeScreenVideoMode /* =0*/, bool bRedrawWholeScreen /* =false*/)
-{
-	if (bRedrawWholeScreen || g_nAppMode == MODE_PAUSED)
-	{
-		// uVideoModeForWholeScreen set if:
-		// . MODE_DEBUG   : always
-		// . MODE_RUNNING : called from VideoRedrawScreen(), eg. during full-speed
-		if (bRedrawWholeScreen)
-			NTSC_SetVideoMode( uRedrawWholeScreenVideoMode );
-		NTSC_VideoRedrawWholeScreen();
-
-		// MODE_DEBUG|PAUSED: Need to refresh a 2nd time if changing video-type, otherwise could have residue from prev image!
-		// . eg. Amber -> B&W TV
-		if (g_nAppMode == MODE_DEBUG || g_nAppMode == MODE_PAUSED)
-			NTSC_VideoRedrawWholeScreen();
-	}
-
 	HDC hFrameDC = FrameGetDC();
 
 	if (hFrameDC)
@@ -568,19 +523,6 @@ void WinVideo::DDUninit(void)
 
 #undef SAFE_RELEASE
 
-//===========================================================================
-
-void WinVideo::Video_RedrawAndTakeScreenShot(const char* pScreenshotFilename)
-{
-	_ASSERT(pScreenshotFilename);
-	if (!pScreenshotFilename)
-		return;
-
-	GetFrame().VideoRedrawScreen();
-	Video_SaveScreenShot(Video::SCREENSHOT_560x384, pScreenshotFilename);
-}
-
-//===========================================================================
 //===========================================================================
 
 // NB. Win32Frame, not WinVideo

--- a/source/Windows/WinVideo.h
+++ b/source/Windows/WinVideo.h
@@ -19,10 +19,7 @@ public:
 	virtual void Initialize(void);
 	virtual void Destroy(void);
 
-	virtual void VideoRedrawScreenDuringFullSpeed(DWORD dwCyclesThisFrame, bool bInit = false);
-	virtual void VideoRedrawScreenAfterFullSpeed(DWORD dwCyclesThisFrame);
-	virtual void VideoRefreshScreen(uint32_t uRedrawWholeScreenVideoMode = 0, bool bRedrawWholeScreen = false);
-	virtual void Video_RedrawAndTakeScreenShot(const char* pScreenshotFilename);
+	virtual void VideoPresentScreen(void);
 	virtual void ChooseMonochromeColor(void);
 	virtual void Benchmark(void);
 	virtual void DisplayLogo(void);


### PR DESCRIPTION
Move generic functions to the base class as they can be reused by other archs.

Split VideoRefreshScreen() to extract the system-specific code to VideoPresentScreen().
