### PR TITLE
Improve save-state card mgmt

### DIFF
--- a/source/Card.h
+++ b/source/Card.h
@@ -25,7 +25,7 @@ enum SS_CARDTYPE
 	CT_SNESMAX,			// 2 port Nintendo NES/SNES controller serial interface card
 };
 
-enum SLOTS { SLOT0=0, SLOT1, SLOT2, SLOT3, SLOT4, SLOT5, SLOT6, SLOT7, NUM_SLOTS };
+enum SLOTS { SLOT0=0, SLOT1, SLOT2, SLOT3, SLOT4, SLOT5, SLOT6, SLOT7, NUM_SLOTS, SLOT_AUX };
 
 class Card
 {

--- a/source/CardManager.cpp
+++ b/source/CardManager.cpp
@@ -117,10 +117,11 @@ void CardManager::InsertInternal(UINT slot, SS_CARDTYPE type)
 		Remove(slot);			// creates a new EmptyCard
 }
 
-void CardManager::Insert(UINT slot, SS_CARDTYPE type)
+void CardManager::Insert(UINT slot, SS_CARDTYPE type, bool updateRegistry/*=true*/)
 {
 	InsertInternal(slot, type);
-	RegSetConfigSlotNewCardType(slot, type);
+	if (updateRegistry)
+		RegSetConfigSlotNewCardType(slot, type);
 }
 
 void CardManager::RemoveInternal(UINT slot)

--- a/source/CardManager.cpp
+++ b/source/CardManager.cpp
@@ -39,14 +39,14 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "SerialComms.h"
 #include "SNESMAX.h"
 
