### PR TITLE
Simplify logic around CConfigNeedingRestart

### DIFF
--- a/source/Configuration/Config.h
+++ b/source/Configuration/Config.h
@@ -32,7 +32,6 @@ public:
 	}
 
 	// update from current global configuration
-	// except m_uSaveLoadStateMsg
 	void Reload()
 	{
 		m_Apple2Type = GetApple2Type();
@@ -43,7 +42,7 @@ public:
 		m_SlotAux = cardManager.QueryAux();
 		m_tfeInterface = get_tfe_interface();
 		m_bEnableTheFreezesF8Rom = GetPropertySheet().GetTheFreezesF8Rom();
-		// we do not touch m_uSaveLoadStateMsg
+		m_uSaveLoadStateMsg = 0;
 		m_videoRefreshRate = GetVideo().GetVideoRefreshRate();
 	}
 

--- a/source/Configuration/Config.h
+++ b/source/Configuration/Config.h
@@ -11,19 +11,40 @@
 class CConfigNeedingRestart
 {
 public:
-	CConfigNeedingRestart(UINT bEnableTheFreezesF8Rom = false) :
-		m_Apple2Type( GetApple2Type() ),
-		m_CpuType( GetMainCpu() ),
-		m_uSaveLoadStateMsg(0),
-		m_videoRefreshRate( GetVideo().GetVideoRefreshRate() )
+	// zero initialise
+	CConfigNeedingRestart()
 	{
-		m_bEnableTheFreezesF8Rom = bEnableTheFreezesF8Rom;
+		m_Apple2Type = A2TYPE_APPLE2;
+		m_CpuType = CPU_UNKNOWN;
+		memset(m_Slot, 0, sizeof(m_Slot));
+		m_SlotAux = CT_Empty;
+		m_bEnableTheFreezesF8Rom = 0;
+		m_uSaveLoadStateMsg = 0;
+		m_videoRefreshRate = VR_NONE;
+	}
 
+	// create from current global configuration
+	static CConfigNeedingRestart Create()
+	{
+		CConfigNeedingRestart config;
+		config.Reload();
+		return config;
+	}
+
+	// update from current global configuration
+	// except m_uSaveLoadStateMsg
+	void Reload()
+	{
+		m_Apple2Type = GetApple2Type();
+		m_CpuType = GetMainCpu();
+		CardManager& cardManager = GetCardMgr();
 		for (UINT slot = SLOT0; slot < NUM_SLOTS; slot++)
-			m_Slot[slot] = GetCardMgr().QuerySlot(slot);
-		m_SlotAux = GetCardMgr().QueryAux();
-
+			m_Slot[slot] = cardManager.QuerySlot(slot);
+		m_SlotAux = cardManager.QueryAux();
 		m_tfeInterface = get_tfe_interface();
+		m_bEnableTheFreezesF8Rom = GetPropertySheet().GetTheFreezesF8Rom();
+		// we do not touch m_uSaveLoadStateMsg
+		m_videoRefreshRate = GetVideo().GetVideoRefreshRate();
 	}
 
 	const CConfigNeedingRestart& operator= (const CConfigNeedingRestart& other)

--- a/source/Configuration/PropertySheetHelper.cpp
+++ b/source/Configuration/PropertySheetHelper.cpp
@@ -376,23 +376,11 @@ void CPropertySheetHelper::ApplyNewConfig(void)
 void CPropertySheetHelper::SaveCurrentConfig(void)
 {
 	// NB. clone-type is encoded in g_Apple2Type
-	m_ConfigOld.m_Apple2Type = GetApple2Type();
-	m_ConfigOld.m_CpuType = GetMainCpu();
-	m_ConfigOld.m_Slot[SLOT3] = GetCardMgr().QuerySlot(SLOT3);
-	m_ConfigOld.m_Slot[SLOT4] = GetCardMgr().QuerySlot(SLOT4);
-	m_ConfigOld.m_Slot[SLOT5] = GetCardMgr().QuerySlot(SLOT5);
-	m_ConfigOld.m_Slot[SLOT6] = GetCardMgr().QuerySlot(SLOT6);	// CPageDisk::HandleFloppyDriveCombo() needs this to be CT_Disk2 (temp, as will replace with PR #955)
-	m_ConfigOld.m_Slot[SLOT7] = GetCardMgr().QuerySlot(SLOT7);
-	m_ConfigOld.m_bEnableTheFreezesF8Rom = GetPropertySheet().GetTheFreezesF8Rom();
-	m_ConfigOld.m_videoRefreshRate = GetVideo().GetVideoRefreshRate();
-	m_ConfigOld.m_tfeInterface = get_tfe_interface();
+	m_ConfigNew.Reload();  // this preserves m_uSaveLoadStateMsg
+	m_ConfigOld = m_ConfigNew;
 
 	// Reset flags each time:
-	m_ConfigOld.m_uSaveLoadStateMsg = 0;
 	m_bDoBenchmark = false;
-
-	// Setup ConfigNew
-	m_ConfigNew = m_ConfigOld;
 }
 
 void CPropertySheetHelper::RestoreCurrentConfig(void)
@@ -405,7 +393,6 @@ void CPropertySheetHelper::RestoreCurrentConfig(void)
 	SetSlot(SLOT5, m_ConfigOld.m_Slot[SLOT5]);
 	HD_SetEnabled(m_ConfigOld.m_Slot[SLOT7] == CT_GenericHDD);
 	GetPropertySheet().SetTheFreezesF8Rom(m_ConfigOld.m_bEnableTheFreezesF8Rom);
-	m_ConfigNew.m_videoRefreshRate = m_ConfigOld.m_videoRefreshRate;	// Not SetVideoRefreshRate(), as this re-inits much Video/NTSC state!
 }
 
 bool CPropertySheetHelper::IsOkToSaveLoadState(HWND hWnd, const bool bConfigChanged)

