### PR TITLE
FrameBase: some changes to ease implementations

### DIFF
--- a/source/Configuration/PageConfig.cpp
+++ b/source/Configuration/PageConfig.cpp
@@ -28,6 +28,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include "../Windows/AppleWin.h"
 #include "../Windows/WinFrame.h"
+#include "../Windows/Win32Frame.h"
 #include "../Registry.h"
 #include "../SerialComms.h"
 #include "../resource/resource.h"
@@ -115,7 +116,7 @@ INT_PTR CPageConfig::DlgProcInternal(HWND hWnd, UINT message, WPARAM wparam, LPA
 			break;
 
 		case IDC_MONOCOLOR:
-			GetFrame().ChooseMonochromeColor();
+			Win32Frame::GetWin32Frame().ChooseMonochromeColor();
 			break;
 
 		case IDC_CHECK_CONFIRM_REBOOT:

--- a/source/Configuration/PageConfig.cpp
+++ b/source/Configuration/PageConfig.cpp
@@ -27,7 +27,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "PropertySheet.h"
 
 #include "../Windows/AppleWin.h"
-#include "../Windows/WinFrame.h"
 #include "../Windows/Win32Frame.h"
 #include "../Registry.h"
 #include "../SerialComms.h"
@@ -202,7 +201,8 @@ INT_PTR CPageConfig::DlgProcInternal(HWND hWnd, UINT message, WPARAM wparam, LPA
 
 			m_PropertySheetHelper.FillComboBox(hWnd,IDC_VIDEOTYPE, GetVideo().GetVideoChoices(), GetVideo().GetVideoType());
 			CheckDlgButton(hWnd, IDC_CHECK_HALF_SCAN_LINES, GetVideo().IsVideoStyle(VS_HALF_SCANLINES) ? BST_CHECKED : BST_UNCHECKED);
-			CheckDlgButton(hWnd, IDC_CHECK_FS_SHOW_SUBUNIT_STATUS, GetFullScreenShowSubunitStatus() ? BST_CHECKED : BST_UNCHECKED);
+			Win32Frame& win32Frame = Win32Frame::GetWin32Frame();
+			CheckDlgButton(hWnd, IDC_CHECK_FS_SHOW_SUBUNIT_STATUS, win32Frame.GetFullScreenShowSubunitStatus() ? BST_CHECKED : BST_UNCHECKED);
 
 			CheckDlgButton(hWnd, IDC_CHECK_VERTICAL_BLEND, GetVideo().IsVideoStyle(VS_COLOR_VERTICAL_BLEND) ? BST_CHECKED : BST_UNCHECKED);
 			EnableWindow(GetDlgItem(hWnd, IDC_CHECK_VERTICAL_BLEND), (GetVideo().GetVideoType() == VT_COLOR_IDEALIZED) ? TRUE : FALSE);
@@ -272,6 +272,7 @@ INT_PTR CPageConfig::DlgProcInternal(HWND hWnd, UINT message, WPARAM wparam, LPA
 void CPageConfig::DlgOK(HWND hWnd)
 {
 	bool bVideoReinit = false;
+	Win32Frame& win32Frame = Win32Frame::GetWin32Frame();
 
 	const VideoType_e newVideoType = (VideoType_e) SendDlgItemMessage(hWnd, IDC_VIDEOTYPE, CB_GETCURSEL, 0, 0);
 	if (GetVideo().GetVideoType() != newVideoType)
@@ -313,34 +314,35 @@ void CPageConfig::DlgOK(HWND hWnd)
 	{
 		GetVideo().Config_Save_Video();
 
-		GetFrame().FrameRefreshStatus(DRAW_TITLE);
+		win32Frame.FrameRefreshStatus(DRAW_TITLE);
 
 		GetVideo().VideoReinitialize();
 		if ((g_nAppMode != MODE_LOGO) && (g_nAppMode != MODE_DEBUG))
 		{
-			GetFrame().VideoRedrawScreen();
+			win32Frame.VideoRedrawScreen();
 		}
 	}
 
 	//
 
 	const bool bNewFSSubunitStatus = IsDlgButtonChecked(hWnd, IDC_CHECK_FS_SHOW_SUBUNIT_STATUS) ? true : false;
-	if (GetFullScreenShowSubunitStatus() != bNewFSSubunitStatus)
+
+	if (win32Frame.GetFullScreenShowSubunitStatus() != bNewFSSubunitStatus)
 	{
 		REGSAVE(TEXT(REGVALUE_FS_SHOW_SUBUNIT_STATUS), bNewFSSubunitStatus ? 1 : 0);
-		GetFrame().SetFullScreenShowSubunitStatus(bNewFSSubunitStatus);
+		win32Frame.SetFullScreenShowSubunitStatus(bNewFSSubunitStatus);
 
-		if (IsFullScreen())
-			GetFrame().FrameRefreshStatus(DRAW_BACKGROUND | DRAW_LEDS | DRAW_DISK_STATUS);
+		if (win32Frame.IsFullScreen())
+			win32Frame.FrameRefreshStatus(DRAW_BACKGROUND | DRAW_LEDS | DRAW_DISK_STATUS);
 	}
 
 	//
 
 	const BOOL bNewConfirmReboot = IsDlgButtonChecked(hWnd, IDC_CHECK_CONFIRM_REBOOT) ? 1 : 0;
-	if (GetFrame().g_bConfirmReboot != bNewConfirmReboot)
+	if (win32Frame.g_bConfirmReboot != bNewConfirmReboot)
 	{
 		REGSAVE(TEXT(REGVALUE_CONFIRM_REBOOT), bNewConfirmReboot);
-		GetFrame().g_bConfirmReboot = bNewConfirmReboot;
+		win32Frame.g_bConfirmReboot = bNewConfirmReboot;
 	}
 
 	//

--- a/source/Configuration/PageConfig.cpp
+++ b/source/Configuration/PageConfig.cpp
@@ -313,7 +313,7 @@ void CPageConfig::DlgOK(HWND hWnd)
 	{
 		GetVideo().Config_Save_Video();
 
-		GetFrame().FrameRefreshStatus(DRAW_TITLE, false);
+		GetFrame().FrameRefreshStatus(DRAW_TITLE);
 
 		GetVideo().VideoReinitialize();
 		if ((g_nAppMode != MODE_LOGO) && (g_nAppMode != MODE_DEBUG))

--- a/source/Configuration/PageDisk.cpp
+++ b/source/Configuration/PageDisk.cpp
@@ -91,14 +91,14 @@ INT_PTR CPageDisk::DlgProcInternal(HWND hWnd, UINT message, WPARAM wparam, LPARA
 			if (HIWORD(wparam) == CBN_SELCHANGE)
 			{
 				HandleFloppyDriveCombo(hWnd, DRIVE_1, LOWORD(wparam));
-				GetFrame().FrameRefreshStatus(DRAW_BUTTON_DRIVES);
+				GetFrame().FrameRefreshStatus(DRAW_BUTTON_DRIVES | DRAW_DISK_STATUS);
 			}
 			break;
 		case IDC_COMBO_DISK2:
 			if (HIWORD(wparam) == CBN_SELCHANGE)
 			{
 				HandleFloppyDriveCombo(hWnd, DRIVE_2, LOWORD(wparam));
-				GetFrame().FrameRefreshStatus(DRAW_BUTTON_DRIVES);
+				GetFrame().FrameRefreshStatus(DRAW_BUTTON_DRIVES | DRAW_DISK_STATUS);
 			}
 			break;
 		case IDC_COMBO_HDD1:

--- a/source/Configuration/PropertySheetHelper.cpp
+++ b/source/Configuration/PropertySheetHelper.cpp
@@ -29,7 +29,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "../Windows/AppleWin.h"	// g_nAppMode, g_uScrollLockToggle, sg_PropertySheet
 #include "../CardManager.h"
 #include "../Disk.h"
-#include "../Windows/WinFrame.h"
 #include "../Log.h"
 #include "../Registry.h"
 #include "../SaveState.h"

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -44,6 +44,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "../Memory.h"
 #include "../NTSC.h"
 #include "../SoundCore.h"	// SoundCore_SetFade()
+#include "../Windows/Win32Frame.h"
 #include "../Windows/WinFrame.h"
 
 //	#define DEBUG_COMMAND_HELP  1
@@ -9662,9 +9663,10 @@ void DebuggerMouseClick( int x, int y )
 	int nFontHeight = g_aFontConfig[ FONT_DISASM_DEFAULT ]._nLineHeight * GetViewportScale();
 
 	// do picking
+	Win32Frame& win32Frame = Win32Frame::GetWin32Frame();
 
-	const int nOffsetX = IsFullScreen() ? GetFullScreenOffsetX() : Get3DBorderWidth();
-	const int nOffsetY = IsFullScreen() ? GetFullScreenOffsetY() : Get3DBorderHeight();
+	const int nOffsetX = win32Frame.IsFullScreen() ? win32Frame.GetFullScreenOffsetX() : win32Frame.Get3DBorderWidth();
+	const int nOffsetY = win32Frame.IsFullScreen() ? win32Frame.GetFullScreenOffsetY() : win32Frame.Get3DBorderHeight();
 
 	const int nOffsetInScreenX = x - nOffsetX;
 	const int nOffsetInScreenY = y - nOffsetY;

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -752,7 +752,7 @@ Update_t CmdBenchmarkStop (int nArgs)
 	g_bBenchmarking = false;
 	DebugEnd();
 	
-	GetFrame().FrameRefreshStatus(DRAW_TITLE);
+	GetFrame().FrameRefreshStatus(DRAW_TITLE | DRAW_DISK_STATUS);
 	GetFrame().VideoRedrawScreen();
 	DWORD currtime = GetTickCount();
 	while ((extbench = GetTickCount()) != currtime)
@@ -1962,7 +1962,7 @@ static Update_t CmdGo (int nArgs, const bool bFullSpeed)
 	g_bGoCmd_ReinitFlag = true;
 
 	g_nAppMode = MODE_STEPPING;
-	GetFrame().FrameRefreshStatus(DRAW_TITLE);
+	GetFrame().FrameRefreshStatus(DRAW_TITLE | DRAW_DISK_STATUS);
 
 	SoundCore_SetFade(FADE_IN);
 
@@ -2031,7 +2031,7 @@ Update_t CmdTrace (int nArgs)
 	g_nDebugStepStart = regs.pc;
 	g_nDebugStepUntil = -1;
 	g_nAppMode = MODE_STEPPING;
-	GetFrame().FrameRefreshStatus(DRAW_TITLE);
+	GetFrame().FrameRefreshStatus(DRAW_TITLE | DRAW_DISK_STATUS);
 	DebugContinueStepping(true);
 
 	return UPDATE_ALL; // TODO: Verify // 0
@@ -2091,7 +2091,7 @@ Update_t CmdTraceLine (int nArgs)
 	g_nDebugStepUntil = -1;
 
 	g_nAppMode = MODE_STEPPING;
-	GetFrame().FrameRefreshStatus(DRAW_TITLE);
+	GetFrame().FrameRefreshStatus(DRAW_TITLE | DRAW_DISK_STATUS);
 	DebugContinueStepping(true);
 
 	return UPDATE_ALL; // TODO: Verify // 0
@@ -3771,7 +3771,7 @@ Update_t CmdDisk ( int nArgs)
 			return HelpLastCommand();
 
 		diskCard.EjectDisk( iDrive );
-		GetFrame().FrameRefreshStatus(DRAW_LEDS | DRAW_BUTTON_DRIVES);
+		GetFrame().FrameRefreshStatus(DRAW_LEDS | DRAW_BUTTON_DRIVES | DRAW_DISK_STATUS);
 	}
 	else
 	if (iParam == PARAM_DISK_PROTECT)
@@ -3785,7 +3785,7 @@ Update_t CmdDisk ( int nArgs)
 			bProtect = g_aArgs[ 3 ].nValue ? true : false;
 
 		diskCard.SetProtect( iDrive, bProtect );
-		GetFrame().FrameRefreshStatus(DRAW_LEDS | DRAW_BUTTON_DRIVES);
+		GetFrame().FrameRefreshStatus(DRAW_LEDS | DRAW_BUTTON_DRIVES | DRAW_DISK_STATUS);
 	}
 	else
 	{
@@ -3796,7 +3796,7 @@ Update_t CmdDisk ( int nArgs)
 
 		// DISK # "Diskname"
 		diskCard.InsertDisk( iDrive, pDiskName, IMAGE_FORCE_WRITE_PROTECTED, IMAGE_DONT_CREATE );
-		GetFrame().FrameRefreshStatus(DRAW_LEDS | DRAW_BUTTON_DRIVES);
+		GetFrame().FrameRefreshStatus(DRAW_LEDS | DRAW_BUTTON_DRIVES | DRAW_DISK_STATUS);
 	}
 
 	return UPDATE_CONSOLE_DISPLAY;
@@ -8547,7 +8547,7 @@ void DebugBegin ()
 	GetDebuggerMemDC();
 
 	g_nAppMode = MODE_DEBUG;
-	GetFrame().FrameRefreshStatus(DRAW_TITLE);
+	GetFrame().FrameRefreshStatus(DRAW_TITLE | DRAW_DISK_STATUS);
 
 	if (GetMainCpu() == CPU_6502)
 	{
@@ -8734,7 +8734,7 @@ void DebugContinueStepping(const bool bCallerWillUpdateDisplay/*=false*/)
 		SoundCore_SetFade(FADE_OUT);	// NB. Call when MODE_STEPPING (not MODE_DEBUG) - see function
 
 		g_nAppMode = MODE_DEBUG;
-		GetFrame().FrameRefreshStatus(DRAW_TITLE);
+		GetFrame().FrameRefreshStatus(DRAW_TITLE | DRAW_DISK_STATUS);
 // BUG: PageUp, Trace - doesn't center cursor
 
 		g_nDisasmCurAddress = regs.pc;

--- a/source/Debugger/Debugger_Display.cpp
+++ b/source/Debugger/Debugger_Display.cpp
@@ -36,6 +36,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "../Interface.h"
 #include "../CPU.h"
 #include "../Windows/WinFrame.h"
+#include "../Windows/Win32Frame.h"
 #include "../LanguageCard.h"
 #include "../Memory.h"
 #include "../Mockingboard.h"
@@ -671,8 +672,10 @@ void StretchBltMemToFrameDC(void)
 	int nViewportCX, nViewportCY;
 	GetViewportCXCY(nViewportCX, nViewportCY);
 
-	int xdest = IsFullScreen() ? GetFullScreenOffsetX() : 0;
-	int ydest = IsFullScreen() ? GetFullScreenOffsetY() : 0;
+	Win32Frame& win32Frame = Win32Frame::GetWin32Frame();
+
+	int xdest = win32Frame.IsFullScreen() ? win32Frame.GetFullScreenOffsetX() : 0;
+	int ydest = win32Frame.IsFullScreen() ? win32Frame.GetFullScreenOffsetY() : 0;
 	int wdest = nViewportCX;
 	int hdest = nViewportCY;
 

--- a/source/Disk.cpp
+++ b/source/Disk.cpp
@@ -218,7 +218,7 @@ void Disk2InterfaceCard::CheckSpinning(const bool stateChanged, const ULONG uExe
 		m_floppyDrive[m_currDrive].m_spinning = SPINNING_CYCLES;
 
 	if (modeChanged)
-		GetFrame().FrameDrawDiskLEDS( (HDC)0 );
+		GetFrame().FrameDrawDiskLEDS();
 
 	if (modeChanged)
 	{
@@ -510,7 +510,7 @@ void __stdcall Disk2InterfaceCard::ControlStepper(WORD, WORD address, BYTE, BYTE
 		pDrive->m_phasePrecise = newPhasePrecise;
 		pFloppy->m_trackimagedata = false;
 		m_formatTrack.DriveNotWritingTrack();
-		GetFrame().FrameDrawDiskStatus((HDC)0);	// Show track status (GH#201)
+		GetFrame().FrameDrawDiskStatus();	// Show track status (GH#201)
 	}
 
 #if LOG_DISK_PHASES
@@ -1032,7 +1032,7 @@ void __stdcall Disk2InterfaceCard::ReadWrite(WORD pc, WORD addr, BYTE bWrite, BY
 
 	// Show track status (GH#201) - NB. Prevent flooding of forcing UI to redraw!!!
 	if ((pFloppy->m_byte & 0xFF) == 0)
-		GetFrame().FrameDrawDiskStatus( (HDC)0 );
+		GetFrame().FrameDrawDiskStatus();
 }
 
 //===========================================================================
@@ -1183,7 +1183,7 @@ void __stdcall Disk2InterfaceCard::DataLatchReadWriteWOZ(WORD pc, WORD addr, BYT
 
 	// Show track status (GH#201) - NB. Prevent flooding of forcing UI to redraw!!!
 	if ((floppy.m_byte & 0xFF) == 0)
-		GetFrame().FrameDrawDiskStatus((HDC)0);
+		GetFrame().FrameDrawDiskStatus();
 }
 
 void Disk2InterfaceCard::DataLatchReadWOZ(WORD pc, WORD addr, UINT bitCellRemainder)
@@ -1684,7 +1684,7 @@ void __stdcall Disk2InterfaceCard::SetWriteMode(WORD, WORD, BYTE, BYTE, ULONG uE
 	m_floppyDrive[m_currDrive].m_writelight = WRITELIGHT_CYCLES;
 
 	if (modechange)
-		GetFrame().FrameDrawDiskLEDS( (HDC)0 );
+		GetFrame().FrameDrawDiskLEDS();
 }
 
 //===========================================================================
@@ -1700,8 +1700,8 @@ void Disk2InterfaceCard::UpdateDriveState(DWORD cycles)
 		{
 			if (!(pDrive->m_spinning -= MIN(pDrive->m_spinning, cycles)))
 			{
-				GetFrame().FrameDrawDiskLEDS( (HDC)0 );
-				GetFrame().FrameDrawDiskStatus( (HDC)0 );
+				GetFrame().FrameDrawDiskLEDS();
+				GetFrame().FrameDrawDiskStatus();
 			}
 		}
 
@@ -1713,8 +1713,8 @@ void Disk2InterfaceCard::UpdateDriveState(DWORD cycles)
 		{
 			if (!(pDrive->m_writelight -= MIN(pDrive->m_writelight, cycles)))
 			{
-				GetFrame().FrameDrawDiskLEDS( (HDC)0 );
-				GetFrame().FrameDrawDiskStatus( (HDC)0 );
+				GetFrame().FrameDrawDiskLEDS();
+				GetFrame().FrameDrawDiskStatus();
 			}
 		}
 	}

--- a/source/Disk.cpp
+++ b/source/Disk.cpp
@@ -682,7 +682,7 @@ ImageError_e Disk2InterfaceCard::InsertDisk(const int drive, LPCTSTR pszImageFil
 		if (!strcmp(pszOtherPathname.c_str(), szCurrentPathname))
 		{
 			EjectDisk(!drive);
-			GetFrame().FrameRefreshStatus(DRAW_LEDS | DRAW_BUTTON_DRIVES);
+			GetFrame().FrameRefreshStatus(DRAW_LEDS | DRAW_BUTTON_DRIVES | DRAW_DISK_STATUS);
 		}
 	}
 
@@ -1542,11 +1542,11 @@ void Disk2InterfaceCard::Reset(const bool bIsPowerCycle)
 		m_floppyDrive[DRIVE_2].m_spinning   = 0;
 		m_floppyDrive[DRIVE_2].m_writelight = 0;
 
-		GetFrame().FrameRefreshStatus(DRAW_LEDS, false);
+		GetFrame().FrameRefreshStatus(DRAW_LEDS);
 	}
 
 	InitFirmware(GetCxRomPeripheral());
-	GetFrame().FrameRefreshStatus(DRAW_TITLE, false);
+	GetFrame().FrameRefreshStatus(DRAW_TITLE);
 }
 
 void Disk2InterfaceCard::ResetSwitches(void)
@@ -1770,7 +1770,7 @@ bool Disk2InterfaceCard::DriveSwap(void)
 	SaveLastDiskImage(DRIVE_1);
 	SaveLastDiskImage(DRIVE_2);
 
-	GetFrame().FrameRefreshStatus(DRAW_LEDS | DRAW_BUTTON_DRIVES, false);
+	GetFrame().FrameRefreshStatus(DRAW_LEDS | DRAW_BUTTON_DRIVES);
 
 	return true;
 }
@@ -2261,7 +2261,7 @@ bool Disk2InterfaceCard::LoadSnapshot(class YamlLoadHelper& yamlLoadHelper, UINT
 	LoadSnapshotDriveUnit(yamlLoadHelper, DRIVE_1, version);
 	LoadSnapshotDriveUnit(yamlLoadHelper, DRIVE_2, version);
 
-	GetFrame().FrameRefreshStatus(DRAW_LEDS | DRAW_BUTTON_DRIVES);
+	GetFrame().FrameRefreshStatus(DRAW_LEDS | DRAW_BUTTON_DRIVES | DRAW_DISK_STATUS);
 
 	return true;
 }

--- a/source/FrameBase.h
+++ b/source/FrameBase.h
@@ -21,7 +21,7 @@ public:
 	virtual void FrameDrawDiskLEDS() = 0;
 	virtual void FrameDrawDiskStatus() = 0;
 
-	virtual void FrameRefreshStatus(int, bool bUpdateDiskStatus = true) = 0;
+	virtual void FrameRefreshStatus(int drawflags) = 0;
 	virtual void FrameUpdateApple2Type() = 0;
 	virtual void FrameSetCursorPosByMousePos() = 0;
 

--- a/source/FrameBase.h
+++ b/source/FrameBase.h
@@ -18,8 +18,9 @@ public:
 	virtual void Initialize(void) = 0;
 	virtual void Destroy(void) = 0;
 
-	virtual void FrameDrawDiskLEDS(HDC hdc) = 0;
-	virtual void FrameDrawDiskStatus(HDC hdc) = 0;
+	virtual void FrameDrawDiskLEDS() = 0;
+	virtual void FrameDrawDiskStatus() = 0;
+
 	virtual void FrameRefreshStatus(int, bool bUpdateDiskStatus = true) = 0;
 	virtual void FrameUpdateApple2Type() = 0;
 	virtual void FrameSetCursorPosByMousePos() = 0;

--- a/source/FrameBase.h
+++ b/source/FrameBase.h
@@ -33,9 +33,6 @@ public:
 	virtual void SetLoadedSaveStateFlag(const bool bFlag) = 0;
 
 	virtual void VideoPresentScreen(void) = 0;
-	virtual void ChooseMonochromeColor(void) = 0;
-	virtual void Benchmark(void) = 0;
-	virtual void DisplayLogo(void) = 0;
 
 	void VideoRefreshScreen(uint32_t uRedrawWholeScreenVideoMode, bool bRedrawWholeScreen);
 	void VideoRedrawScreen(void);

--- a/source/Harddisk.cpp
+++ b/source/Harddisk.cpp
@@ -417,7 +417,7 @@ BOOL HD_Insert(const int iDrive, const std::string & pszImageFilename)
 		if (!strcmp(pszOtherPathname.c_str(), szCurrentPathname))
 		{
 			HD_Unplug(!iDrive);
-			GetFrame().FrameRefreshStatus(DRAW_LEDS);
+			GetFrame().FrameRefreshStatus(DRAW_LEDS | DRAW_DISK_STATUS);
 		}
 	}
 
@@ -711,7 +711,7 @@ static BYTE __stdcall HD_IO_EMUL(WORD pc, WORD addr, BYTE bWrite, BYTE d, ULONG 
 	if( pHDD->hd_status_prev != pHDD->hd_status_next ) // Update LEDs if state changes
 	{
 		pHDD->hd_status_prev = pHDD->hd_status_next;
-		GetFrame().FrameRefreshStatus(DRAW_LEDS);
+		GetFrame().FrameRefreshStatus(DRAW_LEDS | DRAW_DISK_STATUS);
 	}
 #endif
 
@@ -740,7 +740,7 @@ bool HD_ImageSwap(void)
 	HD_SaveLastDiskImage(HARDDISK_1);
 	HD_SaveLastDiskImage(HARDDISK_2);
 
-	GetFrame().FrameRefreshStatus(DRAW_LEDS, false);
+	GetFrame().FrameRefreshStatus(DRAW_LEDS);
 
 	return true;
 }
@@ -900,7 +900,7 @@ bool HD_LoadSnapshot(YamlLoadHelper& yamlLoadHelper, UINT slot, UINT version, co
 
 	HD_SetEnabled(true);
 
-	GetFrame().FrameRefreshStatus(DRAW_LEDS);
+	GetFrame().FrameRefreshStatus(DRAW_LEDS | DRAW_DISK_STATUS);
 
 	return true;
 }

--- a/source/Keyboard.cpp
+++ b/source/Keyboard.cpp
@@ -301,7 +301,7 @@ void KeybQueueKeypress (WPARAM key, Keystroke_e bASCII)
 			if (g_Apple2Type == A2TYPE_TK30002E)
 			{
 				g_bTK3KModeKey = (GetKeyState(VK_SCROLL) & 1) ? true : false;	// Sync with the Scroll Lock status
-				GetFrame().FrameRefreshStatus(DRAW_LEDS);	// TODO: Implement |Mode| LED in the UI; make it appear only when in TK3000 mode
+				GetFrame().FrameRefreshStatus(DRAW_LEDS | DRAW_DISK_STATUS);	// TODO: Implement |Mode| LED in the UI; make it appear only when in TK3000 mode
 				GetFrame().VideoRedrawScreen();	// TODO: Still need to implement page mode switching and 'whatnot'
 			}
 			return;
@@ -537,7 +537,7 @@ void KeybToggleCapsLock ()
 	if (!IS_APPLE2)
 	{
 		g_bCapsLock = (GetKeyState(VK_CAPITAL) & 1);
-		GetFrame().FrameRefreshStatus(DRAW_LEDS);
+		GetFrame().FrameRefreshStatus(DRAW_LEDS | DRAW_DISK_STATUS);
 	}
 }
 
@@ -546,7 +546,7 @@ void KeybToggleP8ACapsLock ()
 {
 	_ASSERT(g_Apple2Type == A2TYPE_PRAVETS8A);
 	P8CAPS_ON = !P8CAPS_ON;
-	GetFrame().FrameRefreshStatus(DRAW_LEDS);
+	GetFrame().FrameRefreshStatus(DRAW_LEDS | DRAW_DISK_STATUS);
 	// g_bP8CapsLock= g_bP8CapsLock?false:true; //The same as the upper, but slower
 }
 

--- a/source/Pravets.cpp
+++ b/source/Pravets.cpp
@@ -44,6 +44,6 @@ void PravetsReset(void)
 	{
 		P8CAPS_ON = false; 
 		TapeWrite(0, 0, 0, 0 ,0);
-		GetFrame().FrameRefreshStatus(DRAW_LEDS);
+		GetFrame().FrameRefreshStatus(DRAW_LEDS | DRAW_DISK_STATUS);
 	}
 }

