### PR TITLE
Card::InitializeIO

### DIFF
--- a/AppleWinExpress2008.vcproj
+++ b/AppleWinExpress2008.vcproj
@@ -658,6 +658,10 @@
 					>
 				</File>
 				<File
+					RelativePath=".\source\Card.cpp"
+					>
+				</File>
+				<File
 					RelativePath=".\source\Card.h"
 					>
 				</File>

--- a/AppleWinExpress2019.vcxproj
+++ b/AppleWinExpress2019.vcxproj
@@ -144,6 +144,7 @@
   <ItemGroup>
     <ClCompile Include="source\6821.cpp" />
     <ClCompile Include="source\AY8910.cpp" />
+    <ClCompile Include="source\Card.cpp" />
     <ClCompile Include="source\CardManager.cpp" />
     <ClCompile Include="source\CmdLine.cpp" />
     <ClCompile Include="source\Configuration\About.cpp" />

--- a/AppleWinExpress2019.vcxproj.filters
+++ b/AppleWinExpress2019.vcxproj.filters
@@ -238,6 +238,9 @@
     <ClCompile Include="source\SNESMAX.cpp">
       <Filter>Source Files\Emulator</Filter>
     </ClCompile>
+    <ClCompile Include="source\Card.cpp">
+      <Filter>Source Files\Emulator</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="source\CommonVICE\6510core.h">

