### PR TITLE
Videoreinitialize: make code more uniform

### DIFF
--- a/source/Configuration/PageConfig.cpp
+++ b/source/Configuration/PageConfig.cpp
@@ -312,15 +312,8 @@ void CPageConfig::DlgOK(HWND hWnd)
 
 	if (bVideoReinit)
 	{
-		GetVideo().Config_Save_Video();
-
 		win32Frame.FrameRefreshStatus(DRAW_TITLE);
-
-		GetVideo().VideoReinitialize(false);
-		if ((g_nAppMode != MODE_LOGO) && (g_nAppMode != MODE_DEBUG))
-		{
-			win32Frame.VideoRedrawScreen();
-		}
+		win32Frame.ApplyVideoModeChange();
 	}
 
 	//

--- a/source/Configuration/PageConfig.cpp
+++ b/source/Configuration/PageConfig.cpp
@@ -316,7 +316,7 @@ void CPageConfig::DlgOK(HWND hWnd)
 
 		win32Frame.FrameRefreshStatus(DRAW_TITLE);
 
-		GetVideo().VideoReinitialize();
+		GetVideo().VideoReinitialize(false);
 		if ((g_nAppMode != MODE_LOGO) && (g_nAppMode != MODE_DEBUG))
 		{
 			win32Frame.VideoRedrawScreen();

--- a/source/NTSC.cpp
+++ b/source/NTSC.cpp
@@ -2117,7 +2117,7 @@ void NTSC_VideoInit( uint8_t* pFramebuffer ) // wsVideoInit
 	g_pFuncUpdateTextScreen     = updateScreenText40;
 	g_pFuncUpdateGraphicsScreen = updateScreenText40;
 
-	GetVideo().VideoReinitialize(); // Setup g_pFunc_ntsc*Pixel()
+	GetVideo().VideoReinitialize(true); // Setup g_pFunc_ntsc*Pixel()
 
 	bgra_t baseColors[kNumBaseColors];
 	GenerateBaseColors(&baseColors);

--- a/source/SaveState.cpp
+++ b/source/SaveState.cpp
@@ -287,7 +287,7 @@ static void ParseUnitApple2(YamlLoadHelper& yamlLoadHelper, UINT version)
 	MemLoadSnapshot(yamlLoadHelper, version);
 
 	// g_Apple2Type may've changed: so redraw frame (title, buttons, leds, etc)
-	GetVideo().VideoReinitialize();	// g_CharsetType changed
+	GetVideo().VideoReinitialize(true);	// g_CharsetType changed
 	GetFrame().FrameUpdateApple2Type();	// Calls VideoRedrawScreen() before the aux mem has been loaded (so if DHGR is enabled, then aux mem will be zeros at this stage)
 }
 

--- a/source/Video.cpp
+++ b/source/Video.cpp
@@ -126,7 +126,7 @@ UINT Video::GetFrameBufferHeight(void)
 
 //===========================================================================
 
-void Video::VideoReinitialize(bool bInitVideoScannerAddress /*= true*/)
+void Video::VideoReinitialize(bool bInitVideoScannerAddress)
 {
 	NTSC_VideoReinitialize( g_dwCyclesThisFrame, bInitVideoScannerAddress );
 	NTSC_VideoInitAppleType();

--- a/source/Video.h
+++ b/source/Video.h
@@ -211,7 +211,7 @@ public:
 	COLORREF GetMonochromeRGB(void) { return g_nMonochromeRGB; }
 	void SetMonochromeRGB(COLORREF colorRef) { g_nMonochromeRGB = colorRef; }
 
-	void VideoReinitialize(bool bInitVideoScannerAddress = true);
+	void VideoReinitialize(bool bInitVideoScannerAddress);
 	void VideoResetState(void);
 	void VideoRefreshBuffer(uint32_t uRedrawWholeScreenVideoMode, bool bRedrawWholeScreen);
 

--- a/source/Windows/Win32Frame.cpp
+++ b/source/Windows/Win32Frame.cpp
@@ -9,6 +9,7 @@
 #include "Log.h"
 #include "Memory.h"
 #include "CardManager.h"
+#include "Debugger/Debug.h"
 #include "../resource/resource.h"
 
 // Win32Frame methods are implemented in AppleWin, WinFrame and WinVideo.
@@ -306,12 +307,7 @@ void Win32Frame::ChooseMonochromeColor(void)
 	if (ChooseColor(&cc))
 	{
 		video.SetMonochromeRGB(cc.rgbResult);
-		video.VideoReinitialize(false);
-		if ((g_nAppMode != MODE_LOGO) && (g_nAppMode != MODE_DEBUG))
-		{
-			VideoRedrawScreen();
-		}
-		video.Config_Save_Video();
+		ApplyVideoModeChange();
 	}
 }
 