-void CardManager::Insert(UINT slot, SS_CARDTYPE type)
+void CardManager::InsertInternal(UINT slot, SS_CARDTYPE type)
 {
 	RemoveInternal(slot);
 
 	switch (type)
 	{
 	case CT_Empty:
-		Remove(slot);	// creates a new EmptyCard
+		m_slot[slot] = new EmptyCard;
 		break;
 	case CT_Disk2:
 		m_slot[slot] = new Disk2InterfaceCard(slot);
@@ -115,11 +115,12 @@ void CardManager::Insert(UINT slot, SS_CARDTYPE type)
 
 	if (m_slot[slot] == NULL)
 		Remove(slot);			// creates a new EmptyCard
+}
 
-	//
-
-	if (m_updateRegistryForInsert)
-		RegSetConfigSlotNewCardType(slot, type);
+void CardManager::Insert(UINT slot, SS_CARDTYPE type)
+{
+	InsertInternal(slot, type);
+	RegSetConfigSlotNewCardType(slot, type);
 }
 
 void CardManager::RemoveInternal(UINT slot)
@@ -136,18 +137,17 @@ void CardManager::RemoveInternal(UINT slot)
 
 void CardManager::Remove(UINT slot)
 {
-	RemoveInternal(slot);
-	m_slot[slot] = new EmptyCard;
+	Insert(slot, CT_Empty);
 }
 
-void CardManager::InsertAux(SS_CARDTYPE type)
+void CardManager::InsertAuxInternal(SS_CARDTYPE type)
 {
 	RemoveAuxInternal();
 
 	switch (type)
 	{
 	case CT_Empty:
-		RemoveAux();	// creates a new EmptyCard
+		m_aux = new EmptyCard;
 		break;
 	case CT_80Col:
 		m_aux = new DummyCard(type);
@@ -167,11 +167,12 @@ void CardManager::InsertAux(SS_CARDTYPE type)
 	_ASSERT(m_aux != NULL);
 	if (m_aux == NULL)
 		RemoveAux();	// creates a new EmptyCard
+}
 
-	//
-
-	if (m_updateRegistryForInsert)
-		RegSetConfigSlotNewCardType(SLOT_AUX, type);
+void CardManager::InsertAux(SS_CARDTYPE type)
+{
+	InsertAuxInternal(type);
+	RegSetConfigSlotNewCardType(SLOT_AUX, type);
 }
 
 void CardManager::RemoveAuxInternal()
@@ -182,6 +183,5 @@ void CardManager::RemoveAuxInternal()
 
 void CardManager::RemoveAux(void)
 {
-	RemoveAuxInternal();
-	m_aux = new EmptyCard;
+	InsertAux(CT_Empty);
 }

--- a/source/CardManager.h
+++ b/source/CardManager.h
@@ -11,17 +11,15 @@ public:
 		m_pMouseCard(NULL),
 		m_pSSC(NULL)
 	{
-		m_updateRegistryForInsert = false;	// don't overwrite the Registry with these default cards
-		Insert(0, CT_Empty);
-		Insert(1, CT_GenericPrinter);
-		Insert(2, CT_SSC);
-		Insert(3, CT_Uthernet);
-		Insert(4, CT_Empty);
-		Insert(5, CT_Empty);
-		Insert(6, CT_Disk2);
-		Insert(7, CT_Empty);
-		InsertAux(CT_Extended80Col);	// For Apple //e and above
-		m_updateRegistryForInsert = true;
+		InsertInternal(SLOT0, CT_Empty);
+		InsertInternal(SLOT1, CT_GenericPrinter);
+		InsertInternal(SLOT2, CT_SSC);
+		InsertInternal(SLOT3, CT_Uthernet);
+		InsertInternal(SLOT4, CT_Empty);
+		InsertInternal(SLOT5, CT_Empty);
+		InsertInternal(SLOT6, CT_Disk2);
+		InsertInternal(SLOT7, CT_Empty);
+		InsertAuxInternal(CT_Extended80Col);	// For Apple //e and above
 	}
 	~CardManager(void)
 	{
@@ -54,6 +52,8 @@ public:
 	bool IsSSCInstalled(void) { return m_pSSC != NULL; }
 
 private:
+	void InsertInternal(UINT slot, SS_CARDTYPE type);
+	void InsertAuxInternal(SS_CARDTYPE type);
 	void RemoveInternal(UINT slot);
 	void RemoveAuxInternal(void);
 
@@ -62,5 +62,4 @@ private:
 	Disk2CardManager m_disk2CardMgr;
 	class CMouseInterface* m_pMouseCard;
 	class CSuperSerialCard* m_pSSC;
-	bool m_updateRegistryForInsert;	// inserting a new card should update the Registry
 };

--- a/source/CardManager.h
+++ b/source/CardManager.h
@@ -28,7 +28,7 @@ public:
 		RemoveAuxInternal();
 	}
 
-	void Insert(UINT slot, SS_CARDTYPE type);
+	void Insert(UINT slot, SS_CARDTYPE type, bool updateRegistry = true);
 	void Remove(UINT slot);
 	SS_CARDTYPE QuerySlot(UINT slot) { _ASSERT(slot<NUM_SLOTS); return m_slot[slot]->QueryType(); }
 	Card& GetRef(UINT slot)

--- a/source/CardManager.h
+++ b/source/CardManager.h
@@ -11,6 +11,7 @@ public:
 		m_pMouseCard(NULL),
 		m_pSSC(NULL)
 	{
+		m_updateRegistryForInsert = false;	// don't overwrite the Registry with these default cards
 		Insert(0, CT_Empty);
 		Insert(1, CT_GenericPrinter);
 		Insert(2, CT_SSC);
@@ -20,6 +21,7 @@ public:
 		Insert(6, CT_Disk2);
 		Insert(7, CT_Empty);
 		InsertAux(CT_Extended80Col);	// For Apple //e and above
+		m_updateRegistryForInsert = true;
 	}
 	~CardManager(void)
 	{
@@ -60,4 +62,5 @@ private:
 	Disk2CardManager m_disk2CardMgr;
 	class CMouseInterface* m_pMouseCard;
 	class CSuperSerialCard* m_pSSC;
+	bool m_updateRegistryForInsert;	// inserting a new card should update the Registry
 };

--- a/source/Common.h
+++ b/source/Common.h
@@ -72,7 +72,7 @@ enum AppMode_e
 #define  REGVALUE_MB_VOLUME          "Mockingboard Volume"
 #define  REGVALUE_SAVESTATE_FILENAME "Save State Filename"
 #define  REGVALUE_SAVE_STATE_ON_EXIT "Save State On Exit"
-#define  REGVALUE_HDD_ENABLED        "Harddisk Enable"
+#define  REGVALUE_HDD_ENABLED        "Harddisk Enable"		// Deprecated from 1.30.5
 #define  REGVALUE_JOYSTICK0_EMU_TYPE		"Joystick0 Emu Type v3"	// GH#434: Added at 1.26.3.0 (previously was "Joystick0 Emu Type")
 #define  REGVALUE_JOYSTICK1_EMU_TYPE		"Joystick1 Emu Type v3"	// GH#434: Added at 1.26.3.0 (previously was "Joystick1 Emu Type")
 #define  REGVALUE_OLD_JOYSTICK0_EMU_TYPE2	"Joystick0 Emu Type"	// GH#434: Deprecated from 1.26.3.0 (previously was "Joystick 0 Emulation")
@@ -107,7 +107,7 @@ enum AppMode_e
 #define  REGVALUE_CUSTOM_SPEED       "Custom Speed"
 #define  REGVALUE_EMULATION_SPEED    "Emulation Speed"
 #define  REGVALUE_WINDOW_SCALE       "Window Scale"
-#define  REGVALUE_UTHERNET_ACTIVE       "Uthernet Active"	// GH#977: Deprecated from 1.30.4
+#define  REGVALUE_UTHERNET_ACTIVE       "Uthernet Active"	// GH#977: Deprecated from 1.30.5
 #define  REGVALUE_UTHERNET_INTERFACE    "Uthernet Interface"
 #define  REGVALUE_SLOT4					"Slot 4"			// GH#977: Deprecated from 1.30.4
 #define  REGVALUE_SLOT5					"Slot 5"			// GH#977: Deprecated from 1.30.4

--- a/source/Common.h
+++ b/source/Common.h
@@ -90,7 +90,6 @@ enum AppMode_e
 #define  REGVALUE_MOUSE_RESTRICT_TO_WINDOW "Mouse restrict to window"
 #define  REGVALUE_THE_FREEZES_F8_ROM "The Freeze's F8 Rom"
 #define  REGVALUE_CIDERPRESSLOC      "CiderPress Location"
-#define  REGVALUE_CPM_CONFIG         "CPM Config"
 #define  REGVALUE_DUMP_TO_PRINTER    "Dump to printer"
 #define  REGVALUE_CONVERT_ENCODING   "Convert printer encoding for clones"
 #define  REGVALUE_FILTER_UNPRINTABLE "Filter unprintable characters"
@@ -119,13 +118,13 @@ enum AppMode_e
 // Preferences 
 #define REG_PREFS						"Preferences"
 #define REGVALUE_PREF_START_DIR      "Starting Directory"
-#define REGVALUE_PREF_LAST_DISK_1	 "Last Disk Image 1"
-#define REGVALUE_PREF_LAST_DISK_2	 "Last Disk Image 2"
+#define REGVALUE_PREF_LAST_DISK_1	 "Last Disk Image 1"		// GH#977: Deprecated from 1.30.4
+#define REGVALUE_PREF_LAST_DISK_2	 "Last Disk Image 2"		// GH#977: Deprecated from 1.30.4
 #define REGVALUE_PREF_WINDOW_X_POS   "Window X-Position"
 #define REGVALUE_PREF_WINDOW_Y_POS   "Window Y-Position"
 #define REGVALUE_PREF_HDV_START_DIR  "HDV Starting Directory"
-#define REGVALUE_PREF_LAST_HARDDISK_1 "Last Harddisk Image 1"
-#define REGVALUE_PREF_LAST_HARDDISK_2 "Last Harddisk Image 2"
+#define REGVALUE_PREF_LAST_HARDDISK_1 "Last Harddisk Image 1"	// Deprecated from 1.30.5
+#define REGVALUE_PREF_LAST_HARDDISK_2 "Last Harddisk Image 2"	// Deprecated from 1.30.5
 
 #define WM_USER_BENCHMARK	WM_USER+1
 #define WM_USER_SAVESTATE	WM_USER+2

--- a/source/Common.h
+++ b/source/Common.h
@@ -112,6 +112,7 @@ enum AppMode_e
 #define  REGVALUE_SLOT4					"Slot 4"			// GH#977: Deprecated from 1.30.4
 #define  REGVALUE_SLOT5					"Slot 5"			// GH#977: Deprecated from 1.30.4
 #define  REGVALUE_VERSION				"Version"
+#define REG_CONFIG_SLOT_AUX			"Slot Auxiliary"
 #define REG_CONFIG_SLOT				"Slot "
 #define  REGVALUE_CARD_TYPE			"Card type"
 

--- a/source/Common.h
+++ b/source/Common.h
@@ -114,17 +114,17 @@ enum AppMode_e
 #define REG_CONFIG_SLOT_AUX			"Slot Auxiliary"
 #define REG_CONFIG_SLOT				"Slot "
 #define  REGVALUE_CARD_TYPE			"Card type"
+#define  REGVALUE_LAST_DISK_1		"Last Disk Image 1"
+#define  REGVALUE_LAST_DISK_2		"Last Disk Image 2"
+#define  REGVALUE_LAST_HARDDISK_1	"Last Harddisk Image 1"
+#define  REGVALUE_LAST_HARDDISK_2	"Last Harddisk Image 2"
 
 // Preferences 
 #define REG_PREFS						"Preferences"
 #define REGVALUE_PREF_START_DIR      "Starting Directory"
-#define REGVALUE_PREF_LAST_DISK_1	 "Last Disk Image 1"		// GH#977: Deprecated from 1.30.4
-#define REGVALUE_PREF_LAST_DISK_2	 "Last Disk Image 2"		// GH#977: Deprecated from 1.30.4
 #define REGVALUE_PREF_WINDOW_X_POS   "Window X-Position"
 #define REGVALUE_PREF_WINDOW_Y_POS   "Window Y-Position"
 #define REGVALUE_PREF_HDV_START_DIR  "HDV Starting Directory"
-#define REGVALUE_PREF_LAST_HARDDISK_1 "Last Harddisk Image 1"	// Deprecated from 1.30.5
-#define REGVALUE_PREF_LAST_HARDDISK_2 "Last Harddisk Image 2"	// Deprecated from 1.30.5
 
 #define WM_USER_BENCHMARK	WM_USER+1
 #define WM_USER_SAVESTATE	WM_USER+2

--- a/source/Configuration/Config.h
+++ b/source/Configuration/Config.h
@@ -4,7 +4,7 @@
 #include "../CardManager.h"
 #include "../CPU.h"
 #include "../DiskImage.h"	// Disk_Status_e
-#include "../Harddisk.h"	// HD_CardIsEnabled()
+#include "../Harddisk.h"
 #include "../Interface.h"	// VideoRefreshRate_e, GetVideoRefreshRate()
 #include "../Tfe/tfe.h"
 
@@ -17,7 +17,6 @@ public:
 		m_uSaveLoadStateMsg(0),
 		m_videoRefreshRate( GetVideo().GetVideoRefreshRate() )
 	{
-		m_bEnableHDD = HD_CardIsEnabled();
 		m_bEnableTheFreezesF8Rom = bEnableTheFreezesF8Rom;
 
 		for (UINT slot = SLOT0; slot < NUM_SLOTS; slot++)
@@ -33,7 +32,6 @@ public:
 		m_CpuType = other.m_CpuType;
 		memcpy(m_Slot, other.m_Slot, sizeof(m_Slot));
 		m_SlotAux = other.m_SlotAux;
-		m_bEnableHDD = other.m_bEnableHDD;
 		m_tfeInterface = other.m_tfeInterface;
 		m_bEnableTheFreezesF8Rom = other.m_bEnableTheFreezesF8Rom;
 		m_uSaveLoadStateMsg = other.m_uSaveLoadStateMsg;
@@ -47,7 +45,6 @@ public:
 			m_CpuType == other.m_CpuType &&
 			memcmp(m_Slot, other.m_Slot, sizeof(m_Slot)) == 0 &&
 			m_SlotAux == other.m_SlotAux &&
-			m_bEnableHDD == other.m_bEnableHDD &&
 			m_tfeInterface == other.m_tfeInterface &&
 			m_bEnableTheFreezesF8Rom == other.m_bEnableTheFreezesF8Rom &&
 			m_uSaveLoadStateMsg == other.m_uSaveLoadStateMsg &&
@@ -61,9 +58,8 @@ public:
 
 	eApple2Type	m_Apple2Type;
 	eCpuType m_CpuType;
-	SS_CARDTYPE m_Slot[NUM_SLOTS];	// 0..7
+	SS_CARDTYPE m_Slot[NUM_SLOTS];
 	SS_CARDTYPE m_SlotAux;
-	bool m_bEnableHDD;
 	std::string m_tfeInterface;
 	UINT m_bEnableTheFreezesF8Rom;
 	UINT m_uSaveLoadStateMsg;

--- a/source/Configuration/Config.h
+++ b/source/Configuration/Config.h
@@ -19,11 +19,10 @@ public:
 	{
 		m_bEnableHDD = HD_CardIsEnabled();
 		m_bEnableTheFreezesF8Rom = bEnableTheFreezesF8Rom;
-		memset(&m_Slot, 0, sizeof(m_Slot));
-		m_SlotAux = CT_Empty;
-		m_Slot[SLOT4] = GetCardMgr().QuerySlot(SLOT4);
-		m_Slot[SLOT5] = GetCardMgr().QuerySlot(SLOT5);
-		m_Slot[SLOT7] = GetCardMgr().QuerySlot(SLOT7);
+
+		for (UINT slot = SLOT0; slot < NUM_SLOTS; slot++)
+			m_Slot[slot] = GetCardMgr().QuerySlot(slot);
+		m_SlotAux = GetCardMgr().QueryAux();
 
 		m_tfeInterface = get_tfe_interface();
 	}

--- a/source/Configuration/Config.h
+++ b/source/Configuration/Config.h
@@ -32,6 +32,7 @@ public:
 		m_Apple2Type = other.m_Apple2Type;
 		m_CpuType = other.m_CpuType;
 		memcpy(m_Slot, other.m_Slot, sizeof(m_Slot));
+		m_SlotAux = other.m_SlotAux;
 		m_bEnableHDD = other.m_bEnableHDD;
 		m_tfeInterface = other.m_tfeInterface;
 		m_bEnableTheFreezesF8Rom = other.m_bEnableTheFreezesF8Rom;
@@ -45,6 +46,7 @@ public:
 		return	m_Apple2Type == other.m_Apple2Type &&
 			m_CpuType == other.m_CpuType &&
 			memcmp(m_Slot, other.m_Slot, sizeof(m_Slot)) == 0 &&
+			m_SlotAux == other.m_SlotAux &&
 			m_bEnableHDD == other.m_bEnableHDD &&
 			m_tfeInterface == other.m_tfeInterface &&
 			m_bEnableTheFreezesF8Rom == other.m_bEnableTheFreezesF8Rom &&

--- a/source/Configuration/IPropertySheet.h
+++ b/source/Configuration/IPropertySheet.h
@@ -11,6 +11,7 @@ public:
 	virtual DWORD GetVolumeMax(void) = 0;								// TODO:TC: Move out of here
 	virtual bool SaveStateSelectImage(HWND hWindow, bool bSave) = 0;	// TODO:TC: Move out of here
 	virtual void ApplyNewConfig(const CConfigNeedingRestart& ConfigNew, const CConfigNeedingRestart& ConfigOld) = 0;
+	virtual void ApplyNewConfigFromSnapshot(const CConfigNeedingRestart& ConfigNew) = 0;
 	virtual void ConfigSaveApple2Type(eApple2Type apple2Type) = 0;
 
 	virtual UINT GetScrollLockToggle(void) = 0;

--- a/source/Configuration/PageConfig.cpp
+++ b/source/Configuration/PageConfig.cpp
@@ -350,13 +350,8 @@ void CPageConfig::DlgOK(HWND hWnd)
 
 	if (GetCardMgr().IsSSCInstalled())
 	{
-		CSuperSerialCard* pSSC = GetCardMgr().GetSSC();
 		const DWORD uNewSerialPort = (DWORD) SendDlgItemMessage(hWnd, IDC_SERIALPORT, CB_GETCURSEL, 0, 0);
-		pSSC->CommSetSerialPort(hWnd, uNewSerialPort);
-		RegSaveString(	TEXT(REG_CONFIG),
-						TEXT(REGVALUE_SERIAL_PORT_NAME),
-						TRUE,
-						pSSC->GetSerialPortName() );
+		GetCardMgr().GetSSC()->CommSetSerialPort(uNewSerialPort);
 	}
 
 	//

--- a/source/Configuration/PropertySheet.h
+++ b/source/Configuration/PropertySheet.h
@@ -28,6 +28,10 @@ public:
 	{
 		m_PropertySheetHelper.ApplyNewConfig(ConfigNew, ConfigOld);
 	}
+	void ApplyNewConfigFromSnapshot(const CConfigNeedingRestart& ConfigNew)
+	{
+		m_PropertySheetHelper.ApplyNewConfigFromSnapshot(ConfigNew);
+	}
 	void ConfigSaveApple2Type(eApple2Type apple2Type)
 	{
 		m_PropertySheetHelper.ConfigSaveApple2Type(apple2Type);

--- a/source/Configuration/PropertySheetHelper.cpp
+++ b/source/Configuration/PropertySheetHelper.cpp
@@ -125,18 +125,10 @@ void CPropertySheetHelper::SetSlot(UINT slot, SS_CARDTYPE newCardType)
 	if (slot >= NUM_SLOTS)
 		return;
 
-	// Two paths:
-	// 1) Via Config dialog: card not inserted yet
-	// 2) Snapshot_LoadState_v2(): card already inserted
 	if (GetCardMgr().QuerySlot(slot) == newCardType)
 		return;
 
 	GetCardMgr().Insert(slot, newCardType);
-
-	RegDeleteConfigSlotSection(slot);
-
-	std::string& regSection = RegGetConfigSlotSection(slot);
-	RegSaveValue(regSection.c_str(), REGVALUE_CARD_TYPE, TRUE, newCardType);
 }
 
 // Used by:
@@ -374,6 +366,15 @@ void CPropertySheetHelper::ApplyNewConfig(const CConfigNeedingRestart& ConfigNew
 	{
 		REGSAVE(TEXT(REGVALUE_VIDEO_REFRESH_RATE), ConfigNew.m_videoRefreshRate);
 	}
+}
+
+void CPropertySheetHelper::ApplyNewConfigFromSnapshot(const CConfigNeedingRestart& ConfigNew)
+{
+	SaveComputerType(ConfigNew.m_Apple2Type);
+	SaveCpuType(ConfigNew.m_CpuType);
+	REGSAVE(TEXT(REGVALUE_HDD_ENABLED), ConfigNew.m_bEnableHDD ? 1 : 0);
+	REGSAVE(TEXT(REGVALUE_THE_FREEZES_F8_ROM), ConfigNew.m_bEnableTheFreezesF8Rom);
+	REGSAVE(TEXT(REGVALUE_VIDEO_REFRESH_RATE), ConfigNew.m_videoRefreshRate);
 }
 
 void CPropertySheetHelper::ApplyNewConfig(void)

--- a/source/Configuration/PropertySheetHelper.cpp
+++ b/source/Configuration/PropertySheetHelper.cpp
@@ -348,14 +348,9 @@ void CPropertySheetHelper::ApplyNewConfig(const CConfigNeedingRestart& ConfigNew
 	if (CONFIG_CHANGED_LOCAL(m_Slot[slot]))
 		SetSlot(slot, ConfigNew.m_Slot[slot]);
 
-//	slot = SLOT7;
-//	if (CONFIG_CHANGED_LOCAL(m_Slot[slot]))
-//		SetSlot(slot, ConfigNew.m_Slot[slot]);
-
-	if (CONFIG_CHANGED_LOCAL(m_bEnableHDD))
-	{
-		REGSAVE(TEXT(REGVALUE_HDD_ENABLED), ConfigNew.m_bEnableHDD ? 1 : 0);
-	}
+	slot = SLOT7;
+	if (CONFIG_CHANGED_LOCAL(m_Slot[slot]))
+		SetSlot(slot, ConfigNew.m_Slot[slot]);
 
 	if (CONFIG_CHANGED_LOCAL(m_bEnableTheFreezesF8Rom))
 	{
@@ -372,7 +367,6 @@ void CPropertySheetHelper::ApplyNewConfigFromSnapshot(const CConfigNeedingRestar
 {
 	SaveComputerType(ConfigNew.m_Apple2Type);
 	SaveCpuType(ConfigNew.m_CpuType);
-	REGSAVE(TEXT(REGVALUE_HDD_ENABLED), ConfigNew.m_bEnableHDD ? 1 : 0);
 	REGSAVE(TEXT(REGVALUE_THE_FREEZES_F8_ROM), ConfigNew.m_bEnableTheFreezesF8Rom);
 	REGSAVE(TEXT(REGVALUE_VIDEO_REFRESH_RATE), ConfigNew.m_videoRefreshRate);
 }
@@ -391,7 +385,7 @@ void CPropertySheetHelper::SaveCurrentConfig(void)
 	m_ConfigOld.m_Slot[SLOT4] = GetCardMgr().QuerySlot(SLOT4);
 	m_ConfigOld.m_Slot[SLOT5] = GetCardMgr().QuerySlot(SLOT5);
 	m_ConfigOld.m_Slot[SLOT6] = GetCardMgr().QuerySlot(SLOT6);	// CPageDisk::HandleFloppyDriveCombo() needs this to be CT_Disk2 (temp, as will replace with PR #955)
-	m_ConfigOld.m_bEnableHDD = HD_CardIsEnabled();
+	m_ConfigOld.m_Slot[SLOT7] = GetCardMgr().QuerySlot(SLOT7);
 	m_ConfigOld.m_bEnableTheFreezesF8Rom = GetPropertySheet().GetTheFreezesF8Rom();
 	m_ConfigOld.m_videoRefreshRate = GetVideo().GetVideoRefreshRate();
 	m_ConfigOld.m_tfeInterface = get_tfe_interface();
@@ -412,7 +406,7 @@ void CPropertySheetHelper::RestoreCurrentConfig(void)
 	SetSlot(SLOT3, m_ConfigOld.m_Slot[SLOT3]);
 	SetSlot(SLOT4, m_ConfigOld.m_Slot[SLOT4]);
 	SetSlot(SLOT5, m_ConfigOld.m_Slot[SLOT5]);
-	HD_SetEnabled(m_ConfigOld.m_bEnableHDD);
+	HD_SetEnabled(m_ConfigOld.m_Slot[SLOT7] == CT_GenericHDD);
 	GetPropertySheet().SetTheFreezesF8Rom(m_ConfigOld.m_bEnableTheFreezesF8Rom);
 	m_ConfigNew.m_videoRefreshRate = m_ConfigOld.m_videoRefreshRate;	// Not SetVideoRefreshRate(), as this re-inits much Video/NTSC state!
 }
@@ -477,7 +471,7 @@ bool CPropertySheetHelper::HardwareConfigChanged(HWND hWnd)
 		if (CONFIG_CHANGED(m_Slot[SLOT5]))
 			strMsgMain += GetSlot(SLOT5);
 
-		if (CONFIG_CHANGED(m_bEnableHDD))
+		if (CONFIG_CHANGED(m_Slot[SLOT7]))
 			strMsgMain += ". Harddisk(s) have been plugged/unplugged\n";
 
 		if (CONFIG_CHANGED(m_bEnableTheFreezesF8Rom))

--- a/source/Configuration/PropertySheetHelper.h
+++ b/source/Configuration/PropertySheetHelper.h
@@ -34,6 +34,7 @@ public:
 	bool IsConfigChanged(void) { return m_ConfigNew != m_ConfigOld; }
 	void SetDoBenchmark(void) { m_bDoBenchmark = true; }
 	void ApplyNewConfig(const CConfigNeedingRestart& ConfigNew, const CConfigNeedingRestart& ConfigOld);
+	void ApplyNewConfigFromSnapshot(const CConfigNeedingRestart& ConfigNew);
 	void ConfigSaveApple2Type(eApple2Type apple2Type);
 	void SetSlot(UINT slot, SS_CARDTYPE newCardType);
 

--- a/source/Disk.cpp
+++ b/source/Disk.cpp
@@ -175,7 +175,6 @@ void Disk2InterfaceCard::LoadLastDiskImage(const int drive)
 	if (RegLoadString(regSection.c_str(), regKey.c_str(), TRUE, pathname, MAX_PATH, TEXT("")))
 	{
 		m_saveDiskImage = false;
-		// Pass in ptr to local copy of filepath, since RemoveDisk() sets DiskPathFilename = ""
 		InsertDisk(drive, pathname, IMAGE_USE_FILES_WRITE_PROTECT_STATUS, IMAGE_DONT_CREATE);
 		m_saveDiskImage = true;
 	}

--- a/source/Disk.cpp
+++ b/source/Disk.cpp
@@ -166,8 +166,8 @@ void Disk2InterfaceCard::LoadLastDiskImage(const int drive)
 	_ASSERT(drive == DRIVE_1 || drive == DRIVE_2);
 
 	const std::string regKey = (drive == DRIVE_1)
-		? REGVALUE_PREF_LAST_DISK_1
-		: REGVALUE_PREF_LAST_DISK_2;
+		? REGVALUE_LAST_DISK_1
+		: REGVALUE_LAST_DISK_2;
 
 	char pathname[MAX_PATH];
 
@@ -193,8 +193,8 @@ void Disk2InterfaceCard::SaveLastDiskImage(const int drive)
 	RegSaveValue(regSection.c_str(), REGVALUE_CARD_TYPE, TRUE, CT_Disk2);
 
 	const std::string regKey = (drive == DRIVE_1)
-		? REGVALUE_PREF_LAST_DISK_1
-		: REGVALUE_PREF_LAST_DISK_2;
+		? REGVALUE_LAST_DISK_1
+		: REGVALUE_LAST_DISK_2;
 
 	const std::string& pathName = DiskGetFullPathName(drive);
 

--- a/source/Harddisk.cpp
+++ b/source/Harddisk.cpp
@@ -282,7 +282,7 @@ bool HD_CardIsEnabled(void)
 // . LoadConfiguration() - Done at each restart
 // . RestoreCurrentConfig() - Done when Config dialog is cancelled
 // . Snapshot_LoadState_v2() - Done to default to disabled state
-void HD_SetEnabled(const bool bEnabled)
+void HD_SetEnabled(const bool bEnabled, bool updateRegistry/*=true*/)
 {
 	if(g_bHD_Enabled == bEnabled)
 		return;
@@ -290,7 +290,7 @@ void HD_SetEnabled(const bool bEnabled)
 	g_bHD_Enabled = bEnabled;
 
 	if (bEnabled)
-		GetCardMgr().Insert(SLOT7, CT_GenericHDD);
+		GetCardMgr().Insert(SLOT7, CT_GenericHDD, updateRegistry);
 	else
 		GetCardMgr().Remove(SLOT7);
 

--- a/source/Harddisk.cpp
+++ b/source/Harddisk.cpp
@@ -896,7 +896,7 @@ bool HD_LoadSnapshot(YamlLoadHelper& yamlLoadHelper, UINT slot, UINT version, co
 	if (!bResSelectImage1 && !bResSelectImage2)
 		RegSaveString(TEXT(REG_PREFS), TEXT(REGVALUE_PREF_HDV_START_DIR), 1, strSaveStatePath);
 
-	HD_SetEnabled(true);
+	HD_SetEnabled(true, false);
 
 	GetFrame().FrameRefreshStatus(DRAW_LEDS | DRAW_DISK_STATUS);
 

--- a/source/Harddisk.cpp
+++ b/source/Harddisk.cpp
@@ -209,49 +209,59 @@ static void NotifyInvalidImage(TCHAR* pszImageFilename)
 
 BOOL HD_Insert(const int iDrive, const std::string& pathname);
 
-void HD_LoadLastDiskImage(const int iDrive)
+void HD_LoadLastDiskImage(const int drive)
 {
-	_ASSERT(iDrive == HARDDISK_1 || iDrive == HARDDISK_2);
+	_ASSERT(drive == HARDDISK_1 || drive == HARDDISK_2);
 
-	const char *pRegKey = (iDrive == HARDDISK_1)
+	const std::string regKey = (drive == HARDDISK_1)
 		? REGVALUE_PREF_LAST_HARDDISK_1
 		: REGVALUE_PREF_LAST_HARDDISK_2;
 
-	TCHAR sFilePath[MAX_PATH];
-	if (RegLoadString(TEXT(REG_PREFS), pRegKey, 1, sFilePath, MAX_PATH, TEXT("")))
+	char pathname[MAX_PATH];
+
+	std::string& regSection = RegGetConfigSlotSection(g_uSlot);
+	if (RegLoadString(regSection.c_str(), regKey.c_str(), TRUE, pathname, MAX_PATH, TEXT("")))
 	{
 		g_bSaveDiskImage = false;
-		// Pass in ptr to local copy of filepath, since RemoveDisk() sets DiskPathFilename = ""		// todo: update comment for HD func
-		HD_Insert(iDrive, sFilePath);
+		HD_Insert(drive, pathname);
 		g_bSaveDiskImage = true;
 	}
 }
 
 //===========================================================================
 
-static void HD_SaveLastDiskImage(const int iDrive)
+static void HD_SaveLastDiskImage(const int drive)
 {
-	_ASSERT(iDrive == HARDDISK_1 || iDrive == HARDDISK_2);
+	_ASSERT(drive == HARDDISK_1 || drive == HARDDISK_2);
 
 	if (!g_bSaveDiskImage)
 		return;
 
-	const std::string & pFileName = HD_GetFullPathName(iDrive);
+	std::string& regSection = RegGetConfigSlotSection(g_uSlot);
+	RegSaveValue(regSection.c_str(), REGVALUE_CARD_TYPE, TRUE, CT_GenericHDD);
 
-	if (iDrive == HARDDISK_1)
-		RegSaveString(TEXT(REG_PREFS), REGVALUE_PREF_LAST_HARDDISK_1, TRUE, pFileName);
-	else
-		RegSaveString(TEXT(REG_PREFS), REGVALUE_PREF_LAST_HARDDISK_2, TRUE, pFileName);
+	const std::string regKey = (drive == HARDDISK_1)
+		? REGVALUE_PREF_LAST_HARDDISK_1
+		: REGVALUE_PREF_LAST_HARDDISK_2;
+
+	const std::string& pathName = HD_GetFullPathName(drive);
+
+	RegSaveString(regSection.c_str(), regKey.c_str(), TRUE, pathName);
 
 	//
 
-	char szPathName[MAX_PATH];
-	strcpy(szPathName, pFileName.c_str());
-	if (_tcsrchr(szPathName, TEXT(PATH_SEPARATOR)))
+	// For now, only update 'HDV Starting Directory' for slot7 & drive1
+	// . otherwise you'll get inconsistent results if you set drive1, then drive2 (and the images were in different folders)
+	if (g_uSlot != SLOT7 || drive != HARDDISK_1)
+		return;
+
+	TCHAR szPathName[MAX_PATH];
+	StringCbCopy(szPathName, MAX_PATH, pathName.c_str());
+	TCHAR* slash = _tcsrchr(szPathName, PATH_SEPARATOR);
+	if (slash != NULL)
 	{
-		char* pPathEnd = _tcsrchr(szPathName, TEXT(PATH_SEPARATOR))+1;
-		*pPathEnd = 0;
-		RegSaveString(TEXT(REG_PREFS), TEXT(REGVALUE_PREF_HDV_START_DIR), 1, szPathName);
+		slash[1] = '\0';
+		RegSaveString(REG_PREFS, REGVALUE_PREF_HDV_START_DIR, 1, szPathName);
 	}
 }
 

--- a/source/Harddisk.cpp
+++ b/source/Harddisk.cpp
@@ -214,8 +214,8 @@ void HD_LoadLastDiskImage(const int drive)
 	_ASSERT(drive == HARDDISK_1 || drive == HARDDISK_2);
 
 	const std::string regKey = (drive == HARDDISK_1)
-		? REGVALUE_PREF_LAST_HARDDISK_1
-		: REGVALUE_PREF_LAST_HARDDISK_2;
+		? REGVALUE_LAST_HARDDISK_1
+		: REGVALUE_LAST_HARDDISK_2;
 
 	char pathname[MAX_PATH];
 
@@ -241,8 +241,8 @@ static void HD_SaveLastDiskImage(const int drive)
 	RegSaveValue(regSection.c_str(), REGVALUE_CARD_TYPE, TRUE, CT_GenericHDD);
 
 	const std::string regKey = (drive == HARDDISK_1)
-		? REGVALUE_PREF_LAST_HARDDISK_1
-		: REGVALUE_PREF_LAST_HARDDISK_2;
+		? REGVALUE_LAST_HARDDISK_1
+		: REGVALUE_LAST_HARDDISK_2;
 
 	const std::string& pathName = HD_GetFullPathName(drive);
 

--- a/source/Harddisk.h
+++ b/source/Harddisk.h
@@ -37,7 +37,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 	void HD_Destroy(void);
 	bool HD_CardIsEnabled(void);
-	void HD_SetEnabled(const bool bEnabled);
+	void HD_SetEnabled(const bool bEnabled, bool updateRegistry = true);
 	const std::string & HD_GetFullName(const int iDrive);
 	const std::string & HD_GetFullPathName(const int iDrive);
 	void HD_GetFilenameAndPathForSaveState(std::string& filename, std::string& path);

--- a/source/Registry.cpp
+++ b/source/Registry.cpp
@@ -158,8 +158,15 @@ void RegSaveValue (LPCTSTR section, LPCTSTR key, BOOL peruser, DWORD value) {
 static std::string& RegGetSlotSection(UINT slot)
 {
 	static std::string section;
-	section = REG_CONFIG_SLOT;
-	section += (char)('0' + slot);
+	if (slot == SLOT_AUX)
+	{
+		section = REG_CONFIG_SLOT_AUX;
+	}
+	else
+	{
+		section = REG_CONFIG_SLOT;
+		section += (char)('0' + slot);
+	}
 	return section;
 }
 
@@ -177,8 +184,7 @@ void RegDeleteConfigSlotSection(UINT slot)
 
 	if (!g_sConfigFile.empty())
 	{
-		std::string section = REG_CONFIG "\\";
-		section += RegGetSlotSection(slot);
+		std::string& section = RegGetConfigSlotSection(slot);
 		return _ini::RegDeleteString(section.c_str(), peruser);
 	}
 
@@ -194,11 +200,21 @@ void RegDeleteConfigSlotSection(UINT slot)
 		&keyhandle);
 	if (status == ERROR_SUCCESS)
 	{
-		std::string& keySlot = RegGetSlotSection(slot);
-		LSTATUS status2 = RegDeleteKey(keyhandle, keySlot.c_str());
+		std::string& section = RegGetSlotSection(slot);
+		LSTATUS status2 = RegDeleteKey(keyhandle, section.c_str());
 		if (status2 != ERROR_SUCCESS && status2 != ERROR_FILE_NOT_FOUND)
 			_ASSERT(0);
 	}
 
 	RegCloseKey(keyhandle);
+}
+
+void RegSetConfigSlotNewCardType(UINT slot, SS_CARDTYPE type)
+{
+	RegDeleteConfigSlotSection(slot);
+
+	std::string regSection;
+	regSection = RegGetConfigSlotSection(slot);
+
+	RegSaveValue(regSection.c_str(), REGVALUE_CARD_TYPE, TRUE, type);
 }

--- a/source/Registry.h
+++ b/source/Registry.h
@@ -13,3 +13,4 @@ void RegSaveValue (LPCTSTR section, LPCTSTR key, BOOL peruser, DWORD value);
 
 std::string& RegGetConfigSlotSection(UINT slot);
 void RegDeleteConfigSlotSection(UINT slot);
+void RegSetConfigSlotNewCardType(UINT slot, enum SS_CARDTYPE type);

--- a/source/SaveState.cpp
+++ b/source/SaveState.cpp
@@ -415,7 +415,7 @@ static void ParseSlots(YamlLoadHelper& yamlLoadHelper, UINT unitVersion)
 	{
 		if (cardInserted[slot])
 			continue;
-		GetCardMgr().Insert(slot, CT_Empty);
+		GetCardMgr().Remove(slot);
 	}
 }
 

--- a/source/SaveState.cpp
+++ b/source/SaveState.cpp
@@ -372,7 +372,6 @@ static void ParseSlots(YamlLoadHelper& yamlLoadHelper, UINT unitVersion)
 			type = CT_GenericHDD;
 			GetCardMgr().Insert(slot, type);
 			bRes = HD_LoadSnapshot(yamlLoadHelper, slot, cardVersion, g_strSaveStatePath);
-//			m_ConfigNew.m_bEnableHDD = true;
 		}
 		else if (card == LanguageCardSlot0::GetSnapshotCardName())
 		{
@@ -479,7 +478,6 @@ static void Snapshot_LoadState_v2(void)
 
 		restart = true;
 
-		//m_ConfigNew.m_bEnableHDD = false;
 		//m_ConfigNew.m_bEnableTheFreezesF8Rom = ?;	// todo: when support saving config
 
 		for (UINT slot = SLOT0; slot < NUM_SLOTS; slot++)
@@ -490,7 +488,7 @@ static void Snapshot_LoadState_v2(void)
 		GetPravets().Reset();
 
 		HD_Reset();
-		HD_SetEnabled(false);
+		HD_SetEnabled(false);				// Set disabled & also removes card from slot 7
 
 		KeybReset();
 		GetVideo().VideoResetState();

--- a/source/SaveState.cpp
+++ b/source/SaveState.cpp
@@ -301,6 +301,8 @@ static void ParseSlots(YamlLoadHelper& yamlLoadHelper, UINT unitVersion)
 	if (unitVersion != UNIT_SLOTS_VER)
 		throw std::string(SS_YAML_KEY_UNIT ": Slots: Version mismatch");
 
+	bool cardInserted[NUM_SLOTS] = {};
+
 	while (1)
 	{
 		std::string scalar = yamlLoadHelper.GetMapNextSlotNumber();
@@ -403,8 +405,18 @@ static void ParseSlots(YamlLoadHelper& yamlLoadHelper, UINT unitVersion)
 			throw std::string("Slots: Unknown card: " + card);	// todo: don't throw - just ignore & continue
 		}
 
+		cardInserted[slot] = true;
+
 		yamlLoadHelper.PopMap();
 		yamlLoadHelper.PopMap();
+	}
+
+	// Save-state may not contain any info about empty slots, so ensure they are set to empty
+	for (UINT slot = SLOT0; slot < NUM_SLOTS; slot++)
+	{
+		if (cardInserted[slot])
+			continue;
+		GetCardMgr().Insert(slot, CT_Empty);
 	}
 }
 

--- a/source/SaveState.cpp
+++ b/source/SaveState.cpp
@@ -286,6 +286,7 @@ static void ParseUnitApple2(YamlLoadHelper& yamlLoadHelper, UINT version)
 	KeybLoadSnapshot(yamlLoadHelper, version);
 	SpkrLoadSnapshot(yamlLoadHelper);
 	GetVideo().VideoLoadSnapshot(yamlLoadHelper, version);
+	m_ConfigNew.m_videoRefreshRate = GetVideo().GetVideoRefreshRate();
 	MemLoadSnapshot(yamlLoadHelper, version);
 
 	// g_Apple2Type may've changed: so redraw frame (title, buttons, leds, etc)
@@ -308,7 +309,7 @@ static void ParseSlots(YamlLoadHelper& yamlLoadHelper, UINT unitVersion)
 
 		const int slot = strtoul(scalar.c_str(), NULL, 10);	// NB. aux slot supported as a different "unit"
 															// NB. slot-0 only supported for Apple II or II+ (or similar clones)
-		if (slot < 0 || slot > 7)
+		if (slot < SLOT0 || slot > SLOT7)
 			throw std::string("Slots: Invalid slot #: ") + scalar;
 
 		yamlLoadHelper.GetSubMap(scalar);
@@ -324,8 +325,9 @@ static void ParseSlots(YamlLoadHelper& yamlLoadHelper, UINT unitVersion)
 
 		if (card == Printer_GetSnapshotCardName())
 		{
-			bRes = Printer_LoadSnapshot(yamlLoadHelper, slot, cardVersion);
 			type = CT_GenericPrinter;
+			GetCardMgr().Insert(slot, type);
+			bRes = Printer_LoadSnapshot(yamlLoadHelper, slot, cardVersion);
 		}
 		else if (card == CSuperSerialCard::GetSnapshotCardName())
 		{
@@ -341,18 +343,21 @@ static void ParseSlots(YamlLoadHelper& yamlLoadHelper, UINT unitVersion)
 		}
 		else if (card == Z80_GetSnapshotCardName())
 		{
-			bRes = Z80_LoadSnapshot(yamlLoadHelper, slot, cardVersion);
 			type = CT_Z80;
+			GetCardMgr().Insert(slot, type);
+			bRes = Z80_LoadSnapshot(yamlLoadHelper, slot, cardVersion);
 		}
 		else if (card == MB_GetSnapshotCardName())
 		{
-			bRes = MB_LoadSnapshot(yamlLoadHelper, slot, cardVersion);
 			type = CT_MockingboardC;
+			GetCardMgr().Insert(slot, type);
+			bRes = MB_LoadSnapshot(yamlLoadHelper, slot, cardVersion);
 		}
 		else if (card == Phasor_GetSnapshotCardName())
 		{
-			bRes = Phasor_LoadSnapshot(yamlLoadHelper, slot, cardVersion);
 			type = CT_Phasor;
+			GetCardMgr().Insert(slot, type);
+			bRes = Phasor_LoadSnapshot(yamlLoadHelper, slot, cardVersion);
 		}
 		else if (card == Disk2InterfaceCard::GetSnapshotCardName())
 		{
@@ -362,21 +367,22 @@ static void ParseSlots(YamlLoadHelper& yamlLoadHelper, UINT unitVersion)
 		}
 		else if (card == HD_GetSnapshotCardName())
 		{
+			type = CT_GenericHDD;
+			GetCardMgr().Insert(slot, type);
 			bRes = HD_LoadSnapshot(yamlLoadHelper, slot, cardVersion, g_strSaveStatePath);
 			m_ConfigNew.m_bEnableHDD = true;
-			type = CT_GenericHDD;
 		}
 		else if (card == LanguageCardSlot0::GetSnapshotCardName())
 		{
 			type = CT_LanguageCard;
-			SetExpansionMemType(type);
+			SetExpansionMemType(type);	// calls GetCardMgr().Insert() & InsertAux()
 			CreateLanguageCard();
 			bRes = GetLanguageCard()->LoadSnapshot(yamlLoadHelper, slot, cardVersion);
 		}
 		else if (card == Saturn128K::GetSnapshotCardName())
 		{
 			type = CT_Saturn128K;
-			SetExpansionMemType(type);
+			SetExpansionMemType(type);	// calls GetCardMgr().Insert() & InsertAux()
 			CreateLanguageCard();
 			bRes = GetLanguageCard()->LoadSnapshot(yamlLoadHelper, slot, cardVersion);
 		}
@@ -395,11 +401,6 @@ static void ParseSlots(YamlLoadHelper& yamlLoadHelper, UINT unitVersion)
 		else
 		{
 			throw std::string("Slots: Unknown card: " + card);	// todo: don't throw - just ignore & continue
-		}
-
-		if (bRes)
-		{
-			m_ConfigNew.m_Slot[slot] = type;
 		}
 
 		yamlLoadHelper.PopMap();
@@ -466,41 +467,15 @@ static void Snapshot_LoadState_v2(void)
 
 		restart = true;
 
-		CConfigNeedingRestart ConfigOld;
-		//ConfigOld.m_Slot[0] = CT_LanguageCard;	// fixme: II/II+=LC, //e=empty
-		ConfigOld.m_Slot[1] = CT_GenericPrinter;	// fixme
-		ConfigOld.m_Slot[2] = CT_SSC;				// fixme
-		//ConfigOld.m_Slot[3] = CT_Uthernet;		// todo
-		ConfigOld.m_Slot[6] = CT_Disk2;				// fixme
-		ConfigOld.m_Slot[7] = ConfigOld.m_bEnableHDD ? CT_GenericHDD : CT_Empty;	// fixme
-		//ConfigOld.m_SlotAux = ?;					// fixme
-
-		for (UINT i=0; i<NUM_SLOTS; i++)
-			m_ConfigNew.m_Slot[i] = CT_Empty;
-		m_ConfigNew.m_SlotAux = CT_Empty;
 		m_ConfigNew.m_bEnableHDD = false;
 		//m_ConfigNew.m_bEnableTheFreezesF8Rom = ?;	// todo: when support saving config
 
+		for (UINT slot = SLOT0; slot < NUM_SLOTS; slot++)
+			GetCardMgr().Remove(slot);
+		GetCardMgr().RemoveAux();
+
 		MemReset();							// Also calls CpuInitialize()
 		GetPravets().Reset();
-
-		if (GetCardMgr().IsSSCInstalled())
-		{
-			GetCardMgr().GetSSC()->CommReset();
-		}
-		else
-		{
-			_ASSERT(GetCardMgr().QuerySlot(SLOT2) == CT_Empty);
-			ConfigOld.m_Slot[2] = CT_Empty;
-		}
-
-		if (GetCardMgr().QuerySlot(SLOT4) == CT_MouseInterface)
-			GetCardMgr().Remove(SLOT4);		// Remove Mouse card from slot-4
-
-		if (GetCardMgr().QuerySlot(SLOT5) == CT_Disk2)
-			GetCardMgr().Remove(SLOT5);		// Remove Disk2 card from slot-5
-
-		GetCardMgr().GetDisk2CardMgr().Reset(false);
 
 		HD_Reset();
 		HD_SetEnabled(false);
@@ -530,7 +505,7 @@ static void Snapshot_LoadState_v2(void)
 		// . A change in h/w via loading a save-state avoids this VM restart
 		// The latter is the desired approach (as the former needs a "power-on" / F2 to start things again)
 
-		GetPropertySheet().ApplyNewConfig(m_ConfigNew, ConfigOld);	// Mainly just saves (some) new state to Registry
+		GetPropertySheet().ApplyNewConfigFromSnapshot(m_ConfigNew);	// Saves new state to Registry (not slot/cards though)
 
 		MemInitializeROM();
 		MemInitializeCustomROM();

--- a/source/SaveState.cpp
+++ b/source/SaveState.cpp
@@ -372,7 +372,7 @@ static void ParseSlots(YamlLoadHelper& yamlLoadHelper, UINT unitVersion)
 			type = CT_GenericHDD;
 			GetCardMgr().Insert(slot, type);
 			bRes = HD_LoadSnapshot(yamlLoadHelper, slot, cardVersion, g_strSaveStatePath);
-			m_ConfigNew.m_bEnableHDD = true;
+//			m_ConfigNew.m_bEnableHDD = true;
 		}
 		else if (card == LanguageCardSlot0::GetSnapshotCardName())
 		{
@@ -479,7 +479,7 @@ static void Snapshot_LoadState_v2(void)
 
 		restart = true;
 
-		m_ConfigNew.m_bEnableHDD = false;
+		//m_ConfigNew.m_bEnableHDD = false;
 		//m_ConfigNew.m_bEnableTheFreezesF8Rom = ?;	// todo: when support saving config
 
 		for (UINT slot = SLOT0; slot < NUM_SLOTS; slot++)

--- a/source/SerialComms.cpp
+++ b/source/SerialComms.cpp
@@ -1395,8 +1395,6 @@ void CSuperSerialCard::SetSerialPortName(const char* pSerialPortName)
 		m_ayCurrentSerialPortName.clear();	// "None"
 		m_dwSerialPortItem = 0;
 	}
-
-	SetRegistrySerialPortName();
 }
 
 void CSuperSerialCard::SetRegistrySerialPortName(void)