--- a/source/Utilities.cpp
+++ b/source/Utilities.cpp
@@ -402,7 +402,7 @@ void InsertFloppyDisks(const UINT slot, LPSTR szImageName_drive[NUM_DRIVES], boo
 	{
 		bRes = DoDiskInsert(slot, DRIVE_1, szImageName_drive[DRIVE_1]);
 		LogFileOutput("Init: S%d, DoDiskInsert(D1), res=%d\n", slot, bRes);
-		GetFrame().FrameRefreshStatus(DRAW_LEDS | DRAW_BUTTON_DRIVES);	// floppy activity LEDs and floppy buttons
+		GetFrame().FrameRefreshStatus(DRAW_LEDS | DRAW_BUTTON_DRIVES | DRAW_DISK_STATUS);	// floppy activity LEDs and floppy buttons
 		bBoot = true;
 	}
 
@@ -442,7 +442,7 @@ void InsertHardDisks(LPSTR szImageName_harddisk[NUM_HARDDISKS], bool& bBoot)
 	{
 		bRes = DoHardDiskInsert(HARDDISK_1, szImageName_harddisk[HARDDISK_1]);
 		LogFileOutput("Init: DoHardDiskInsert(HDD1), res=%d\n", bRes);
-		GetFrame().FrameRefreshStatus(DRAW_LEDS);	// harddisk activity LED
+		GetFrame().FrameRefreshStatus(DRAW_LEDS | DRAW_DISK_STATUS);	// harddisk activity LED
 		bBoot = true;
 	}
 

--- a/source/Windows/AppleWin.cpp
+++ b/source/Windows/AppleWin.cpp
@@ -768,7 +768,7 @@ static void OneTimeInitialization(HINSTANCE passinstance)
 		LogFileOutput("Init: RegisterExtensions()\n");
 	}
 
