### PR TITLE
Debugger: fix bound on maximum bytes to move backward.

### DIFF
--- a/source/Debugger/Debugger_Disassembler.cpp
+++ b/source/Debugger/Debugger_Disassembler.cpp
@@ -627,7 +627,7 @@ void FormatDisassemblyLine(const DisasmLine_t& line, char* sDisassembly, const i
 //===========================================================================
 void DisasmCalcTopFromCurAddress(bool bUpdateTop)
 {
-	int nLen = ((g_nDisasmWinHeight - g_nDisasmCurLine) * 3); // max 3 opcodes/instruction, is our search window
+	int nLen = g_nDisasmCurLine * 3; // max 3 opcodes/instruction, is our search window
 
 	// Look for a start address that when disassembled,
 	// will have the cursor on the specified line and address


### PR DESCRIPTION
The higher g_nDisasmCurLine the more we will have to travel back to find the instruction at the top of the window.

In AppleWin it does not matter because the line is halfway and so the result is the same.