@@ -1526,6 +1524,7 @@ bool CSuperSerialCard::LoadSnapshot(YamlLoadHelper& yamlLoadHelper, UINT slot, U
 
 	std::string serialPortName = yamlLoadHelper.LoadString(SS_YAML_KEY_SERIALPORTNAME);
 	SetSerialPortName(serialPortName.c_str());
+	SetRegistrySerialPortName();
 
 	return true;
 }

--- a/source/SerialComms.cpp
+++ b/source/SerialComms.cpp
@@ -72,7 +72,6 @@ CSuperSerialCard::CSuperSerialCard(UINT slot) :
 	m_bCfgSupportDCD(false),
 	m_pExpansionRom(NULL)
 {
-	m_currentSerialPortName.clear();
 	m_dwSerialPortItem = 0;
 
 	m_hCommHandle = INVALID_HANDLE_VALUE;
@@ -88,7 +87,13 @@ CSuperSerialCard::CSuperSerialCard(UINT slot) :
 
 	InternalReset();
 
-	SetSerialPortName();
+	//
+
+	char serialPortName[CSuperSerialCard::SIZEOF_SERIALCHOICE_ITEM];
+	std::string& regSection = RegGetConfigSlotSection(m_uSlot);
+	RegLoadString(regSection.c_str(), REGVALUE_SERIAL_PORT_NAME, TRUE, serialPortName, sizeof(serialPortName), TEXT(""));
+
+	SetSerialPortName(serialPortName);
 }
 
 void CSuperSerialCard::InternalReset()
