### PR TITLE
Enable ConformanceMode in VS2019.

### DIFF
--- a/AppleWinExpress2019.vcxproj
+++ b/AppleWinExpress2019.vcxproj
@@ -441,6 +441,7 @@
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <BasicRuntimeChecks>Default</BasicRuntimeChecks>
+      <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -469,6 +470,7 @@
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <BasicRuntimeChecks>Default</BasicRuntimeChecks>
       <DisableSpecificWarnings>4995</DisableSpecificWarnings>
+      <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -495,6 +497,7 @@
       <AdditionalIncludeDirectories>source;source\cpu;source\debugger;zlib;zip_lib;libyaml\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -524,6 +527,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -557,6 +561,7 @@
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>4995</DisableSpecificWarnings>
+      <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -589,6 +594,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/source/Configuration/PropertySheetHelper.cpp
+++ b/source/Configuration/PropertySheetHelper.cpp
@@ -150,7 +150,7 @@ void CPropertySheetHelper::SetSlot(UINT slot, SS_CARDTYPE newCardType)
 // Used by:
 // . CPageDisk:		IDC_CIDERPRESS_BROWSE
 // . CPageAdvanced:	IDC_PRINTER_DUMP_FILENAME_BROWSE
-std::string CPropertySheetHelper::BrowseToFile(HWND hWindow, TCHAR* pszTitle, TCHAR* REGVALUE, TCHAR* FILEMASKS)
+std::string CPropertySheetHelper::BrowseToFile(HWND hWindow, const TCHAR* pszTitle, const TCHAR* REGVALUE, const TCHAR* FILEMASKS)
 {
 	TCHAR szFilename[MAX_PATH];
 	RegLoadString(REG_CONFIG, REGVALUE, 1, szFilename, MAX_PATH, TEXT(""));
@@ -189,7 +189,7 @@ void CPropertySheetHelper::SaveStateUpdate()
 }
 
 // NB. OK'ing this property sheet will call SaveStateUpdate()->Snapshot_SetFilename() with this new path & filename