-	FrameRegisterClass();
+	Win32Frame::GetWin32Frame().FrameRegisterClass();
 	LogFileOutput("Init: FrameRegisterClass()\n");
 }
 
@@ -843,7 +843,7 @@ static void RepeatInitialization(void)
 		LogFileOutput("Main: VideoInitialize()\n");
 
 		LogFileOutput("Main: FrameCreateWindow() - pre\n");
-		FrameCreateWindow();	// GetFrame().g_hFrameWindow is now valid
+		Win32Frame::GetWin32Frame().FrameCreateWindow();	// GetFrame().g_hFrameWindow is now valid
 		LogFileOutput("Main: FrameCreateWindow() - post\n");
 
 		// Init palette color

--- a/source/Windows/Win32Frame.cpp
+++ b/source/Windows/Win32Frame.cpp
@@ -499,3 +499,10 @@ void Win32Frame::DDUninit(void)
 }
 
 #undef SAFE_RELEASE
+
+Win32Frame& Win32Frame::GetWin32Frame()
+{
+	FrameBase& frameBase = GetFrame();
+	Win32Frame& win32Frame = static_cast<Win32Frame&>(frameBase);
+	return win32Frame;
+}

--- a/source/Windows/Win32Frame.cpp
+++ b/source/Windows/Win32Frame.cpp
@@ -517,6 +517,6 @@ void Win32Frame::DDUninit(void)
 Win32Frame& Win32Frame::GetWin32Frame()
 {
 	FrameBase& frameBase = GetFrame();
-	Win32Frame& win32Frame = static_cast<Win32Frame&>(frameBase);
+	Win32Frame& win32Frame = dynamic_cast<Win32Frame&>(frameBase);
 	return win32Frame;
 }