@@ -1347,17 +1352,7 @@ char* CSuperSerialCard::GetSerialPortChoices()
 	return m_aySerialPortChoices;
 }
 
-// Called by ctor
-void CSuperSerialCard::SetSerialPortName(void)
-{
-	char serialPortName[CSuperSerialCard::SIZEOF_SERIALCHOICE_ITEM];
-	std::string& regSection = RegGetConfigSlotSection(m_uSlot);
-	RegLoadString(regSection.c_str(), REGVALUE_SERIAL_PORT_NAME, TRUE, serialPortName, sizeof(serialPortName), TEXT(""));
-
-	SetSerialPortName(serialPortName);
-}
-
-// Called by LoadSnapshot()
+// Called by ctor & LoadSnapshot()
 void CSuperSerialCard::SetSerialPortName(const char* pSerialPortName)
 {
 	m_currentSerialPortName = pSerialPortName;

--- a/source/SerialComms.cpp
+++ b/source/SerialComms.cpp
@@ -1012,8 +1012,7 @@ void CSuperSerialCard::CommSetSerialPort(DWORD dwNewSerialPortItem)
 		m_ayCurrentSerialPortName.clear();	// "None"
 	}
 
-	std::string& regSection = RegGetConfigSlotSection(m_uSlot);
-	RegSaveString(regSection.c_str(), REGVALUE_SERIAL_PORT_NAME, TRUE, GetSerialPortName());
+	SetRegistrySerialPortName();
 }
 
 //===========================================================================
