### PR TITLE
Move last remaining globals from WinFrame.cpp to Win32Frame.

### DIFF
--- a/AppleWinExpress2008.vcproj
+++ b/AppleWinExpress2008.vcproj
@@ -997,10 +997,6 @@
 					RelativePath=".\source\Windows\WinFrame.cpp"
 					>
 				</File>
-				<File
-					RelativePath=".\source\Windows\WinFrame.h"
-					>
-				</File>
 			</Filter>
 			<Filter
 				Name="Configuration"

--- a/AppleWinExpress2019.vcxproj
+++ b/AppleWinExpress2019.vcxproj
@@ -121,7 +121,6 @@
     <ClInclude Include="source\Windows\AppleWin.h" />
     <ClInclude Include="source\Windows\DirectInput.h" />
     <ClInclude Include="source\Windows\Win32Frame.h" />
-    <ClInclude Include="source\Windows\WinFrame.h" />
     <ClInclude Include="source\YamlHelper.h" />
     <ClInclude Include="source\z80emu.h" />
     <ClInclude Include="source\Z80VICE\daa.h" />

--- a/AppleWinExpress2019.vcxproj.filters
+++ b/AppleWinExpress2019.vcxproj.filters
@@ -501,9 +501,6 @@
     <ClInclude Include="source\Windows\DirectInput.h">
       <Filter>Source Files\Windows</Filter>
     </ClInclude>
