### PR TITLE
Missing cards and yaml files

### DIFF
--- a/source/SaveState.cpp
+++ b/source/SaveState.cpp
@@ -480,11 +480,10 @@ static void Snapshot_LoadState_v2(void)
 			ConfigOld.m_Slot[2] = CT_Empty;
 		}
 
-		if (GetCardMgr().QuerySlot(SLOT4) == CT_MouseInterface)
-			GetCardMgr().Remove(SLOT4);		// Remove Mouse card from slot-4
-
-		if (GetCardMgr().QuerySlot(SLOT5) == CT_Disk2)
-			GetCardMgr().Remove(SLOT5);		// Remove Disk2 card from slot-5
+		// because the save state only contains "present" cards
+		// we need to remove them all first
+		GetCardMgr().Remove(SLOT4);
+		GetCardMgr().Remove(SLOT5);
 
 		GetCardMgr().GetDisk2CardMgr().Reset(false);
 


### PR DESCRIPTION
This patch is orthogonal to https://github.com/AppleWin/AppleWin/pull/955.

A yaml file only contains information about present cards.
So if a slot is empty (e.g. 4), the yaml file contains no info about it.

Should the system after a state reload keep the Slot 4 **unchanged** or make it **empty**?

Either way, the current code behaves differently according to which cards are in slot 4 and 5.
If a Mouse card is in slot 4, then it will be reset by a yaml file, anything else will stay.

I personally think all cards missing from a yaml should go to their default state.