@@ -1396,6 +1395,14 @@ void CSuperSerialCard::SetSerialPortName(const char* pSerialPortName)
 		m_ayCurrentSerialPortName.clear();	// "None"
 		m_dwSerialPortItem = 0;
 	}
+
+	SetRegistrySerialPortName();
+}
+
+void CSuperSerialCard::SetRegistrySerialPortName(void)
+{
+	std::string& regSection = RegGetConfigSlotSection(m_uSlot);
+	RegSaveString(regSection.c_str(), REGVALUE_SERIAL_PORT_NAME, TRUE, GetSerialPortName());
 }
 
 //===========================================================================

--- a/source/SerialComms.cpp
+++ b/source/SerialComms.cpp
@@ -72,7 +72,7 @@ CSuperSerialCard::CSuperSerialCard(UINT slot) :
 	m_bCfgSupportDCD(false),
 	m_pExpansionRom(NULL)
 {
-	m_ayCurrentSerialPortName.clear();
+	m_currentSerialPortName.clear();
 	m_dwSerialPortItem = 0;
 
 	m_hCommHandle = INVALID_HANDLE_VALUE;
@@ -999,17 +999,17 @@ void CSuperSerialCard::CommSetSerialPort(DWORD dwNewSerialPortItem)
 
 	if (m_dwSerialPortItem == m_uTCPChoiceItemIdx)
 	{
-		m_ayCurrentSerialPortName = TEXT_SERIAL_TCP;
+		m_currentSerialPortName = TEXT_SERIAL_TCP;
 	}
 	else if (m_dwSerialPortItem != 0)
 	{
 		TCHAR temp[SIZEOF_SERIALCHOICE_ITEM];
 		sprintf(temp, TEXT_SERIAL_COM"%d", m_vecSerialPortsItems[m_dwSerialPortItem]);
-		m_ayCurrentSerialPortName = temp;
+		m_currentSerialPortName = temp;
 	}
 	else
 	{
-		m_ayCurrentSerialPortName.clear();	// "None"
+		m_currentSerialPortName.clear();	// "None"
 	}
 
 	SetRegistrySerialPortName();
@@ -1360,7 +1360,7 @@ void CSuperSerialCard::SetSerialPortName(void)
 // Called by LoadSnapshot()
 void CSuperSerialCard::SetSerialPortName(const char* pSerialPortName)
 {
-	m_ayCurrentSerialPortName = pSerialPortName;
+	m_currentSerialPortName = pSerialPortName;
 
 	// Init m_aySerialPortChoices, so that we have choices to show if serial is active when we 1st open Config dialog
 	GetSerialPortChoices();
@@ -1392,7 +1392,7 @@ void CSuperSerialCard::SetSerialPortName(const char* pSerialPortName)
 	}
 	else
 	{
-		m_ayCurrentSerialPortName.clear();	// "None"
+		m_currentSerialPortName.clear();	// "None"
 		m_dwSerialPortItem = 0;
 	}
 }

