### PR TITLE
Fix to sound not working in modern environments.

### DIFF
--- a/source/Mockingboard.cpp
+++ b/source/Mockingboard.cpp
@@ -1007,10 +1007,11 @@ static void MB_UpdateInt(void)
 	DWORD dwDSLockedBufferSize0, dwDSLockedBufferSize1;
 	SHORT *pDSLockedBuffer0, *pDSLockedBuffer1;
 
-	if(!DSGetLock(MockingboardVoice.lpDSBvoice,
-						dwByteOffset, (DWORD)nNumSamples*sizeof(short)*g_nMB_NumChannels,
-						&pDSLockedBuffer0, &dwDSLockedBufferSize0,
-						&pDSLockedBuffer1, &dwDSLockedBufferSize1))
+	hr = DSGetLock(MockingboardVoice.lpDSBvoice,
+		dwByteOffset, (DWORD)nNumSamples * sizeof(short) * g_nMB_NumChannels,
+		&pDSLockedBuffer0, &dwDSLockedBufferSize0,
+		&pDSLockedBuffer1, &dwDSLockedBufferSize1);
+	if (FAILED(hr))
 		return;
 
 	memcpy(pDSLockedBuffer0, &g_nMixBuffer[0], dwDSLockedBufferSize0);

--- a/source/SSI263.cpp
+++ b/source/SSI263.cpp
@@ -614,10 +614,11 @@ void SSI263::Update(void)
 	DWORD dwDSLockedBufferSize0, dwDSLockedBufferSize1;
 	short *pDSLockedBuffer0, *pDSLockedBuffer1;
 
-	if (!DSGetLock(SSI263SingleVoice.lpDSBvoice,
-						m_byteOffset, (DWORD)nNumSamples*sizeof(short)*m_kNumChannels,
-						&pDSLockedBuffer0, &dwDSLockedBufferSize0,
-						&pDSLockedBuffer1, &dwDSLockedBufferSize1))
+	hr = DSGetLock(SSI263SingleVoice.lpDSBvoice,
+		m_byteOffset, (DWORD)nNumSamples * sizeof(short) * m_kNumChannels,
+		&pDSLockedBuffer0, &dwDSLockedBufferSize0,
+		&pDSLockedBuffer1, &dwDSLockedBufferSize1);
+	if (FAILED(hr))
 		return;
 
 	memcpy(pDSLockedBuffer0, &m_mixBufferSSI263[0], dwDSLockedBufferSize0);

--- a/source/SoundCore.cpp
+++ b/source/SoundCore.cpp
@@ -124,14 +124,14 @@ static const char *DirectSound_ErrorText (HRESULT error)
 
 //-----------------------------------------------------------------------------
 
-bool DSGetLock(LPDIRECTSOUNDBUFFER pVoice, DWORD dwOffset, DWORD dwBytes,
+HRESULT DSGetLock(LPDIRECTSOUNDBUFFER pVoice, DWORD dwOffset, DWORD dwBytes,
 					  SHORT** ppDSLockedBuffer0, DWORD* pdwDSLockedBufferSize0,
 					  SHORT** ppDSLockedBuffer1, DWORD* pdwDSLockedBufferSize1)
 {
 	DWORD nStatus;
 	HRESULT hr = pVoice->GetStatus(&nStatus);
 	if(hr != DS_OK)
-		return false;
+		return hr;
 
 	if(nStatus & DSBSTATUS_BUFFERLOST)
 	{
@@ -151,7 +151,7 @@ bool DSGetLock(LPDIRECTSOUNDBUFFER pVoice, DWORD dwOffset, DWORD dwBytes,
 								(void**)ppDSLockedBuffer0, pdwDSLockedBufferSize0,
 								(void**)ppDSLockedBuffer1, pdwDSLockedBufferSize1,
 								DSBLOCK_ENTIREBUFFER)))
-			return false;
+			return hr;
 	}
 	else
 	{
@@ -159,10 +159,10 @@ bool DSGetLock(LPDIRECTSOUNDBUFFER pVoice, DWORD dwOffset, DWORD dwBytes,
 								(void**)ppDSLockedBuffer0, pdwDSLockedBufferSize0,
 								(void**)ppDSLockedBuffer1, pdwDSLockedBufferSize1,
 								0)))
-			return false;
+			return hr;
 	}
 
-	return true;
+	return hr;
 }
 
 //-----------------------------------------------------------------------------

--- a/source/SoundCore.h
+++ b/source/SoundCore.h
@@ -38,7 +38,7 @@ struct VOICE
 
 typedef VOICE* PVOICE;
 
-bool DSGetLock(LPDIRECTSOUNDBUFFER pVoice, DWORD dwOffset, DWORD dwBytes,
+HRESULT DSGetLock(LPDIRECTSOUNDBUFFER pVoice, DWORD dwOffset, DWORD dwBytes,
 					  SHORT** ppDSLockedBuffer0, DWORD* pdwDSLockedBufferSize0,
 					  SHORT** ppDSLockedBuffer1, DWORD* pdwDSLockedBufferSize1);
 

--- a/source/Speaker.cpp
+++ b/source/Speaker.cpp
@@ -576,10 +576,11 @@ static ULONG Spkr_SubmitWaveBuffer_FullSpeed(short* pSpeakerBuffer, ULONG nNumSa
 
 	if(nNumSamplesToUse >= 128)	// Limit the buffer unlock/locking to a minimum
 	{
-		if(!DSGetLock(SpeakerVoice.lpDSBvoice,
-							dwByteOffset, (DWORD)nNumSamplesToUse*sizeof(short),
-							&pDSLockedBuffer0, &dwDSLockedBufferSize0,
-							&pDSLockedBuffer1, &dwDSLockedBufferSize1))
+		hr = DSGetLock(SpeakerVoice.lpDSBvoice,
+			dwByteOffset, (DWORD)nNumSamplesToUse * sizeof(short),
+			&pDSLockedBuffer0, &dwDSLockedBufferSize0,
+			&pDSLockedBuffer1, &dwDSLockedBufferSize1);
+		if (FAILED(hr))
 			return nNumSamples;
 
 		//
@@ -777,10 +778,11 @@ static ULONG Spkr_SubmitWaveBuffer(short* pSpeakerBuffer, ULONG nNumSamples)
 	{
 		//sprintf(szDbg, "[Submit]    C=%08X, PC=%08X, WC=%08X, Diff=%08X, Off=%08X, NS=%08X +++\n", nDbgSpkrCnt, dwCurrentPlayCursor, dwCurrentWriteCursor, dwCurrentWriteCursor-dwCurrentPlayCursor, dwByteOffset, nNumSamplesToUse); OutputDebugString(szDbg);
 
-		if (!DSGetLock(SpeakerVoice.lpDSBvoice,
+		hr = DSGetLock(SpeakerVoice.lpDSBvoice,
 			dwByteOffset, (DWORD)nNumSamplesToUse * sizeof(short),
 			&pDSLockedBuffer0, &dwDSLockedBufferSize0,
-			&pDSLockedBuffer1, &dwDSLockedBufferSize1))
+			&pDSLockedBuffer1, &dwDSLockedBufferSize1);
+		if (FAILED(hr))
 		{
 			LogFileOutput("Spkr_SubmitWaveBuffer: DSGetLock failed\n");
 			return nNumSamples;


### PR DESCRIPTION
Need to use FAILED() instead of boolean check.
This is an update to the original PR https://github.com/AppleWin/AppleWin/pull/931/commits/ac214879e3581f93fbfa3fe85127f415068c806b