@@ -513,6 +509,29 @@ void Win32Frame::DDUninit(void)
 }
 
 #undef SAFE_RELEASE
+
+void Win32Frame::ApplyVideoModeChange(void)
+{
+	Video& video = GetVideo();
+	video.Config_Save_Video();
+	video.VideoReinitialize(false);
+
+	if (g_nAppMode != MODE_LOGO)
+	{
+		if (g_nAppMode == MODE_DEBUG)
+		{
+			UINT debugVideoMode;
+			if (DebugGetVideoMode(&debugVideoMode))
+				VideoRefreshScreen(debugVideoMode, true);
+			else
+				VideoPresentScreen();
+		}
+		else
+		{
+			VideoPresentScreen();
+		}
+	}
+}
 
 Win32Frame& Win32Frame::GetWin32Frame()
 {

--- a/source/Windows/Win32Frame.cpp
+++ b/source/Windows/Win32Frame.cpp
@@ -306,7 +306,7 @@ void Win32Frame::ChooseMonochromeColor(void)
 	if (ChooseColor(&cc))
 	{
 		video.SetMonochromeRGB(cc.rgbResult);
-		video.VideoReinitialize();
+		video.VideoReinitialize(false);
 		if ((g_nAppMode != MODE_LOGO) && (g_nAppMode != MODE_DEBUG))
 		{
 			VideoRedrawScreen();

--- a/source/Windows/Win32Frame.h
+++ b/source/Windows/Win32Frame.h
@@ -44,6 +44,7 @@ public:
 	void ChooseMonochromeColor(void);
 	UINT Get3DBorderWidth(void);
 	UINT Get3DBorderHeight(void);
+	void ApplyVideoModeChange(void);
 	LRESULT WndProc(HWND   window, UINT   message, WPARAM wparam, LPARAM lparam);
 
 private:

--- a/source/Windows/WinFrame.cpp
+++ b/source/Windows/WinFrame.cpp
@@ -1113,7 +1113,7 @@ LRESULT Win32Frame::WndProc(
 	}
 
     case WM_DISPLAYCHANGE:
-      GetVideo().VideoReinitialize();
+      GetVideo().VideoReinitialize(false);
       break;
 
     case WM_DROPFILES:

--- a/source/Windows/WinFrame.cpp
+++ b/source/Windows/WinFrame.cpp
@@ -1223,26 +1223,7 @@ LRESULT Win32Frame::WndProc(
 
 			// TODO: Clean up code:FrameRefreshStatus(DRAW_TITLE) DrawStatusArea((HDC)0,DRAW_TITLE)
 			DrawStatusArea( (HDC)0, DRAW_TITLE );
-
-			GetVideo().VideoReinitialize(false);
-
-			if (g_nAppMode != MODE_LOGO)
-			{
-				if (g_nAppMode == MODE_DEBUG)
-				{
-					UINT debugVideoMode;
-					if ( DebugGetVideoMode(&debugVideoMode) )
-						VideoRefreshScreen(debugVideoMode, true);
-					else
-						VideoPresentScreen();
-				}
-				else
-				{
-					VideoPresentScreen();
-				}
-			}
-
-			GetVideo().Config_Save_Video();
+			ApplyVideoModeChange();
 		}
 		else if (wparam == VK_F10)
 		{


### PR DESCRIPTION
This was originally discussed in https://github.com/AppleWin/AppleWin/pull/910#issuecomment-757303832

When VideoMode changes, call ``VideoReinitialize(false)``.

I still have one open question.
If this code is needed after a ``F9``: https://github.com/AppleWin/AppleWin/blob/master/source/Windows/WinFrame.cpp#L1254-L1258

should it be needed here as well:
https://github.com/AppleWin/AppleWin/blob/master/source/Windows/Win32Frame.cpp#L296
and here
https://github.com/AppleWin/AppleWin/blob/master/source/Configuration/PageConfig.cpp#L318
?
I might be trying too hard to make uniform parts of the code which are not meant to, they just look very similar.