--- a/source/SerialComms.h
+++ b/source/SerialComms.h
@@ -42,7 +42,6 @@ public:
 	char*	GetSerialPortChoices();
 	DWORD	GetSerialPort() { return m_dwSerialPortItem; }	// Drop-down list item
 	const std::string& GetSerialPortName() { return m_currentSerialPortName; }
-	void	SetSerialPortName(void);
 	bool	IsActive() { return (m_hCommHandle != INVALID_HANDLE_VALUE) || (m_hCommListenSocket != INVALID_SOCKET); }
 	void	SupportDCD(bool bEnable) { m_bCfgSupportDCD = bEnable; }	// Status
 

--- a/source/SerialComms.h
+++ b/source/SerialComms.h
@@ -34,7 +34,7 @@ public:
 	void	CommInitialize(LPBYTE pCxRomPeripheral, UINT uSlot);
 	void    CommReset();
 	void    CommDestroy();
-	void    CommSetSerialPort(HWND hWindow, DWORD dwNewSerialPortItem);
+	void    CommSetSerialPort(DWORD dwNewSerialPortItem);
 	static std::string GetSnapshotCardName(void);
 	void	SaveSnapshot(class YamlSaveHelper& yamlSaveHelper);
 	bool	LoadSnapshot(class YamlLoadHelper& yamlLoadHelper, UINT slot, UINT version);