--- a/source/Windows/Win32Frame.cpp
+++ b/source/Windows/Win32Frame.cpp
@@ -22,6 +22,20 @@ Win32Frame::Win32Frame()
 	g_hLogoBitmap = (HBITMAP)0;
 	g_hDeviceBitmap = (HBITMAP)0;
 	g_hDeviceDC = (HDC)0;
+	g_bAltEnter_ToggleFullScreen = false;
+	g_bIsFullScreen = false;
+	g_bShowingCursor = true;
+	g_bLastCursorInAppleViewport = false;
+	g_uCount100msec = 0;
+	g_TimerIDEvent_100msec = 0;
+	g_bUsingCursor = FALSE;
+	g_bAppActive = false;
+	g_bFrameActive = false;
+	g_windowMinimized = false;
+	g_bFullScreen_ShowSubunitStatus = true;
+	g_win_fullscreen_scale = 1;
+	g_win_fullscreen_offsetx = 0;
+	g_win_fullscreen_offsety = 0;
 }
 
 void Win32Frame::videoCreateDIBSection(Video & video)

--- a/source/Windows/Win32Frame.h
+++ b/source/Windows/Win32Frame.h
@@ -9,8 +9,12 @@ class Win32Frame : public FrameBase
 public:
 	Win32Frame();
 