--- a/source/Configuration/PropertySheetHelper.cpp
+++ b/source/Configuration/PropertySheetHelper.cpp
@@ -376,11 +376,13 @@ void CPropertySheetHelper::ApplyNewConfig(void)
 void CPropertySheetHelper::SaveCurrentConfig(void)
 {
 	// NB. clone-type is encoded in g_Apple2Type
-	m_ConfigNew.Reload();  // this preserves m_uSaveLoadStateMsg
-	m_ConfigOld = m_ConfigNew;
+	m_ConfigOld.Reload();
 
 	// Reset flags each time:
 	m_bDoBenchmark = false;
+
+	// Setup ConfigNew
+	m_ConfigNew = m_ConfigOld;
 }
 
 void CPropertySheetHelper::RestoreCurrentConfig(void)

--- a/source/SaveState.cpp
+++ b/source/SaveState.cpp
@@ -172,8 +172,6 @@ void Snapshot_UpdatePath(void)
 
 //-----------------------------------------------------------------------------
 
-static CConfigNeedingRestart m_ConfigNew;
-
 static std::string GetSnapshotUnitApple2Name(void)
 {
 	static const std::string name("Apple2");
@@ -279,16 +277,13 @@ static void ParseUnitApple2(YamlLoadHelper& yamlLoadHelper, UINT version)
 
 	std::string model = yamlLoadHelper.LoadString(SS_YAML_KEY_MODEL);
 	SetApple2Type( ParseApple2Type(model) );	// NB. Sets default main CPU type
-	m_ConfigNew.m_Apple2Type = GetApple2Type();
 
 	CpuLoadSnapshot(yamlLoadHelper, version);	// NB. Overrides default main CPU type
-	m_ConfigNew.m_CpuType = GetMainCpu();
 
 	JoyLoadSnapshot(yamlLoadHelper, version);
 	KeybLoadSnapshot(yamlLoadHelper, version);
 	SpkrLoadSnapshot(yamlLoadHelper);
 	GetVideo().VideoLoadSnapshot(yamlLoadHelper, version);
-	m_ConfigNew.m_videoRefreshRate = GetVideo().GetVideoRefreshRate();
 	MemLoadSnapshot(yamlLoadHelper, version);
 
 	// g_Apple2Type may've changed: so redraw frame (title, buttons, leds, etc)
@@ -529,7 +524,8 @@ static void Snapshot_LoadState_v2(void)
 		// . A change in h/w via loading a save-state avoids this VM restart
 		// The latter is the desired approach (as the former needs a "power-on" / F2 to start things again)
 
-		GetPropertySheet().ApplyNewConfigFromSnapshot(m_ConfigNew);	// Saves new state to Registry (not slot/cards though)
+		const CConfigNeedingRestart configNew = CConfigNeedingRestart::Create();
+		GetPropertySheet().ApplyNewConfigFromSnapshot(configNew);	// Saves new state to Registry (not slot/cards though)
 
 		MemInitializeROM();
 		MemInitializeCustomROM();


### PR DESCRIPTION
1. separate class initialisation from loading settings (to avoid static variable initialisation loop)
2. include all slots (so to match the usage in SaveState.cpp)
3. in SaveState simply create an object before and after loading the yaml file, and compare them
4. remove RestoreCurrentConfig as it does not actually do anything (AW state is not touched so it does not need to be reset)