--- a/source/Card.cpp
+++ b/source/Card.cpp
@@ -1,0 +1,54 @@
+/*
+AppleWin : An Apple //e emulator for Windows
+
+Copyright (C) 2021, Tom Charlesworth, Michael Pohoreski
+
+AppleWin is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+AppleWin is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with AppleWin; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+#include "StdAfx.h"
+#include "Card.h"
+
+#include "Tfe/tfe.h"
+#include "Mockingboard.h"
+#include "ParallelPrinter.h"
+#include "z80emu.h"
+
+
+void DummyCard::InitializeIO(LPBYTE pCxRomPeripheral)
+{
+	switch (QueryType())
+	{
+	case CT_GenericPrinter:
+		PrintLoadRom(pCxRomPeripheral, m_slot);
+		break;
+	case CT_Uthernet:
+		tfe_InitializeIO(pCxRomPeripheral, m_slot);
+		break;
+	case CT_GenericClock:
+		break; // nothing to do
+	case CT_MockingboardC:
+	case CT_Phasor:
+		// only in slot 4
+		if (m_slot == SLOT4)
+		{
+			MB_InitializeIO(pCxRomPeripheral, SLOT4, SLOT5);
+		}
+		break;
+	case CT_Z80:
+		Z80_InitializeIO(pCxRomPeripheral, m_slot);
+		break;
+	}
+}

--- a/source/Card.h
+++ b/source/Card.h
@@ -34,6 +34,7 @@ public:
 	Card(SS_CARDTYPE type, UINT slot) : m_type(type), m_slot(slot) {}
 	virtual ~Card(void) {}
 
+	virtual void InitializeIO(LPBYTE pCxRomPeripheral) = 0;
 	virtual void Init(void) = 0;
 	virtual void Reset(const bool powerCycle) = 0;
 	SS_CARDTYPE QueryType(void) { return m_type; }
@@ -53,8 +54,9 @@ public:
 	EmptyCard(void) {}
 	virtual ~EmptyCard(void) {}
 
-	virtual void Init(void) {};
-	virtual void Reset(const bool powerCycle) {};
+	virtual void InitializeIO(LPBYTE pCxRomPeripheral) {}
+	virtual void Init(void) {}
+	virtual void Reset(const bool powerCycle) {}
 };
 
 //
@@ -65,6 +67,7 @@ public:
 	DummyCard(SS_CARDTYPE type, UINT slot) : Card(type, slot) {}
 	virtual ~DummyCard(void) {}
 
-	virtual void Init(void) {};
-	virtual void Reset(const bool powerCycle) {};
+	virtual void InitializeIO(LPBYTE pCxRomPeripheral);
+	virtual void Init(void) {}
+	virtual void Reset(const bool powerCycle) {}
 };

--- a/source/Card.h
+++ b/source/Card.h
@@ -30,7 +30,6 @@ enum SLOTS { SLOT0=0, SLOT1, SLOT2, SLOT3, SLOT4, SLOT5, SLOT6, SLOT7, NUM_SLOTS
 class Card
 {
 public:
-	Card(void) : m_type(CT_Empty), m_slot(SLOT0) {}
 	Card(SS_CARDTYPE type, UINT slot) : m_type(type), m_slot(slot) {}
 	virtual ~Card(void) {}
 
@@ -51,7 +50,7 @@ private:
 class EmptyCard : public Card
 {
 public:
-	EmptyCard(void) {}
+	EmptyCard(UINT slot) : Card(CT_Empty, slot) {}
 	virtual ~EmptyCard(void) {}
 
 	virtual void InitializeIO(LPBYTE pCxRomPeripheral) {}

--- a/source/CardManager.cpp
+++ b/source/CardManager.cpp
@@ -188,3 +188,14 @@ void CardManager::RemoveAux(void)
 {
 	InsertAux(CT_Empty);
 }
+
+void CardManager::InitializeIO(LPBYTE pCxRomPeripheral)
+{
+	for (UINT i = 0; i < NUM_SLOTS; ++i)
+	{
+		if (m_slot[i])
+		{
+			m_slot[i]->InitializeIO(pCxRomPeripheral);
+		}
+	}
+}

--- a/source/CardManager.cpp
+++ b/source/CardManager.cpp
@@ -48,7 +48,7 @@ void CardManager::InsertInternal(UINT slot, SS_CARDTYPE type)
 	switch (type)
 	{
 	case CT_Empty:
-		m_slot[slot] = new EmptyCard;
+		m_slot[slot] = new EmptyCard(slot);
 		break;
 	case CT_Disk2:
 		m_slot[slot] = new Disk2InterfaceCard(slot);
@@ -150,7 +150,7 @@ void CardManager::InsertAuxInternal(SS_CARDTYPE type)
 	switch (type)
 	{
 	case CT_Empty:
-		m_aux = new EmptyCard;
+		m_aux = new EmptyCard(SLOT_AUX);
 		break;
 	case CT_80Col:
 		m_aux = new DummyCard(type, SLOT_AUX);

--- a/source/CardManager.h
+++ b/source/CardManager.h
@@ -57,6 +57,8 @@ public:
 	class CSuperSerialCard* GetSSC(void) { return m_pSSC; }
 	bool IsSSCInstalled(void) { return m_pSSC != NULL; }
 
+	void InitializeIO(LPBYTE pCxRomPeripheral);
+
 private:
 	void InsertInternal(UINT slot, SS_CARDTYPE type);
 	void InsertAuxInternal(SS_CARDTYPE type);

--- a/source/Disk.h
+++ b/source/Disk.h
@@ -130,7 +130,7 @@ public:
 	virtual void Init(void) {};
 	virtual void Reset(const bool powerCycle);
 
-	void InitializeIO(LPBYTE pCxRomPeripheral);
+	virtual void InitializeIO(LPBYTE pCxRomPeripheral);
 	void Destroy(void);		// no, doesn't "destroy" the disk image.  DiskIIManagerShutdown()
 
 	void Boot(void);

--- a/source/FourPlay.h
+++ b/source/FourPlay.h
@@ -14,7 +14,7 @@ public:
 	virtual void Init(void) {};
 	virtual void Reset(const bool powerCycle) {};
 
-	void InitializeIO(LPBYTE pCxRomPeripheral);
+	virtual void InitializeIO(LPBYTE pCxRomPeripheral);
 
 	static BYTE __stdcall IORead(WORD pc, WORD addr, BYTE bWrite, BYTE value, ULONG nExecutedCycles);
 

--- a/source/Harddisk.cpp
+++ b/source/Harddisk.cpp
@@ -149,7 +149,7 @@ void HarddiskInterfaceCard::Reset(const bool powerCycle)
 
 //===========================================================================
 
-void HarddiskInterfaceCard::InitializeIO(const LPBYTE pCxRomPeripheral)
+void HarddiskInterfaceCard::InitializeIO(LPBYTE pCxRomPeripheral)
 {
 	const DWORD HARDDISK_FW_SIZE = APPLE_SLOT_SIZE;
 

--- a/source/Harddisk.h
+++ b/source/Harddisk.h
@@ -88,7 +88,7 @@ public:
 	virtual void Init(void) {}
 	virtual void Reset(const bool powerCycle);
 
-	void InitializeIO(const LPBYTE pCxRomPeripheral);
+	virtual void InitializeIO(LPBYTE pCxRomPeripheral);
 	void Destroy(void);
 	const std::string& GetFullName(const int iDrive);
 	const std::string& HarddiskGetFullPathName(const int iDrive);

--- a/source/LanguageCard.cpp
+++ b/source/LanguageCard.cpp
@@ -50,7 +50,7 @@ LanguageCardUnit::~LanguageCardUnit(void)
 	SetMemMainLanguageCard(NULL);
 }
 
-void LanguageCardUnit::InitializeIO(void)
+void LanguageCardUnit::InitializeIO(LPBYTE pCxRomPeripheral)
 {
 	RegisterIoHandler(kSlot0, &LanguageCardUnit::IO, &LanguageCardUnit::IO, NULL, NULL, this, NULL);
 }
@@ -276,7 +276,7 @@ UINT Saturn128K::GetActiveBank(void)
 	return m_uSaturnActiveBank;
 }
 
-void Saturn128K::InitializeIO(void)
+void Saturn128K::InitializeIO(LPBYTE pCxRomPeripheral)
 {
 	RegisterIoHandler(kSlot0, &Saturn128K::IO, &Saturn128K::IO, NULL, NULL, this, NULL);
 }

--- a/source/LanguageCard.h
+++ b/source/LanguageCard.h
@@ -15,7 +15,7 @@ public:
 	virtual void Init(void) {};
 	virtual void Reset(const bool powerCycle) {};
 
-	virtual void InitializeIO(void);
+	virtual void InitializeIO(LPBYTE pCxRomPeripheral);
 	virtual void SetMemorySize(UINT banks) {}		// No-op for //e and slot-0 16K LC
 	virtual UINT GetActiveBank(void) { return 0; }	// Always 0 as only 1x 16K bank
 	virtual void SaveSnapshot(class YamlSaveHelper& yamlSaveHelper) { _ASSERT(0); } // Not used for //e
@@ -71,7 +71,7 @@ public:
 	Saturn128K(UINT banks);
 	virtual ~Saturn128K(void);
 
-	virtual void InitializeIO(void);
+	virtual void InitializeIO(LPBYTE pCxRomPeripheral);
 	virtual void SetMemorySize(UINT banks);
 	virtual UINT GetActiveBank(void);
 	virtual void SaveSnapshot(class YamlSaveHelper& yamlSaveHelper);

--- a/source/Memory.cpp
+++ b/source/Memory.cpp
@@ -1720,84 +1720,11 @@ void MemInitializeIO(void)
 	InitIoHandlers();
 
 	if (g_pLanguageCard)
-		g_pLanguageCard->InitializeIO();
+		g_pLanguageCard->InitializeIO(NULL);
 	else
 		RegisterIoHandler(LanguageCardUnit::kSlot0, IO_Null, IO_Null, NULL, NULL, NULL, NULL);
 
-	if (GetCardMgr().QuerySlot(SLOT1) == CT_GenericPrinter)
-		PrintLoadRom(pCxRomPeripheral, SLOT1);				// $C100 : Parallel printer f/w
-
-	if (GetCardMgr().QuerySlot(SLOT2) == CT_SSC)
-		dynamic_cast<CSuperSerialCard&>(GetCardMgr().GetRef(SLOT2)).InitializeIO(pCxRomPeripheral);	// $C200 : SSC
-
-	if (GetCardMgr().QuerySlot(SLOT3) == CT_Uthernet)
-	{
-		// Slot 3 contains the Uthernet card (which can coexist with an 80-col+Ram card in AUX slot)
-		// . Uthernet card has no ROM and only IO mapped at $C0Bx
-		tfe_InitializeIO(pCxRomPeripheral, SLOT3);
-	}
-	else if (GetCardMgr().QuerySlot(SLOT3) == CT_FourPlay)
-	{
-		dynamic_cast<FourPlayCard&>(GetCardMgr().GetRef(SLOT3)).InitializeIO(pCxRomPeripheral);
-	}
-	else if (GetCardMgr().QuerySlot(SLOT3) == CT_SNESMAX)
-	{
-		dynamic_cast<SNESMAXCard&>(GetCardMgr().GetRef(SLOT3)).InitializeIO(pCxRomPeripheral);
-	}
-
-	// Apple//e: Auxiliary slot contains Extended 80 Column card or RamWorksIII card
-
-	if (GetCardMgr().QuerySlot(SLOT4) == CT_MouseInterface)
-	{
-		dynamic_cast<CMouseInterface&>(GetCardMgr().GetRef(SLOT4)).InitializeIO(pCxRomPeripheral);	// $C400 : Mouse f/w
-	}
-	else if (GetCardMgr().QuerySlot(SLOT4) == CT_MockingboardC || GetCardMgr().QuerySlot(SLOT4) == CT_Phasor)
-	{
-		MB_InitializeIO(pCxRomPeripheral, SLOT4, SLOT5);
-	}
-	else if (GetCardMgr().QuerySlot(SLOT4) == CT_Z80)
-	{
-		Z80_InitializeIO(pCxRomPeripheral, SLOT4);		// $C400 : Z80 card
-	}
-//	else if (GetCardMgr().QuerySlot(SLOT4) == CT_GenericClock)
-//	{
-//		LoadRom_Clock_Generic(pCxRomPeripheral, SLOT4);
-//	}
-	else if (GetCardMgr().QuerySlot(SLOT4) == CT_FourPlay)
-	{
-		dynamic_cast<FourPlayCard&>(GetCardMgr().GetRef(SLOT4)).InitializeIO(pCxRomPeripheral);
-	}
-	else if (GetCardMgr().QuerySlot(SLOT4) == CT_SNESMAX)
-	{
-		dynamic_cast<SNESMAXCard&>(GetCardMgr().GetRef(SLOT4)).InitializeIO(pCxRomPeripheral);
-	}
-
-	if (GetCardMgr().QuerySlot(SLOT5) == CT_Z80)
-	{
-		Z80_InitializeIO(pCxRomPeripheral, SLOT5);		// $C500 : Z80 card
-	}
-	else if (GetCardMgr().QuerySlot(SLOT5) == CT_SAM)
-	{
-		dynamic_cast<SAMCard&>(GetCardMgr().GetRef(SLOT5)).InitializeIO(pCxRomPeripheral);
-	}
-	else if (GetCardMgr().QuerySlot(SLOT5) == CT_FourPlay)
-	{
-		dynamic_cast<FourPlayCard&>(GetCardMgr().GetRef(SLOT5)).InitializeIO(pCxRomPeripheral);
-	}
-	else if (GetCardMgr().QuerySlot(SLOT5) == CT_SNESMAX)
-	{
-		dynamic_cast<SNESMAXCard&>(GetCardMgr().GetRef(SLOT5)).InitializeIO(pCxRomPeripheral);
-	}
-	else if (GetCardMgr().QuerySlot(SLOT5) == CT_Disk2)
-	{
-		dynamic_cast<Disk2InterfaceCard&>(GetCardMgr().GetRef(SLOT5)).InitializeIO(pCxRomPeripheral);	// $C500 : Disk][ card
-	}
-
-	if (GetCardMgr().QuerySlot(SLOT6) == CT_Disk2)
-		dynamic_cast<Disk2InterfaceCard&>(GetCardMgr().GetRef(SLOT6)).InitializeIO(pCxRomPeripheral);	// $C600 : Disk][ card
-
-	if (GetCardMgr().QuerySlot(SLOT7) == CT_GenericHDD)
-		dynamic_cast<HarddiskInterfaceCard&>(GetCardMgr().GetRef(SLOT7)).InitializeIO(pCxRomPeripheral);
+	GetCardMgr().InitializeIO(pCxRomPeripheral);
 }
 
 // Called by:

--- a/source/MouseInterface.h
+++ b/source/MouseInterface.h
@@ -14,7 +14,7 @@ public:
 	virtual void Init(void) {};
 	virtual void Reset(const bool powerCycle) {};
 
-	void InitializeIO(LPBYTE pCxRomPeripheral);
+	virtual void InitializeIO(LPBYTE pCxRomPeripheral);
 //	void Uninitialize();
 	void Reset();
 	UINT GetSlot(void) { return m_slot; }

--- a/source/SAM.h
+++ b/source/SAM.h
@@ -14,7 +14,7 @@ public:
 	virtual void Init(void) {};
 	virtual void Reset(const bool powerCycle) {};
 
-	void InitializeIO(LPBYTE pCxRomPeripheral);
+	virtual void InitializeIO(LPBYTE pCxRomPeripheral);
 
 	static BYTE __stdcall IOWrite(WORD pc, WORD addr, BYTE bWrite, BYTE value, ULONG nExecutedCycles);
 

--- a/source/SNESMAX.h
+++ b/source/SNESMAX.h
@@ -18,10 +18,10 @@ public:
 	}
 	virtual ~SNESMAXCard(void) {}
 
-	virtual void Init(void) {};
-	virtual void Reset(const bool powerCycle) {};
+	virtual void Init(void) {}
+	virtual void Reset(const bool powerCycle) {}
 
-	void InitializeIO(LPBYTE pCxRomPeripheral);
+	virtual void InitializeIO(LPBYTE pCxRomPeripheral);
 
 	static BYTE __stdcall IORead(WORD pc, WORD addr, BYTE bWrite, BYTE value, ULONG nExecutedCycles);
 	static BYTE __stdcall IOWrite(WORD pc, WORD addr, BYTE bWrite, BYTE value, ULONG nExecutedCycles);


### PR DESCRIPTION
Add `Card::InitializeIO`: so one can remove all the inlined checks for card type.

Other areas of improvement:

- `Card::Reset()` probably exactly the same could be done: see https://github.com/AppleWin/AppleWin/blob/ff7c9dc185aed1352e570c583c206af900a8e4f8/source/Utilities.cpp#L541-L559
- `Card::Update(executedCycles)`: https://github.com/AppleWin/AppleWin/blob/ff7c9dc185aed1352e570c583c206af900a8e4f8/source/Windows/AppleWin.cpp#L220-L223
- `Card::Destroy()`?
