### PR TITLE
Disks: save full pathname to registry.

### DIFF
--- a/source/Configuration/PageDisk.cpp
+++ b/source/Configuration/PageDisk.cpp
@@ -226,9 +226,6 @@ void CPageDisk::DlgOK(HWND hWnd)
 		m_PropertySheetHelper.GetConfigNew().m_bEnableHDD = bNewHDDIsEnabled;
 	}
 
-	RegSaveString(TEXT(REG_PREFS), TEXT(REGVALUE_PREF_LAST_HARDDISK_1), 1, HD_GetFullPathName(HARDDISK_1));
-	RegSaveString(TEXT(REG_PREFS), TEXT(REGVALUE_PREF_LAST_HARDDISK_2), 1, HD_GetFullPathName(HARDDISK_2));
-
 	m_PropertySheetHelper.PostMsgAfterClose(hWnd, m_Page);
 }
 

--- a/source/Disk.cpp
+++ b/source/Disk.cpp
@@ -191,7 +191,7 @@ void Disk2InterfaceCard::SaveLastDiskImage(const int drive)
 	if (!m_saveDiskImage)
 		return;
 
-	const std::string & pFileName = m_floppyDrive[drive].m_disk.m_fullname;
+	const std::string & pFileName = DiskGetFullPathName(drive);
 
 	if (drive == DRIVE_1)
 		RegSaveString(TEXT(REG_PREFS), TEXT(REGVALUE_PREF_LAST_DISK_1), TRUE, pFileName);
@@ -201,7 +201,7 @@ void Disk2InterfaceCard::SaveLastDiskImage(const int drive)
 	//
 
 	TCHAR szPathName[MAX_PATH];
-	StringCbCopy(szPathName, MAX_PATH, DiskGetFullPathName(drive).c_str());
+	StringCbCopy(szPathName, MAX_PATH, pFileName.c_str());
 	TCHAR* slash = _tcsrchr(szPathName, TEXT(PATH_SEPARATOR));
 	if (slash != NULL)
 	{

--- a/source/Harddisk.cpp
+++ b/source/Harddisk.cpp
@@ -236,7 +236,7 @@ static void HD_SaveLastDiskImage(const int iDrive)
 	if (!g_bSaveDiskImage)
 		return;
 
-	const std::string & pFileName = g_HardDisk[iDrive].fullname;
+	const std::string & pFileName = HD_GetFullPathName(iDrive);
 
 	if (iDrive == HARDDISK_1)
 		RegSaveString(TEXT(REG_PREFS), REGVALUE_PREF_LAST_HARDDISK_1, TRUE, pFileName);
@@ -246,7 +246,7 @@ static void HD_SaveLastDiskImage(const int iDrive)
 	//
 
 	char szPathName[MAX_PATH];
-	strcpy(szPathName, HD_GetFullPathName(iDrive).c_str());
+	strcpy(szPathName, pFileName.c_str());
 	if (_tcsrchr(szPathName, TEXT(PATH_SEPARATOR)))
 	{
 		char* pPathEnd = _tcsrchr(szPathName, TEXT(PATH_SEPARATOR))+1;


### PR DESCRIPTION
This was already happening for Hard Disks (although in a convoluted way).
Extend to Floppy Disks.