### PR TITLE
Drag and drop / double-click support for .po and .hdv images

### DIFF
--- a/source/Disk.h
+++ b/source/Disk.h
@@ -142,7 +142,7 @@ public:
 	void GetFilenameAndPathForSaveState(std::string& filename, std::string& path);
 	void GetLightStatus (Disk_Status_e* pDisk1Status, Disk_Status_e* pDisk2Status);
 
-	ImageError_e InsertDisk(const int drive, LPCTSTR pszImageFilename, const bool bForceWriteProtected, const bool bCreateIfNecessary);
+	ImageError_e InsertDisk(const int drive, LPCTSTR pszImageFilename, const bool bForceWriteProtected, const bool bCreateIfNecessary, ImageInfo* pImageInfo = NULL);
 	void EjectDisk(const int drive);
 	void UnplugDrive(const int drive);
 

--- a/source/DiskImage.cpp
+++ b/source/DiskImage.cpp
@@ -68,7 +68,11 @@ ImageError_e ImageOpen(	const std::string & pszImageFilename,
 	if (pImageInfo->pImageType && pImageInfo->pImageType->GetType() == eImageHDV)
 	{
 		if (bExpectFloppy)
+		{
 			Err = eIMAGE_ERROR_UNSUPPORTED_HDV;
+			ImageClose(*ppImageInfo);
+			*ppImageInfo = NULL;
+		}
 		return Err;
 	}
 

--- a/source/Harddisk.cpp
+++ b/source/Harddisk.cpp
@@ -207,8 +207,6 @@ static void NotifyInvalidImage(TCHAR* pszImageFilename)
 
 //===========================================================================
 
-BOOL HD_Insert(const int iDrive, const std::string & pszImageFilename);
-
 void HD_LoadLastDiskImage(const int iDrive)
 {
 	_ASSERT(iDrive == HARDDISK_1 || iDrive == HARDDISK_2);
@@ -385,7 +383,7 @@ void HD_Destroy(void)
 }
 
 // Pre: pszImageFilename is qualified with path
-BOOL HD_Insert(const int iDrive, const std::string & pszImageFilename)
+BOOL HD_Insert(const int iDrive, const std::string & pszImageFilename, ImageInfo* pImageInfo /* = NULL */)
 {
 	if (pszImageFilename.empty())
 		return FALSE;
@@ -409,15 +407,26 @@ BOOL HD_Insert(const int iDrive, const std::string & pszImageFilename)
 		}
 	}
 
-	const bool bCreateIfNecessary = false;		// NB. Don't allow creation of HDV files
-	const bool bExpectFloppy = false;
-	const bool bIsHarddisk = true;
-	ImageError_e Error = ImageOpen(pszImageFilename,
-		&g_HardDisk[iDrive].imagehandle,
-		&g_HardDisk[iDrive].bWriteProtected,
-		bCreateIfNecessary,
-		g_HardDisk[iDrive].strFilenameInZip,	// TODO: Use this
-		bExpectFloppy);
+	ImageError_e Error = eIMAGE_ERROR_NONE;
+	if (pImageInfo)
+	{
+		// Use already opened image
+		g_HardDisk[iDrive].imagehandle = pImageInfo;
+		g_HardDisk[iDrive].bWriteProtected = pImageInfo->bWriteProtected;
+	}
+	else
+	{
+		// Open new image
+		const bool bCreateIfNecessary = false;		// NB. Don't allow creation of HDV files
+		const bool bExpectFloppy = false;
+		const bool bIsHarddisk = true;
+		Error = ImageOpen(pszImageFilename,
+			&g_HardDisk[iDrive].imagehandle,
+			&g_HardDisk[iDrive].bWriteProtected,
+			bCreateIfNecessary,
+			g_HardDisk[iDrive].strFilenameInZip,	// TODO: Use this
+			bExpectFloppy);
+	}
 
 	g_HardDisk[iDrive].hd_imageloaded = (Error == eIMAGE_ERROR_NONE);
 

--- a/source/Harddisk.h
+++ b/source/Harddisk.h
@@ -44,7 +44,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 	void HD_Reset(void);
 	void HD_Load_Rom(const LPBYTE pCxRomPeripheral, const UINT uSlot);
 	bool HD_Select(const int iDrive);
-	BOOL HD_Insert(const int iDrive, const std::string & pszImageFilename);
+	BOOL HD_Insert(const int iDrive, const std::string & pszImageFilename, ImageInfo* pImageInfo = NULL);
 	void HD_Unplug(const int iDrive);
 	bool HD_IsDriveUnplugged(const int iDrive);
 	void HD_LoadLastDiskImage(const int iDrive);

--- a/source/Windows/WinFrame.cpp
+++ b/source/Windows/WinFrame.cpp
@@ -1078,6 +1078,14 @@ LRESULT Win32Frame::WndProc(
 					ProcessButtonClick(BTN_RUN);
 				}
 			}
+			else if (Error == eIMAGE_ERROR_UNSUPPORTED_HDV)
+			{
+				if (HD_CardIsEnabled() && DoHardDiskInsert(HARDDISK_1, filename))
+				{
+					SetForegroundWindow(window);
+					ProcessButtonClick(BTN_RUN);
+				}
+			}
 			else
 			{
 				disk2Card.NotifyInvalidImage(iDrive, filename, Error);


### PR DESCRIPTION
Discussion with Nick/@sicklittlemonkey in email:

> [Tom] In the 2x Windowed-mode we have spare space to add more icons, so we could just add 2 more for slot-7 HDD/PO devices 1 & 2. Most people must have a display that capable of 2x Windowed-mode these days!

[Nick] Hmm, a very good point, and in fact I always use AppleWin in 2x mode. Although I was just thinking about it when your email arrived - the regular drive icons could do double duty to cover non-2x mode. If you drop a large image on it, it should just mount to the appropriate HD. That's reasonable default behaviour. And hover could give info for both the respective drive & HD. Right clicking could have an eject (and eventually select ...) option for the respective HD too. 

 > [Tom] or **better** perhaps reboot with Open Apple pressed (which the HDD firmware detects and skips to the $C600 firmware)

[Nick] Ah! I didn't know that! Obvious but super handy! Hmm, it could probably be made even handier ... like a prompt. Maybe it's going too far, but an option to decide slot 7 boot behaviour might be nice. Alt to skip, Alt to boot, or prompt.

> [Tom] or **even better** maybe the "Open Apple press" is just the default in this case (so we dispense with the Message box).

[Nick] Yes, I agree. I think in the double-click and drop in main window cases, we should direct the card to boot. 

 I was thinking it looks like a simple approach might be:
- `WM_DDE_EXECUTE` and `WM_DROPFILES` could call a common function
- That would call `ImageOpen()` to analyse the image and decide which card to use
- `InsertDisk()` and `HD_Insert()` could be refactored to have variants which take an `ImageInfo*`