@@ -42,7 +42,7 @@ public:
 	char*	GetSerialPortChoices();
 	DWORD	GetSerialPort() { return m_dwSerialPortItem; }	// Drop-down list item
 	const std::string &	GetSerialPortName() { return m_ayCurrentSerialPortName; }
-	void	SetSerialPortName(const char* pSerialPortName);
+	void	SetSerialPortName(void);
 	bool	IsActive() { return (m_hCommHandle != INVALID_HANDLE_VALUE) || (m_hCommListenSocket != INVALID_SOCKET); }
 	void	SupportDCD(bool bEnable) { m_bCfgSupportDCD = bEnable; }	// Status
 
@@ -80,6 +80,7 @@ private:
 	void	CommThUninit();
 	UINT	GetNumSerialPortChoices() { return m_vecSerialPortsItems.size(); }
 	void	ScanCOMPorts();
+	void	SetSerialPortName(const char* pSerialPortName);
 	void	SaveSnapshotDIPSW(class YamlSaveHelper& yamlSaveHelper, std::string key, SSC_DIPSW& dipsw);
 	void	LoadSnapshotDIPSW(class YamlLoadHelper& yamlLoadHelper, std::string key, SSC_DIPSW& dipsw);
 

--- a/source/SerialComms.h
+++ b/source/SerialComms.h
@@ -41,7 +41,7 @@ public:
 
 	char*	GetSerialPortChoices();
 	DWORD	GetSerialPort() { return m_dwSerialPortItem; }	// Drop-down list item