-int CPropertySheetHelper::SaveStateSelectImage(HWND hWindow, TCHAR* pszTitle, bool bSave)
+int CPropertySheetHelper::SaveStateSelectImage(HWND hWindow, const TCHAR* pszTitle, bool bSave)
 {
 	// Whenever harddisks/disks are inserted (or removed) and *if path has changed* then:
 	// . Snapshot's path & Snapshot's filename will be updated to reflect the new defaults.

--- a/source/Configuration/PropertySheetHelper.h
+++ b/source/Configuration/PropertySheetHelper.h
@@ -15,9 +15,9 @@ public:
 
 	void FillComboBox(HWND window, int controlid, LPCTSTR choices, int currentchoice);
 	void SetSlot(UINT slot, SS_CARDTYPE newCardType);
-	std::string BrowseToFile(HWND hWindow, TCHAR* pszTitle, TCHAR* REGVALUE,TCHAR* FILEMASKS);
+	std::string BrowseToFile(HWND hWindow, const TCHAR* pszTitle, const TCHAR* REGVALUE, const TCHAR* FILEMASKS);
 	void SaveStateUpdate();
-	int SaveStateSelectImage(HWND hWindow, TCHAR* pszTitle, bool bSave);
+	int SaveStateSelectImage(HWND hWindow, const TCHAR* pszTitle, bool bSave);
 	void PostMsgAfterClose(HWND hWnd, PAGETYPE page);
 
 	void ResetPageMask(void) { m_bmPages = 0; }	// Req'd because cancelling doesn't clear the page-mask

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -4368,7 +4368,7 @@ Update_t CmdMemoryLoad (int nArgs)
 
 	struct KnownFileType_t
 	{
-		char *pExtension;
+		const char *pExtension;
 		int   nAddress;
 		int   nLength;
 	};
@@ -5005,7 +5005,7 @@ Update_t CmdNTSC (int nArgs)
 
 	struct KnownFileType_t
 	{
-		char *pExtension;
+		const char *pExtension;
 	};
 
 	enum KnownFileType_e
@@ -5032,9 +5032,9 @@ Update_t CmdNTSC (int nArgs)
 	assert( (nFileType == NUM_FILE_TYPES) );
 #endif
 
-	char *pFileName = (nArgs > 1) ? g_aArgs[ 2 ].sArg : "";
+	const char *pFileName = (nArgs > 1) ? g_aArgs[ 2 ].sArg : "";
 	int   nLen = strlen( pFileName );
-	char *pEnd = pFileName + nLen - 1;
+	const char *pEnd = pFileName + nLen - 1;
 	while( pEnd > pFileName )
 	{
 		if( *pEnd == '.' )
@@ -5558,7 +5558,7 @@ Update_t CmdNTSC (int nArgs)
 					}
 
 
-				size_t nRead = fread( pSwizzled, g_nChromaSize, 1, pFile );
+				fread( pSwizzled, g_nChromaSize, 1, pFile );
 
 				if( iFileType == TYPE_BMP )
 				{
@@ -8296,12 +8296,12 @@ void ProfileFormat( bool bExport, ProfileFormat_e eFormatMode )
 		bOpcodeGood = false;
 	}
 
-	char *pColorOperator = "";
-	char *pColorNumber   = "";
-	char *pColorOpcode   = "";
-	char *pColorMnemonic = "";
-	char *pColorOpmode   = "";
-	char *pColorTotal    = "";
+	const char *pColorOperator = "";
+	const char *pColorNumber   = "";
+	const char *pColorOpcode   = "";
+	const char *pColorMnemonic = "";
+	const char *pColorOpmode   = "";
+	const char *pColorTotal    = "";
 	if (! bExport)
 	{
 		pColorOperator = CHC_ARG_SEP; // grey
@@ -8700,7 +8700,7 @@ void DebugContinueStepping(const bool bCallerWillUpdateDisplay/*=false*/)
 		{
 			TCHAR sText[ CONSOLE_WIDTH ];
 			char szStopMessage[CONSOLE_WIDTH];
-			char* pszStopReason = szStopMessage;
+			const char* pszStopReason = szStopMessage;
 
 			if (regs.pc == g_nDebugStepUntil)
 				pszStopReason = TEXT("PC matches 'Go until' address");
@@ -8966,7 +8966,7 @@ void DebugInitialize ()
 	// Check all summary help to see if it fits within the console
 	for (int iCmd = 0; iCmd < NUM_COMMANDS; iCmd++ )
 	{	
-		char *pHelp = g_aCommands[ iCmd ].pHelpSummary;
+		const char *pHelp = g_aCommands[ iCmd ].pHelpSummary;
 		if (pHelp)
 		{
 			int nLen = _tcslen( pHelp ) + 2;

--- a/source/Debugger/Debug.h
+++ b/source/Debugger/Debug.h
@@ -150,7 +150,7 @@
 // Symbol Table / Memory
 	bool FindAddressFromSymbol( const char* pSymbol, WORD * pAddress_ = NULL, int * iTable_ = NULL );
 	WORD GetAddressFromSymbol( const char* symbol); // HACK: returns 0 if symbol not found
-	void SymbolUpdate( SymbolTable_Index_e eSymbolTable, char *pSymbolName, WORD nAddrss, bool bRemoveSymbol, bool bUpdateSymbol );
+	void SymbolUpdate( SymbolTable_Index_e eSymbolTable, const char *pSymbolName, WORD nAddrss, bool bRemoveSymbol, bool bUpdateSymbol );
 
 	const char* FindSymbolFromAddress( WORD nAdress, int * iTable_ = NULL );
 	const char* GetSymbol( WORD nAddress, int nBytes);

--- a/source/Debugger/Debugger_Assembler.h
+++ b/source/Debugger/Debugger_Assembler.h
@@ -172,7 +172,7 @@ extern	int g_aAssemblerFirstDirective[ NUM_ASSEMBLERS ];
 
 	struct AssemblerDirective_t
 	{
-		char  *m_pMnemonic;
+		const char  *m_pMnemonic;
 		Hash_t m_nHash;
 	};
 

--- a/source/Debugger/Debugger_DisassemblerData.cpp
+++ b/source/Debugger/Debugger_DisassemblerData.cpp
@@ -80,7 +80,7 @@ WORD _CmdDefineByteRange(int nArgs,int iArg,DisasmData_t & tData_)
 	tData_.nEndAddress = nAddress + nLen;
 //	tData_.nArraySize = 0;
 
-	char *pSymbolName = "";
+	const char *pSymbolName = "";
 	char aSymbolName[ MAX_SYMBOLS_LEN+1 ];
 	SymbolTable_Index_e eSymbolTable = SYMBOLS_ASSEMBLY;
 	bool bAutoDefineName = false; // 2.7.0.34
@@ -93,8 +93,8 @@ WORD _CmdDefineByteRange(int nArgs,int iArg,DisasmData_t & tData_)
 		}
 		else
 		{
-			pSymbolName = g_aArgs[ 1 ].sArg;
-			pSymbolName[MAX_SYMBOLS_LEN] = 0;	// truncate to max symbol length
+			g_aArgs[ 1 ].sArg[MAX_SYMBOLS_LEN] = 0;	// truncate to max symbol length
+			pSymbolName = g_aArgs[1].sArg;
 		}
 	}
 	else
@@ -167,7 +167,7 @@ Update_t CmdDisasmDataDefCode (int nArgs)
 	return UPDATE_DISASM | ConsoleUpdate();
 }
 
-char* g_aNopcodeTypes[ NUM_NOPCODE_TYPES ] =
+const char* g_aNopcodeTypes[ NUM_NOPCODE_TYPES ] =
 {
 	 "-n/a-"
 	,"byte1"

--- a/source/Debugger/Debugger_Display.cpp
+++ b/source/Debugger/Debugger_Display.cpp
@@ -140,12 +140,12 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 			\x19 Down
 	*/
 #if USE_APPLE_FONT
-	char * g_sConfigBranchIndicatorUp   [ NUM_DISASM_BRANCH_TYPES+1 ] = { " ", "^", "\x8B" }; // "`K" 0x4B
-	char * g_sConfigBranchIndicatorEqual[ NUM_DISASM_BRANCH_TYPES+1 ] = { " ", "=", "\x88" }; // "`H" 0x48
-	char * g_sConfigBranchIndicatorDown [ NUM_DISASM_BRANCH_TYPES+1 ] = { " ", "v", "\x8A" }; // "`J" 0x4A
+	const char * g_sConfigBranchIndicatorUp   [ NUM_DISASM_BRANCH_TYPES+1 ] = { " ", "^", "\x8B" }; // "`K" 0x4B
+	const char * g_sConfigBranchIndicatorEqual[ NUM_DISASM_BRANCH_TYPES+1 ] = { " ", "=", "\x88" }; // "`H" 0x48
+	const char * g_sConfigBranchIndicatorDown [ NUM_DISASM_BRANCH_TYPES+1 ] = { " ", "v", "\x8A" }; // "`J" 0x4A
 #else
-	char * g_sConfigBranchIndicatorUp   [ NUM_DISASM_BRANCH_TYPES+1 ] = { " ", "^", "\x35" };
-	char * g_sConfigBranchIndicatorEqual[ NUM_DISASM_BRANCH_TYPES+1 ] = { " ", "=", "\x33" };
+	const char * g_sConfigBranchIndicatorUp   [ NUM_DISASM_BRANCH_TYPES+1 ] = { " ", "^", "\x35" };
+	const char * g_sConfigBranchIndicatorEqual[ NUM_DISASM_BRANCH_TYPES+1 ] = { " ", "=", "\x33" };
 	char * g_sConfigBranchIndicatorDown [ NUM_DISASM_BRANCH_TYPES+1 ] = { " ", "v", "\x36" };
 #endif
 
@@ -2832,7 +2832,7 @@ void _DrawSoftSwitchAddress( RECT & rect, int nAddress, int bg_default = BG_INFO
 
 // 2.7.0.7 Cleaned up display of soft-switches to show address.
 //===========================================================================
-void _DrawSoftSwitch( RECT & rect, int nAddress, bool bSet, char *sPrefix, char *sOn, char *sOff, const char *sSuffix = NULL, int bg_default = BG_INFO )
+void _DrawSoftSwitch( RECT & rect, int nAddress, bool bSet, const char *sPrefix, const char *sOn, const char *sOff, const char *sSuffix = NULL, int bg_default = BG_INFO )
 {
 	RECT temp = rect;
 

--- a/source/Debugger/Debugger_Help.cpp
+++ b/source/Debugger/Debugger_Help.cpp
@@ -335,7 +335,7 @@ void _ColorizeString(
 // pOperator is one of CHC_*
 void _ColorizeOperator(
 	char * & pDst, const char * & pSrc,
-	char * pOperator )
+	const char * pOperator )
 {
 	int nLen;
 	
@@ -828,7 +828,7 @@ Update_t CmdHelpSpecific (int nArgs)
 		
 		if (pCommand)
 		{
-			char *pHelp = pCommand->pHelpSummary;
+			const char *pHelp = pCommand->pHelpSummary;
 			if (pHelp)
 			{
 				if (bCategory)

--- a/source/Debugger/Debugger_Symbols.cpp
+++ b/source/Debugger/Debugger_Symbols.cpp
@@ -42,7 +42,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 // Symbols ________________________________________________________________________________________
 
-	char*     g_sFileNameSymbols[ NUM_SYMBOL_TABLES ] = {
+	const char*     g_sFileNameSymbols[ NUM_SYMBOL_TABLES ] = {
 		 "APPLE2E.SYM"
 		,"A2_BASIC.SYM"
 		,"A2_ASM.SYM"
@@ -55,7 +55,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 	};
 	std::string  g_sFileNameSymbolsUser;
 
-	char * g_aSymbolTableNames[ NUM_SYMBOL_TABLES ] =
+	const char * g_aSymbolTableNames[ NUM_SYMBOL_TABLES ] =
 	{
 		 "Main"
 		,"Basic"
@@ -833,7 +833,7 @@ Update_t _CmdSymbolsClear( SymbolTable_Index_e eSymbolTable )
 
 
 //===========================================================================
-void SymbolUpdate( SymbolTable_Index_e eSymbolTable, char *pSymbolName, WORD nAddress, bool bRemoveSymbol, bool bUpdateSymbol )
+void SymbolUpdate( SymbolTable_Index_e eSymbolTable, const char *pSymbolName, WORD nAddress, bool bRemoveSymbol, bool bUpdateSymbol )
 {
 	if (bRemoveSymbol)
 		pSymbolName = g_aArgs[2].sArg;

--- a/source/Debugger/Debugger_Types.h
+++ b/source/Debugger/Debugger_Types.h
@@ -270,7 +270,7 @@
 		char         m_sName[ MAX_COMMAND_LEN ];
 		CmdFuncPtr_t pFunction;
 		int          iCommand;     // offset (enum) for direct command name lookup
-		char        *pHelpSummary; // 1 line help summary
+		const char   *pHelpSummary; // 1 line help summary
 //		Hash_t       m_nHash; // TODO
 	};
 

--- a/source/SoundCore.cpp
+++ b/source/SoundCore.cpp
@@ -80,7 +80,7 @@ static BOOL CALLBACK DSEnumProc(LPGUID lpGUID, LPCTSTR lpszDesc, LPCTSTR lpszDrv
 //-----------------------------------------------------------------------------
 
 #ifdef _DEBUG
-static char *DirectSound_ErrorText (HRESULT error)
+static const char *DirectSound_ErrorText (HRESULT error)
 {
     switch( error )
     {


### PR DESCRIPTION
This reduces the chances of incompatibility between gcc and vs.

99% is "const char *" literals.
1 case of a goto jumping over a variable declaration.