-	virtual void FrameDrawDiskLEDS(HDC hdc);
-	virtual void FrameDrawDiskStatus(HDC hdc);
+	void FrameDrawDiskLEDS(HDC hdc);  // overloaded Win32 only, call via GetWin32Frame()
+	virtual void FrameDrawDiskLEDS();
+
+	void FrameDrawDiskStatus(HDC hdc);  // overloaded Win32 only, call via GetWin32Frame()
+	virtual void FrameDrawDiskStatus();
+
 	virtual void FrameRefreshStatus(int, bool bUpdateDiskStatus = true);
 	virtual void FrameUpdateApple2Type();
 	virtual void FrameSetCursorPosByMousePos();
@@ -28,6 +32,9 @@ public:
 	virtual void ChooseMonochromeColor(void);
 	virtual void Benchmark(void);
 	virtual void DisplayLogo(void);
+
+	static Win32Frame& GetWin32Frame();
+
 private:
 	void videoCreateDIBSection(Video& video);
 	void VideoDrawLogoBitmap(HDC hDstDC, int xoff, int yoff, int srcw, int srch, int scale);

--- a/source/Windows/Win32Frame.h
+++ b/source/Windows/Win32Frame.h
@@ -15,7 +15,7 @@ public:
 	void FrameDrawDiskStatus(HDC hdc);  // overloaded Win32 only, call via GetWin32Frame()
 	virtual void FrameDrawDiskStatus();
 
