### PR TITLE
SpkrSetEmulationType: simplify logic and remove unreachable code.

### DIFF
--- a/source/Configuration/PageSound.cpp
+++ b/source/Configuration/PageSound.cpp
@@ -139,11 +139,9 @@ void CPageSound::DlgOK(HWND hWnd)
 	const DWORD dwSpkrVolume = SendDlgItemMessage(hWnd, IDC_SPKR_VOLUME, TBM_GETPOS, 0, 0);
 	const DWORD dwMBVolume = SendDlgItemMessage(hWnd, IDC_MB_VOLUME, TBM_GETPOS, 0, 0);
 
-	if (SpkrSetEmulationType(hWnd, newSoundType))
-	{
-		DWORD dwSoundType = (soundtype == SOUND_NONE) ? REG_SOUNDTYPE_NONE : REG_SOUNDTYPE_WAVE;
-		REGSAVE(TEXT(REGVALUE_SOUND_EMULATION), dwSoundType);
-	}
+	SpkrSetEmulationType(newSoundType);
+	DWORD dwSoundType = (soundtype == SOUND_NONE) ? REG_SOUNDTYPE_NONE : REG_SOUNDTYPE_WAVE;
+	REGSAVE(TEXT(REGVALUE_SOUND_EMULATION), dwSoundType);
 
 	// NB. Volume: 0=Loudest, VOLUME_MAX=Silence
 	SpkrSetVolume(dwSpkrVolume, VOLUME_MAX);

--- a/source/Speaker.cpp
+++ b/source/Speaker.cpp
@@ -280,32 +280,13 @@ void SpkrReset()
 
 //=============================================================================
 
-BOOL SpkrSetEmulationType (HWND window, SoundType_e newtype)
+void SpkrSetEmulationType (SoundType_e newtype)
 {
   SpkrDestroy();	// GH#295: Destroy for all types (even SOUND_NONE)
 
   soundtype = newtype;
   if (soundtype != SOUND_NONE)
     SpkrInitialize();
-
-  if (soundtype != newtype)
-    switch (newtype) {
-
-      case SOUND_WAVE:
-        MessageBox(window,
-                   TEXT("The emulator is unable to initialize a waveform ")
-                   TEXT("output device.  Make sure you have a sound card ")
-                   TEXT("and a driver installed and that windows is ")
-                   TEXT("correctly configured to use the driver.  Also ")
-                   TEXT("ensure that no other program is currently using ")
-                   TEXT("the device."),
-                   TEXT("Configuration"),
-                   MB_ICONEXCLAMATION | MB_SETFOREGROUND);
-        return 0;
-
-    }
-
-  return 1;
 }
 
 //=============================================================================

--- a/source/Speaker.cpp
+++ b/source/Speaker.cpp
@@ -241,6 +241,18 @@ void SpkrInitialize ()
 	else
 	{
 		g_bSpkrAvailable = Spkr_DSInit();
+		if (!g_bSpkrAvailable)
+		{
+			GetFrame().FrameMessageBox(
+				TEXT("The emulator is unable to initialize a waveform ")
+				TEXT("output device.  Make sure you have a sound card ")
+				TEXT("and a driver installed and that Windows is ")
+				TEXT("correctly configured to use the driver.  Also ")
+				TEXT("ensure that no other program is currently using ")
+				TEXT("the device."),
+				TEXT("Configuration"),
+				MB_ICONEXCLAMATION | MB_SETFOREGROUND);
+		}
 	}
 
 	//

--- a/source/Speaker.h
+++ b/source/Speaker.h
@@ -21,7 +21,7 @@ void    SpkrDestroy ();
 void    SpkrInitialize ();
 void    SpkrReinitialize ();
 void    SpkrReset();
-BOOL    SpkrSetEmulationType (HWND window, SoundType_e newSoundType);
+void    SpkrSetEmulationType (SoundType_e newSoundType);
 void    SpkrUpdate (DWORD);
 void    SpkrUpdate_Timer();
 DWORD   SpkrGetVolume();


### PR DESCRIPTION
The check (soundtype != newtype) is always false.

So we can remove dependency on a HWND argument.