-    <ClInclude Include="source\Windows\WinFrame.h">
-      <Filter>Source Files\Windows</Filter>
-    </ClInclude>
     <ClInclude Include="source\Core.h">
       <Filter>Source Files</Filter>
     </ClInclude>

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -2811,7 +2811,9 @@ bool _CmdConfigFont ( int iFont, LPCSTR pFontName, int iPitchFamily, int nFontHe
 			_tcsncpy( pFont->_sFontName, pFontName, MAX_FONT_NAME-1 );
 			pFont->_sFontName[ MAX_FONT_NAME-1 ] = 0;
 
-			HDC hDC = FrameGetDC();
+			Win32Frame& win32Frame = Win32Frame::GetWin32Frame();
+
+			HDC hDC = win32Frame.FrameGetDC();
 
 			TEXTMETRIC tm;
 			GetTextMetrics(hDC, &tm);
@@ -2850,7 +2852,7 @@ bool _CmdConfigFont ( int iFont, LPCSTR pFontName, int iPitchFamily, int nFontHe
 				nFontWidthMax = 7;
 			}
 
-			FrameReleaseDC();
+			win32Frame.FrameReleaseDC();
 
 //			DeleteObject( g_hFontDisasm );		
 //			g_hFontDisasm = hFont;
@@ -9659,11 +9661,12 @@ void DebuggerMouseClick( int x, int y )
 	if (iAltCtrlShift != g_bConfigDisasmClick)
 		return;
 
-	int nFontWidth  = g_aFontConfig[ FONT_DISASM_DEFAULT ]._nFontWidthAvg * GetViewportScale();
-	int nFontHeight = g_aFontConfig[ FONT_DISASM_DEFAULT ]._nLineHeight * GetViewportScale();
+	Win32Frame& win32Frame = Win32Frame::GetWin32Frame();
+
+	int nFontWidth  = g_aFontConfig[ FONT_DISASM_DEFAULT ]._nFontWidthAvg * win32Frame.GetViewportScale();
+	int nFontHeight = g_aFontConfig[ FONT_DISASM_DEFAULT ]._nLineHeight * win32Frame.GetViewportScale();
 
 	// do picking
-	Win32Frame& win32Frame = Win32Frame::GetWin32Frame();
 
 	const int nOffsetX = win32Frame.IsFullScreen() ? win32Frame.GetFullScreenOffsetX() : win32Frame.Get3DBorderWidth();
 	const int nOffsetY = win32Frame.IsFullScreen() ? win32Frame.GetFullScreenOffsetY() : win32Frame.Get3DBorderHeight();

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -45,7 +45,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "../NTSC.h"
 #include "../SoundCore.h"	// SoundCore_SetFade()
 #include "../Windows/Win32Frame.h"
-#include "../Windows/WinFrame.h"
 
 //	#define DEBUG_COMMAND_HELP  1
 //	#define DEBUG_ASM_HASH 1

--- a/source/Debugger/Debugger_Display.cpp
+++ b/source/Debugger/Debugger_Display.cpp
@@ -35,7 +35,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "../Core.h"
 #include "../Interface.h"
 #include "../CPU.h"
-#include "../Windows/WinFrame.h"
 #include "../Windows/Win32Frame.h"
 #include "../LanguageCard.h"
 #include "../Memory.h"

--- a/source/Debugger/Debugger_Display.cpp
+++ b/source/Debugger/Debugger_Display.cpp
@@ -552,7 +552,9 @@ HDC GetDebuggerMemDC(void)
 {
 	if (!g_hDebuggerMemDC)
 	{
-		HDC hFrameDC = FrameGetDC();
+		Win32Frame& win32Frame = Win32Frame::GetWin32Frame();
+
+		HDC hFrameDC = win32Frame.FrameGetDC();
 		g_hDebuggerMemDC = CreateCompatibleDC(hFrameDC);
 
 		// CREATE A BITMAPINFO STRUCTURE FOR THE FRAME BUFFER
@@ -591,7 +593,8 @@ void ReleaseDebuggerMemDC(void)
 		DeleteDC(g_hDebuggerMemDC);
 		g_hDebuggerMemDC = NULL;
 
-		FrameReleaseDC();
+		Win32Frame& win32Frame = Win32Frame::GetWin32Frame();
+		win32Frame.FrameReleaseDC();
 
 		delete [] g_pDebuggerMemFramebufferinfo;
 		g_pDebuggerMemFramebufferinfo = NULL;
@@ -604,7 +607,8 @@ HDC GetConsoleFontDC(void)
 {
 	if (!g_hConsoleFontDC)
 	{
-		HDC hFrameDC = FrameGetDC();
+		Win32Frame& win32Frame = Win32Frame::GetWin32Frame();
+		HDC hFrameDC = win32Frame.FrameGetDC();
 		g_hConsoleFontDC = CreateCompatibleDC(hFrameDC);
 
 		// CREATE A BITMAPINFO STRUCTURE FOR THE FRAME BUFFER
@@ -632,7 +636,7 @@ HDC GetConsoleFontDC(void)
 		// DRAW THE SOURCE IMAGE INTO THE SOURCE BIT BUFFER
 		HDC tmpDC = CreateCompatibleDC(hFrameDC);
 		// Pre-scaled bitmap
-		HBITMAP tmpFont = LoadBitmap(GetFrame().g_hInstance, TEXT("IDB_DEBUG_FONT_7x8"));  // Bitmap must be 112x128 as defined above
+		HBITMAP tmpFont = LoadBitmap(win32Frame.g_hInstance, TEXT("IDB_DEBUG_FONT_7x8"));  // Bitmap must be 112x128 as defined above
 		SelectObject(tmpDC, tmpFont);
 		BitBlt(g_hConsoleFontDC, 0, 0, CONSOLE_FONT_BITMAP_WIDTH, CONSOLE_FONT_BITMAP_HEIGHT,
 			tmpDC, 0, 0,
@@ -669,10 +673,10 @@ void ReleaseConsoleFontDC(void)
 
 void StretchBltMemToFrameDC(void)
 {
-	int nViewportCX, nViewportCY;
-	GetViewportCXCY(nViewportCX, nViewportCY);
-
 	Win32Frame& win32Frame = Win32Frame::GetWin32Frame();
+
+	int nViewportCX, nViewportCY;
+	win32Frame.GetViewportCXCY(nViewportCX, nViewportCY);
 
 	int xdest = win32Frame.IsFullScreen() ? win32Frame.GetFullScreenOffsetX() : 0;
 	int ydest = win32Frame.IsFullScreen() ? win32Frame.GetFullScreenOffsetY() : 0;
@@ -680,7 +684,7 @@ void StretchBltMemToFrameDC(void)
 	int hdest = nViewportCY;
 
 	BOOL bRes = StretchBlt(
-		FrameGetDC(),			                            // HDC hdcDest,
+		win32Frame.FrameGetDC(),			                // HDC hdcDest,
 		xdest, ydest,									    // int nXOriginDest, int nYOriginDest,
 		wdest, hdest,										// int nWidthDest,   int nHeightDest,
 		GetDebuggerMemDC(),									// HDC hdcSrc,

--- a/source/Windows/AppleWin.cpp
+++ b/source/Windows/AppleWin.cpp
@@ -47,7 +47,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "Speech.h"
 #endif
 #include "Windows/Win32Frame.h"
-#include "Windows/WinFrame.h"
 #include "RGBMonitor.h"
 #include "NTSC.h"
 

--- a/source/Windows/AppleWin.cpp
+++ b/source/Windows/AppleWin.cpp
@@ -143,7 +143,7 @@ static void ContinueExecution(void)
 	bool bScrollLock_FullSpeed = false;
 	if (GetPropertySheet().GetScrollLockToggle())
 	{
-		bScrollLock_FullSpeed = g_bScrollLock_FullSpeed;
+		bScrollLock_FullSpeed = Win32Frame::GetWin32Frame().g_bScrollLock_FullSpeed;
 	}
 	else
 	{

--- a/source/Windows/Win32Frame.cpp
+++ b/source/Windows/Win32Frame.cpp
@@ -37,6 +37,39 @@ Win32Frame::Win32Frame()
 	g_win_fullscreen_scale = 1;
 	g_win_fullscreen_offsetx = 0;
 	g_win_fullscreen_offsety = 0;
+
+	btnfacebrush = (HBRUSH)0;
+	btnfacepen = (HPEN)0;
+	btnhighlightpen = (HPEN)0;
+	btnshadowpen = (HPEN)0;
+	buttonactive = -1;
+	buttondown = -1;
+	buttonover = -1;
+	buttonx = BUTTONX;
+	buttony = BUTTONY;
+	g_hFrameDC = (HDC)0;
+	framerect = { 0,0,0,0 };
+
+	helpquit = 0;
+	smallfont = (HFONT)0;
+	tooltipwindow = (HWND)0;
+	viewportx = VIEWPORTX;	// Default to Normal (non-FullScreen) mode
+	viewporty = VIEWPORTY;	// Default to Normal (non-FullScreen) mode
+
+	g_bScrollLock_FullSpeed = false;
+
+	g_nTrackDrive1 = -1;
+	g_nTrackDrive2 = -1;
+	g_nSectorDrive1 = -1;
+	g_nSectorDrive2 = -1;
+
+	g_eStatusDrive1 = DISK_STATUS_OFF;
+	g_eStatusDrive2 = DISK_STATUS_OFF;
+
+	g_nViewportCX = GetVideo().GetFrameBufferBorderlessWidth() * kDEFAULT_VIEWPORT_SCALE;
+	g_nViewportCY = GetVideo().GetFrameBufferBorderlessHeight() * kDEFAULT_VIEWPORT_SCALE;
+	g_nViewportScale = kDEFAULT_VIEWPORT_SCALE; // saved REGSAVE
+	g_nMaxViewportScale = kDEFAULT_VIEWPORT_SCALE;	// Max scale in Windowed mode with borders, buttons etc (full-screen may be +1)
 }
 
 void Win32Frame::videoCreateDIBSection(Video & video)

--- a/source/Windows/Win32Frame.cpp
+++ b/source/Windows/Win32Frame.cpp
@@ -1,7 +1,6 @@
 #include "StdAfx.h"
 
 #include "Windows/Win32Frame.h"
-#include "Windows/WinFrame.h"
 #include "Interface.h"
 #include "Core.h"
 #include "CPU.h"

--- a/source/Windows/Win32Frame.h
+++ b/source/Windows/Win32Frame.h
@@ -2,7 +2,6 @@
 
 #include "FrameBase.h"
 #include "DiskImage.h"
-#include "Windows/WinFrame.h"
 
 class Video;
 
@@ -29,6 +28,7 @@ public:
 	Win32Frame();
 
 	static Win32Frame& GetWin32Frame();
+	static LRESULT CALLBACK FrameWndProc(HWND window, UINT message, WPARAM wparam, LPARAM lparam);
 
 	virtual void FrameDrawDiskLEDS();
 	virtual void FrameDrawDiskStatus();
@@ -65,12 +65,11 @@ public:
 	HDC FrameGetDC();
 	void FrameReleaseDC();
 
-	LRESULT WndProc(HWND   window, UINT   message, WPARAM wparam, LPARAM lparam);
-
 	bool	g_bScrollLock_FullSpeed;
 
 private:
 	static BOOL CALLBACK DDEnumProc(LPGUID lpGUID, LPCTSTR lpszDesc, LPCTSTR lpszDrvName, LPVOID lpContext);
+	LRESULT WndProc(HWND   window, UINT   message, WPARAM wparam, LPARAM lparam);
 
 	void videoCreateDIBSection(Video& video);
 	void VideoDrawLogoBitmap(HDC hDstDC, int xoff, int yoff, int srcw, int srch, int scale);

--- a/source/Windows/Win32Frame.h
+++ b/source/Windows/Win32Frame.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "FrameBase.h"
+#include "DiskImage.h"
+#include "Windows/WinFrame.h"
 
 class Video;
 
@@ -9,6 +11,17 @@ class Video;
 #else
 #define FULLSCREEN_SCALE_TYPE int
 #endif
+
+// 3D border around the 560x384 Apple II display
+#define  VIEWPORTX   5
+#define  VIEWPORTY   5
+
+#define  BUTTONX     (g_nViewportCX + VIEWPORTX*2)
+#define  BUTTONY     0
+#define  BUTTONCX    45
+#define  BUTTONCY    45
+#define  BUTTONS     8
+
 
 class Win32Frame : public FrameBase
 {
@@ -44,8 +57,17 @@ public:
 	void ChooseMonochromeColor(void);
 	UINT Get3DBorderWidth(void);
 	UINT Get3DBorderHeight(void);
+	int GetViewportScale(void);
+	void GetViewportCXCY(int& nViewportCX, int& nViewportCY);
+
 	void ApplyVideoModeChange(void);
+
+	HDC FrameGetDC();
+	void FrameReleaseDC();
+
 	LRESULT WndProc(HWND   window, UINT   message, WPARAM wparam, LPARAM lparam);
+
+	bool	g_bScrollLock_FullSpeed;
 
 private:
 	static BOOL CALLBACK DDEnumProc(LPGUID lpGUID, LPCTSTR lpszDesc, LPCTSTR lpszDrvName, LPVOID lpContext);
@@ -64,6 +86,8 @@ private:
 	void DrawCrosshairs(int x, int y);
 	void DrawFrameWindow(bool bPaintingWindow = false);
 	void DrawStatusArea(HDC passdc, int drawflags);
+	void Draw3dRect(HDC dc, int x1, int y1, int x2, int y2, BOOL out);
+	void DrawBitmapRect(HDC dc, int x, int y, LPRECT rect, HBITMAP bitmap);
 	void ProcessButtonClick(int button, bool bFromButtonUI = false);
 	bool ConfirmReboot(bool bFromButtonUI);
 	void ProcessDiskPopupMenu(HWND hwnd, POINT pt, const int iDrive);
@@ -79,8 +103,10 @@ private:
 	void DrawCrosshairsMouse();
 	void FrameSetCursorPosByMousePos(int x, int y, int dx, int dy, bool bLeavingAppleScreen);
 	void CreateGdiObjects(void);
+	void DeleteGdiObjects(void);
 	void FrameShowCursor(BOOL bShow);
 	void FullScreenRevealCursor(void);
+	void GetWidthHeight(int& nWidth, int& nHeight);
 
 	bool g_bAltEnter_ToggleFullScreen; // Default for ALT+ENTER is to toggle between windowed and full-screen modes
 	bool    g_bIsFullScreen;
@@ -108,4 +134,56 @@ private:
 	GUID draw_device_guid[MAX_DRAW_DEVICES];
 	int num_draw_devices;
 	LPDIRECTDRAW g_lpDD;
+
+	HBITMAP buttonbitmap[BUTTONS];
+
+	HBRUSH  btnfacebrush;
+	HPEN    btnfacepen;
+	HPEN    btnhighlightpen;
+	HPEN    btnshadowpen;
+	int     buttonactive;
+	int     buttondown;
+	int     buttonover;
+	int     buttonx;
+	int     buttony;
+	HDC     g_hFrameDC;
+	RECT    framerect;
+
+	BOOL    helpquit;
+	HFONT   smallfont;
+	HWND    tooltipwindow;
+	int     viewportx;	// Default to Normal (non-FullScreen) mode
+	int     viewporty;	// Default to Normal (non-FullScreen) mode
+
+	RECT	g_main_window_saved_rect;
+	int		g_main_window_saved_style;
+	int		g_main_window_saved_exstyle;
+
+
+	HBITMAP g_hCapsLockBitmap[2];
+	HBITMAP g_hHardDiskBitmap[2];
+
+	//Pravets8 only
+	HBITMAP g_hCapsBitmapP8[2];
+	HBITMAP g_hCapsBitmapLat[2];
+	//HBITMAP charsetbitmap [4]; //The idea was to add a charset indicator on the front panel, but it was given up. All charsetbitmap occurences must be REMOVED!
+	//===========================
+	HBITMAP g_hDiskWindowedLED[NUM_DISK_STATUS];
+
+	int    g_nTrackDrive1;
+	int    g_nTrackDrive2;
+	int    g_nSectorDrive1;
+	int    g_nSectorDrive2;
+	TCHAR  g_sTrackDrive1[8] = TEXT("??");
+	TCHAR  g_sTrackDrive2[8] = TEXT("??");
+	TCHAR  g_sSectorDrive1[8] = TEXT("??");
+	TCHAR  g_sSectorDrive2[8] = TEXT("??");
+	Disk_Status_e g_eStatusDrive1;
+	Disk_Status_e g_eStatusDrive2;
+
+	static const int kDEFAULT_VIEWPORT_SCALE = 2;
+	int g_nViewportCX;
+	int g_nViewportCY;
+	int g_nViewportScale; // saved REGSAVE
+	int g_nMaxViewportScale;	// Max scale in Windowed mode with borders, buttons etc (full-screen may be +1)
 };

--- a/source/Windows/WinFrame.cpp
+++ b/source/Windows/WinFrame.cpp
@@ -28,7 +28,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include "StdAfx.h"
 
-#include "Windows/WinFrame.h"
 #include "Windows/Win32Frame.h"
 #include "Windows/AppleWin.h"
 #include "Interface.h"
@@ -888,7 +887,7 @@ void Win32Frame::EraseButton (int number) {
 
 //===========================================================================
 
-LRESULT CALLBACK FrameWndProc(
+LRESULT CALLBACK Win32Frame::FrameWndProc(
 	HWND   window,
 	UINT   message,
 	WPARAM wparam,

--- a/source/Windows/WinFrame.h
+++ b/source/Windows/WinFrame.h
@@ -1,7 +1,0 @@
-#pragma once
-
-	LRESULT CALLBACK FrameWndProc (
-		HWND   window,
-		UINT   message,
-		WPARAM wparam,
-		LPARAM lparam );

--- a/source/Windows/WinFrame.h
+++ b/source/Windows/WinFrame.h
@@ -1,20 +1,5 @@
 #pragma once
 
-// Win32
-	extern int        g_nViewportCX;
-	extern int        g_nViewportCY;
-
-
-// Emulator
-	extern bool   g_bScrollLock_FullSpeed;
-
-
-// Prototypes
-	HDC     FrameGetDC ();
-	void    FrameReleaseDC ();
-	int		GetViewportScale(void);
-	void	GetViewportCXCY(int& nViewportCX, int& nViewportCY);
-
 	LRESULT CALLBACK FrameWndProc (
 		HWND   window,
 		UINT   message,


### PR DESCRIPTION
After this

- ``Win32Frame.cpp`` and ``WinFrame.cpp`` should be merged back
- Rename class ``Win32Frame`` -> ``WinFrame``?
- If there is a fear that ``Win32Frame::GetWin32Frame`` is expensive (``dynamic_cast``), I can remove it. (safely)