-	virtual void FrameRefreshStatus(int, bool bUpdateDiskStatus = true);
+	virtual void FrameRefreshStatus(int drawflags);
 	virtual void FrameUpdateApple2Type();
 	virtual void FrameSetCursorPosByMousePos();
 

--- a/source/Windows/Win32Frame.h
+++ b/source/Windows/Win32Frame.h
@@ -29,9 +29,9 @@ public:
 	virtual void Initialize(void);
 	virtual void Destroy(void);
 	virtual void VideoPresentScreen(void);
-	virtual void ChooseMonochromeColor(void);
-	virtual void Benchmark(void);
-	virtual void DisplayLogo(void);
+			void ChooseMonochromeColor(void);
+			void Benchmark(void);
+			void DisplayLogo(void);
 
 	static Win32Frame& GetWin32Frame();
 

--- a/source/Windows/Win32Frame.h
+++ b/source/Windows/Win32Frame.h
@@ -4,15 +4,20 @@
 
 class Video;
 
+#if 0 // enable non-integral full-screen scaling
+#define FULLSCREEN_SCALE_TYPE float
+#else
+#define FULLSCREEN_SCALE_TYPE int
+#endif
+
 class Win32Frame : public FrameBase
 {
 public:
 	Win32Frame();
 
-	void FrameDrawDiskLEDS(HDC hdc);  // overloaded Win32 only, call via GetWin32Frame()
-	virtual void FrameDrawDiskLEDS();
+	static Win32Frame& GetWin32Frame();
 
-	void FrameDrawDiskStatus(HDC hdc);  // overloaded Win32 only, call via GetWin32Frame()
+	virtual void FrameDrawDiskLEDS();
 	virtual void FrameDrawDiskStatus();
 
 	virtual void FrameRefreshStatus(int drawflags);
@@ -29,24 +34,73 @@ public:
 	virtual void Initialize(void);
 	virtual void Destroy(void);
 	virtual void VideoPresentScreen(void);
-			void ChooseMonochromeColor(void);
-			void Benchmark(void);
-			void DisplayLogo(void);
 
-	static Win32Frame& GetWin32Frame();
+	bool GetFullScreenShowSubunitStatus(void);
+	int GetFullScreenOffsetX(void);
+	int GetFullScreenOffsetY(void);
+	bool IsFullScreen(void);
+	void FrameRegisterClass();
+	void FrameCreateWindow(void);
+	void ChooseMonochromeColor(void);
+	UINT Get3DBorderWidth(void);
+	UINT Get3DBorderHeight(void);
+	LRESULT WndProc(HWND   window, UINT   message, WPARAM wparam, LPARAM lparam);
 
 private:
+	static BOOL CALLBACK DDEnumProc(LPGUID lpGUID, LPCTSTR lpszDesc, LPCTSTR lpszDrvName, LPVOID lpContext);
+
 	void videoCreateDIBSection(Video& video);
 	void VideoDrawLogoBitmap(HDC hDstDC, int xoff, int yoff, int srcw, int srch, int scale);
-	static BOOL CALLBACK DDEnumProc(LPGUID lpGUID, LPCTSTR lpszDesc, LPCTSTR lpszDrvName, LPVOID lpContext);
 	bool DDInit(void);
 	void DDUninit(void);
 
+	void Benchmark(void);
+	void DisplayLogo(void);
+	void FrameDrawDiskLEDS(HDC hdc);  // overloaded Win32 only, call via GetWin32Frame()
+	void FrameDrawDiskStatus(HDC hdc);  // overloaded Win32 only, call via GetWin32Frame()
+	void EraseButton(int number);
+	void DrawButton(HDC passdc, int number);
+	void DrawCrosshairs(int x, int y);
+	void DrawFrameWindow(bool bPaintingWindow = false);
+	void DrawStatusArea(HDC passdc, int drawflags);
+	void ProcessButtonClick(int button, bool bFromButtonUI = false);
+	bool ConfirmReboot(bool bFromButtonUI);
+	void ProcessDiskPopupMenu(HWND hwnd, POINT pt, const int iDrive);
+	void RelayEvent(UINT message, WPARAM wparam, LPARAM lparam);
+	void SetFullScreenMode();
+	void SetNormalMode();
+	void SetUsingCursor(BOOL bNewValue);
+	void SetupTooltipControls(void);
+	void FrameResizeWindow(int nNewScale);
+	void RevealCursor();
+	void ScreenWindowResize(const bool bCtrlKey);
+	void UpdateMouseInAppleViewport(int iOutOfBoundsX, int iOutOfBoundsY, int x=0, int y=0);
+	void DrawCrosshairsMouse();
+	void FrameSetCursorPosByMousePos(int x, int y, int dx, int dy, bool bLeavingAppleScreen);
+	void CreateGdiObjects(void);
+	void FrameShowCursor(BOOL bShow);
+	void FullScreenRevealCursor(void);
+
+	bool g_bAltEnter_ToggleFullScreen; // Default for ALT+ENTER is to toggle between windowed and full-screen modes
+	bool    g_bIsFullScreen;
+	bool g_bShowingCursor;
+	bool g_bLastCursorInAppleViewport;
+	UINT_PTR	g_TimerIDEvent_100msec;
+	UINT		g_uCount100msec;
 	COLORREF      customcolors[256];	// MONOCHROME is last custom color
 	HBITMAP       g_hLogoBitmap;
 	HBITMAP       g_hDeviceBitmap;
 	HDC           g_hDeviceDC;
 	LPBITMAPINFO  g_pFramebufferinfo;
+	BOOL    g_bUsingCursor;	// TRUE = AppleWin is using (hiding) the mouse-cursor && restricting cursor to window - see SetUsingCursor()
+	bool    g_bAppActive;
+	bool g_bFrameActive;
+	bool g_windowMinimized;
+	std::string driveTooltip;
+	bool g_bFullScreen_ShowSubunitStatus;
+	FULLSCREEN_SCALE_TYPE	g_win_fullscreen_scale;
+	int						g_win_fullscreen_offsetx;
+	int						g_win_fullscreen_offsety;
 
 	static const UINT MAX_DRAW_DEVICES = 10;
 	char* draw_devices[MAX_DRAW_DEVICES];

--- a/source/Windows/WinFrame.cpp
+++ b/source/Windows/WinFrame.cpp
@@ -1438,7 +1438,7 @@ LRESULT CALLBACK FrameWndProc (
 				const int iDrive = wparam - VK_F3;
 				ProcessDiskPopupMenu( window, pt, iDrive );
 
-				GetFrame().FrameRefreshStatus(DRAW_LEDS | DRAW_BUTTON_DRIVES);
+				GetFrame().FrameRefreshStatus(DRAW_LEDS | DRAW_BUTTON_DRIVES | DRAW_DISK_STATUS);
 				DrawButton((HDC)0, iButton);
 			}
 			else
@@ -1746,7 +1746,7 @@ LRESULT CALLBACK FrameWndProc (
 							ProcessDiskPopupMenu( window, pt, iDrive );
                 	}
 
-					GetFrame().FrameRefreshStatus(DRAW_LEDS | DRAW_BUTTON_DRIVES);
+					GetFrame().FrameRefreshStatus(DRAW_LEDS | DRAW_BUTTON_DRIVES | DRAW_DISK_STATUS);
 					DrawButton((HDC)0, iButton);
 				}			
 			}