-	const std::string &	GetSerialPortName() { return m_ayCurrentSerialPortName; }
+	const std::string& GetSerialPortName() { return m_currentSerialPortName; }
 	void	SetSerialPortName(void);
 	bool	IsActive() { return (m_hCommHandle != INVALID_HANDLE_VALUE) || (m_hCommListenSocket != INVALID_SOCKET); }
 	void	SupportDCD(bool bEnable) { m_bCfgSupportDCD = bEnable; }	// Status
@@ -91,7 +91,7 @@ public:
 	static const UINT SIZEOF_SERIALCHOICE_ITEM = 12*sizeof(char);
 
 private:
-	std::string m_ayCurrentSerialPortName;
+	std::string m_currentSerialPortName;
 	DWORD	m_dwSerialPortItem;
 
 	static const UINT SERIALPORTITEM_INVALID_COM_PORT = 0;

--- a/source/SerialComms.h
+++ b/source/SerialComms.h
@@ -81,6 +81,7 @@ private:
 	UINT	GetNumSerialPortChoices() { return m_vecSerialPortsItems.size(); }
 	void	ScanCOMPorts();
 	void	SetSerialPortName(const char* pSerialPortName);
+	void	SetRegistrySerialPortName(void);
 	void	SaveSnapshotDIPSW(class YamlSaveHelper& yamlSaveHelper, std::string key, SSC_DIPSW& dipsw);
 	void	LoadSnapshotDIPSW(class YamlLoadHelper& yamlLoadHelper, std::string key, SSC_DIPSW& dipsw);
 

--- a/source/Utilities.cpp
+++ b/source/Utilities.cpp
@@ -181,18 +181,6 @@ void LoadConfiguration(void)
 		break;
 	}
 
-	TCHAR serialPortName[CSuperSerialCard::SIZEOF_SERIALCHOICE_ITEM];
-	if (RegLoadString(
-		TEXT(REG_CONFIG),
-		TEXT(REGVALUE_SERIAL_PORT_NAME),
-		TRUE,
-		serialPortName,
-		CSuperSerialCard::SIZEOF_SERIALCHOICE_ITEM))
-	{
-		if (GetCardMgr().IsSSCInstalled())
-			GetCardMgr().GetSSC()->SetSerialPortName(serialPortName);
-	}
-
 	REGLOAD_DEFAULT(TEXT(REGVALUE_EMULATION_SPEED), &g_dwSpeed, SPEED_NORMAL);
 	GetVideo().Config_Load_Video();
 	SetCurrentCLK6502();	// Pre: g_dwSpeed && Config_Load_Video()->SetVideoRefreshRate()
@@ -264,7 +252,7 @@ void LoadConfiguration(void)
 
 		if (RegLoadValue(regSection.c_str(), REGVALUE_CARD_TYPE, TRUE, &dwTmp))
 		{
-			GetCardMgr().Insert(slot, (SS_CARDTYPE)dwTmp);
+			GetCardMgr().Insert(slot, (SS_CARDTYPE)dwTmp, false);
 
 			if (slot == SLOT3)
 			{
@@ -284,7 +272,7 @@ void LoadConfiguration(void)
 			else if (slot == SLOT7)
 			{
 				if ((SS_CARDTYPE)dwTmp == CT_GenericHDD)	// TODO: move this to when HarddiskInterfaceCard object is instantiated
-					HD_SetEnabled(true);
+					HD_SetEnabled(true, false);
 			}
 		}
 		else	// legacy (AppleWin 1.30.3 or earlier)

--- a/source/Utilities.cpp
+++ b/source/Utilities.cpp
@@ -281,6 +281,11 @@ void LoadConfiguration(void)
 					tfe_enabled = 0;
 				}
 			}
+			else if (slot == SLOT7)
+			{
+				if ((SS_CARDTYPE)dwTmp == CT_GenericHDD)	// TODO: move this to when HarddiskInterfaceCard object is instantiated
+					HD_SetEnabled(true);
+			}
 		}
 		else	// legacy (AppleWin 1.30.3 or earlier)
 		{
@@ -459,16 +464,7 @@ void InsertHardDisks(LPCSTR szImageName_harddisk[NUM_HARDDISKS], bool& bBoot)
 	if (!szImageName_harddisk[HARDDISK_1] && !szImageName_harddisk[HARDDISK_2])
 		return;
 
-	// Enable the Harddisk controller card
-
-	HD_SetEnabled(true);
-
-	DWORD dwTmp;
-	BOOL res = REGLOAD(TEXT(REGVALUE_HDD_ENABLED), &dwTmp);
-	if (!res || !dwTmp)
-		REGSAVE(TEXT(REGVALUE_HDD_ENABLED), 1);	// Config: HDD Enabled
-
-	//
+	HD_SetEnabled(true);	// Enable the Harddisk controller card
 
 	bool bRes = true;
 
@@ -493,11 +489,6 @@ void InsertHardDisks(LPCSTR szImageName_harddisk[NUM_HARDDISKS], bool& bBoot)
 void UnplugHardDiskControllerCard(void)
 {
 	HD_SetEnabled(false);
-
-	DWORD dwTmp;
-	BOOL res = REGLOAD(TEXT(REGVALUE_HDD_ENABLED), &dwTmp);
-	if (!res || dwTmp)
-		REGSAVE(TEXT(REGVALUE_HDD_ENABLED), 0);	// Config: HDD Disabled
 }
 
 void GetAppleWindowTitle()

--- a/source/Windows/AppleWin.cpp
+++ b/source/Windows/AppleWin.cpp
@@ -745,7 +745,7 @@ static void RepeatInitialization(void)
 		VideoSwitchVideocardPalette(RGB_GetVideocard(), GetVideo().GetVideoType());
 
 		// Allow the 4 hardcoded slots to be configurated as empty
-		// NB. this state is not persisted to the Registry/conf.ini (just as '-s7 empty' isn't)
+		// NB. this state *is* persisted to the Registry/conf.ini (just like '-s7 empty' is)
 		// TODO: support bSlotEmpty[] for slots: 0,4,5
 		if (g_cmdLine.bSlotEmpty[SLOT1])
 			GetCardMgr().Remove(SLOT1);
@@ -782,7 +782,7 @@ static void RepeatInitialization(void)
 
 			if (g_cmdLine.bSlotEmpty[SLOT7])
 			{
-				HD_SetEnabled(false);		// Disable HDD controller, but don't persist this to Registry/conf.ini (consistent with other '-sn empty' cmds)
+				HD_SetEnabled(false);		// Disable HDD controller, and persist this to Registry/conf.ini (consistent with other '-sn empty' cmds)
 				Snapshot_UpdatePath();		// If save-state's filename is a harddisk, and the floppy is in the same path, then the filename won't be updated
 			}
 		}

--- a/source/Windows/AppleWin.cpp
+++ b/source/Windows/AppleWin.cpp
@@ -772,7 +772,7 @@ static void RepeatInitialization(void)
 		{
 			bool temp = false;
 			InsertFloppyDisks(SLOT5, g_cmdLine.szImageName_drive[SLOT5], g_cmdLine.driveConnected[SLOT5], temp);
-			//g_cmdLine.szImageName_drive[SLOT5][DRIVE_1] = g_cmdLine.szImageName_drive[SLOT5][DRIVE_2] = NULL;	// *Do* insert on a restart (since no way they could have changed)
+			g_cmdLine.szImageName_drive[SLOT5][DRIVE_1] = g_cmdLine.szImageName_drive[SLOT5][DRIVE_2] = NULL;	// Don't insert on a restart
 
 			InsertFloppyDisks(SLOT6, g_cmdLine.szImageName_drive[SLOT6], g_cmdLine.driveConnected[SLOT6], g_cmdLine.bBoot);
 			g_cmdLine.szImageName_drive[SLOT6][DRIVE_1] = g_cmdLine.szImageName_drive[SLOT6][DRIVE_2] = NULL;	// Don't insert on a restart


### PR DESCRIPTION
Encompasses PR #956.
Initially all cards are removed before loading save-state.

Use new Registry "Configuration/Slot 2" location to save SSC's port name.
Use new Registry "Configuration/Slot 7" location to save HDV's image names.
Use new Registry "Configuration/Slot n" (and "Configuration/Slot Auxiliary") locations to save all other card types.

Command line: -s\<slot\> <card> (eg. -s7 empty) now get persisted to the Registry.

Only update 'HDV Starting Directory' for slot7 & drive1.