### PR TITLE
Alternative way to handle UTF-8 in Pravets printer conversion

### DIFF
--- a/source/Pravets.cpp
+++ b/source/Pravets.cpp
@@ -34,6 +34,9 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "Keyboard.h"
 #include "Tape.h"
 
+const char Pravets::m_Lat8A[] = "abwgdevzijklmnoprstufhc~{}yx`q|";
+const char Pravets::m_Lat82[] = "abwgdevzijklmnoprstufhc^[]yx@q{}~`";
+
 Pravets::Pravets(void)
 {
 	// Pravets 8A
@@ -42,6 +45,56 @@ Pravets::Pravets(void)
 	// Pravets 8A/8C
 	P8CAPS_ON = false;
 	P8Shift = false;
+
+								//"abwgdevzijklmnoprstufhc~{}yx`q|" = Lat8A[]
+	const char Kir8ACapital[]	= "ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÜÞßÝ";
+	const char Kir8ALowerCase[]	= "àáâãäåæçèéêëìíîïðñòóôõö÷øùúüþÿý";
+	m_Kir8ACapital = ConvertUtf8ToAnsi(Kir8ACapital);
+	m_Kir8ALowerCase = ConvertUtf8ToAnsi(Kir8ALowerCase);
+	//
+								//"abwgdevzijklmnoprstufhc^[]yx@q{}~`" = Lat82[]
+	const char Kir82[]			= "ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÜÞß[]^@";
+	m_Kir82 = ConvertUtf8ToAnsi(Kir82);
+}
+
+char* Pravets::ConvertUtf8ToAnsi(const char* pUTF8)
+{
+	char* pAnsi = NULL;
+	WCHAR* pWC = NULL;
+
+	try
+	{
+		// 1) UTF-8 -> unicode
+		{
+			int size = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, pUTF8, -1, NULL, 0);
+			if (size == 0)
+				throw false;
+			pWC = new WCHAR[size];
+			int res = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, pUTF8, -1, pWC, size);
+			if (!res)
+				throw false;
+		}
+
+		// 2) unicode -> ANSI
+		{
+			// NB. WC_ERR_INVALID_CHARS only defined when WIN_VER >= 0x600 - but stdafx.h defines it as 0x500
+			int size = WideCharToMultiByte(CP_ACP, 0/*WC_ERR_INVALID_CHARS*/, pWC, -1, NULL, 0, NULL, NULL);
+			if (size == 0)
+				throw false;
+			pAnsi = new char[size];
+			int res = WideCharToMultiByte(CP_ACP, 0/*WC_ERR_INVALID_CHARS*/, pWC, -1, pAnsi, size, NULL, NULL);
+			if (!res)
+				throw false;
+		}
+	}
+	catch(bool)
+	{
+		delete [] pAnsi;
+		pAnsi = NULL;
+	}
+
+	delete [] pWC;
+	return pAnsi;
 }
 
 void Pravets::Reset(void)
@@ -208,15 +261,9 @@ BYTE Pravets::ConvertToKeycode(WPARAM key, BYTE keycode)
 
 BYTE Pravets::ConvertToPrinterChar(BYTE value)
 {
-	char Lat8A[]= "abwgdevzijklmnoprstufhc~{}yx`q|]";
-	char Lat82[]= "abwgdevzijklmnoprstufhc^[]yx@q{}~`";
-	char Kir82[]= "ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÜÞß[]^@";
-	char Kir8ACapital[]= "ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÜÞßÝ";
-	char Kir8ALowerCase[]= "àáâãäåæçèéêëìíîïðñòóôõö÷øùúüþÿý";
-
 	BYTE c = 0;
 
-	if (GetApple2Type() == A2TYPE_PRAVETS8A)  //This is print conversion for Pravets 8A/C. Print conversion for Pravets82/M is still to be done.
+	if (GetApple2Type() == A2TYPE_PRAVETS8A)  // Print conversion for Pravets 8A/C
 	{
 		if ((value > 90) && (value < 128)) //This range shall be set more precisely
 		{
@@ -224,8 +271,8 @@ BYTE Pravets::ConvertToPrinterChar(BYTE value)
 			int loop = 0;
 			while (loop < 31)
 			{
-				if (c == Lat8A[loop])
-					c = Kir8ALowerCase[loop];
+				if (c == m_Lat8A[loop])
+					c = m_Kir8ALowerCase[loop];
 				loop++;
 			}
 		}
@@ -239,20 +286,20 @@ BYTE Pravets::ConvertToPrinterChar(BYTE value)
 			int loop = 0;
 			while (loop < 31)
 			{
-				if (c == Lat8A[loop])
-					c = Kir8ACapital[loop];
+				if (c == m_Lat8A[loop])
+					c = m_Kir8ACapital[loop];
 				loop++;
 			}
 		}
 	}
-	else if (GetApple2Type() == A2TYPE_PRAVETS82 || GetApple2Type() == A2TYPE_PRAVETS8M)
+	else if (GetApple2Type() == A2TYPE_PRAVETS82 || GetApple2Type() == A2TYPE_PRAVETS8M)	// Print conversion for Pravets82/M
 	{
 		c = value & 0x7F;
 		int loop = 0;
 		while (loop < 34)
 		{
-			if (c == Lat82[loop])
-				c = Kir82[loop];
+			if (c == m_Lat82[loop])
+				c = m_Kir82[loop];
 			loop++;
 		}
 	}

--- a/source/Pravets.h
+++ b/source/Pravets.h
@@ -17,7 +17,16 @@ public:
 	BYTE ConvertToPrinterChar(BYTE value);
 
 private:
+	char* ConvertUtf8ToAnsi(const char* pUTF8);
+
 	bool g_CapsLockAllowed;
 	bool P8CAPS_ON;
 	bool P8Shift;
+
+	static const char m_Lat8A[];
+	static const char m_Lat82[];
+
+	char* m_Kir8ACapital;
+	char* m_Kir8ALowerCase;
+	char* m_Kir82;
 };


### PR DESCRIPTION
Just convert the UTF-8 strings to Ansi.

Also trimmed the Lat8A ASCII string by 1 char, so that it matches the 2 upper/lowercase Kir8A strings.