@@ -2573,9 +2573,7 @@ void FrameReleaseDC () {
 }
 
 //===========================================================================
-void Win32Frame::FrameRefreshStatus (int drawflags, bool bUpdateDiskStatus) {
-	// NB. 99% of the time we draw the disk status.  On DiskDriveSwap() we don't.
- 	drawflags |= bUpdateDiskStatus ? DRAW_DISK_STATUS : 0;
+void Win32Frame::FrameRefreshStatus (int drawflags) {
 	DrawStatusArea((HDC)0,drawflags);
 }
 

--- a/source/Windows/WinFrame.cpp
+++ b/source/Windows/WinFrame.cpp
@@ -615,6 +615,11 @@ void Win32Frame::SetFullScreenShowSubunitStatus(bool bShow)
 	g_bFullScreen_ShowSubunitStatus = bShow;
 }
 
+void Win32Frame::FrameDrawDiskLEDS()
+{
+	FrameDrawDiskLEDS((HDC)0);
+}
+
 //===========================================================================
 void Win32Frame::FrameDrawDiskLEDS( HDC passdc )
 {
@@ -665,6 +670,11 @@ void Win32Frame::FrameDrawDiskLEDS( HDC passdc )
 		DrawBitmapRect(dc,x+12,y+6,&rDiskLed,g_hDiskWindowedLED[g_eStatusDrive1]);
 		DrawBitmapRect(dc,x+31,y+6,&rDiskLed,g_hDiskWindowedLED[g_eStatusDrive2]);
 	}
+}
+
+void Win32Frame::FrameDrawDiskStatus()
+{
+	FrameDrawDiskStatus((HDC)0);
 }
 
 // Feature Request #201 Show track status
@@ -859,7 +869,9 @@ static void DrawStatusArea (HDC passdc, int drawflags)
 			SelectObject(dc,smallfont);
 
 			if (drawflags & DRAW_DISK_STATUS)
-				GetFrame().FrameDrawDiskStatus( dc );
+			{
+				Win32Frame::GetWin32Frame().FrameDrawDiskStatus(dc);
+			}
 
 #if HD_LED
 			SetTextAlign(dc, TA_RIGHT | TA_TOP);
@@ -926,10 +938,11 @@ static void DrawStatusArea (HDC passdc, int drawflags)
 
 		if (drawflags & DRAW_LEDS)
 		{
-			GetFrame().FrameDrawDiskLEDS( dc );
+			Win32Frame& win32Frame = Win32Frame::GetWin32Frame();
+			win32Frame.FrameDrawDiskLEDS( dc );
 
 			if (drawflags & DRAW_DISK_STATUS)
-				GetFrame().FrameDrawDiskStatus( dc );
+				win32Frame.FrameDrawDiskStatus( dc );
 
 			if (!IS_APPLE2)
 			{

--- a/source/Windows/WinFrame.cpp
+++ b/source/Windows/WinFrame.cpp
@@ -584,7 +584,7 @@ static void DrawFrameWindow (bool bPaintingWindow/*=false*/)
 
 	// DRAW THE CONTENTS OF THE EMULATED SCREEN
 	if (g_nAppMode == MODE_LOGO)
-		GetFrame().DisplayLogo();
+		Win32Frame::GetWin32Frame().DisplayLogo();
 	else if (g_nAppMode == MODE_DEBUG)
 		DebugDisplay();
 	else
@@ -1821,7 +1821,7 @@ LRESULT CALLBACK FrameWndProc (
       DrawStatusArea((HDC)0,DRAW_TITLE);
       HCURSOR oldcursor = SetCursor(LoadCursor(0,IDC_WAIT));
       g_nAppMode = MODE_BENCHMARK;
-      GetFrame().Benchmark();
+      Win32Frame::GetWin32Frame().Benchmark();
       g_nAppMode = MODE_LOGO;
       ResetMachineState();
       SetCursor(oldcursor);

--- a/source/Windows/WinFrame.h
+++ b/source/Windows/WinFrame.h
@@ -10,24 +10,13 @@
 
 
 // Prototypes
-	void    FrameCreateWindow(void);
 	HDC     FrameGetDC ();
 	void    FrameReleaseDC ();
-	void    FrameRegisterClass ();
 	int		GetViewportScale(void);
 	void	GetViewportCXCY(int& nViewportCX, int& nViewportCY);
-
-	bool	IsFullScreen(void);
-	bool	GetFullScreenShowSubunitStatus(void);
 
 	LRESULT CALLBACK FrameWndProc (
 		HWND   window,
 		UINT   message,
 		WPARAM wparam,
 		LPARAM lparam );
-
-	int GetFullScreenOffsetX(void);
-	int GetFullScreenOffsetY(void);
-
-	UINT Get3DBorderWidth(void);
-	UINT Get3DBorderHeight(void);


### PR DESCRIPTION
This PR contains a few things (happy to split if necessary and to improve on feedback)

- simplify the interface FrameBase to make it easier to implement it for different cases (remove HDC and make parameters more explicit)
- remove functions which are only called on a Win32Frame (in which case a cast is guaranteed to succeed)
- otherwise there is the risk that every FrameBase implementation wants to add its own variants.
- video.VideoReinitialize(false); when changing the MonoChrome color: should the video address be reinitialised? I looked at the calls made for other video changes (F9, Shift-F9...) and for consistency changed it. But it might a mistake of mine.
