### PR TITLE
Card::Update()

### DIFF
--- a/source/Card.cpp
+++ b/source/Card.cpp
@@ -52,3 +52,21 @@ void DummyCard::InitializeIO(LPBYTE pCxRomPeripheral)
 		break;
 	}
 }
+
+void DummyCard::Update(const ULONG nExecutedCycles)
+{
+	switch (QueryType())
+	{
+	case CT_GenericPrinter:
+		PrintUpdate(nExecutedCycles);
+		break;
+	case CT_MockingboardC:
+	case CT_Phasor:
+		// only in slot 4
+		if (m_slot == SLOT4)
+		{
+			MB_PeriodicUpdate(nExecutedCycles);
+		}
+		break;
+	}
+}

--- a/source/Card.h
+++ b/source/Card.h
@@ -36,6 +36,7 @@ public:
 	virtual void InitializeIO(LPBYTE pCxRomPeripheral) = 0;
 	virtual void Init(void) = 0;
 	virtual void Reset(const bool powerCycle) = 0;
+	virtual void Update(const ULONG nExecutedCycles) = 0;
 	SS_CARDTYPE QueryType(void) { return m_type; }
 
 protected:
@@ -56,6 +57,7 @@ public:
 	virtual void InitializeIO(LPBYTE pCxRomPeripheral) {}
 	virtual void Init(void) {}
 	virtual void Reset(const bool powerCycle) {}
+	virtual void Update(const ULONG nExecutedCycles) {}
 };
 
 //
@@ -69,4 +71,5 @@ public:
 	virtual void InitializeIO(LPBYTE pCxRomPeripheral);
 	virtual void Init(void) {}
 	virtual void Reset(const bool powerCycle) {}
+	virtual void Update(const ULONG nExecutedCycles);
 };

--- a/source/CardManager.cpp
+++ b/source/CardManager.cpp
@@ -199,3 +199,14 @@ void CardManager::InitializeIO(LPBYTE pCxRomPeripheral)
 		}
 	}
 }
+
+void CardManager::Update(const ULONG nExecutedCycles)
+{
+    for (UINT i = 0; i < NUM_SLOTS; ++i)
+    {
+        if (m_slot[i])
+        {
+            m_slot[i]->Update(nExecutedCycles);
+        }
+    }
+}

--- a/source/CardManager.h
+++ b/source/CardManager.h
@@ -58,6 +58,7 @@ public:
 	bool IsSSCInstalled(void) { return m_pSSC != NULL; }
 
 	void InitializeIO(LPBYTE pCxRomPeripheral);
+	void Update(const ULONG nExecutedCycles);
 
 private:
 	void InsertInternal(UINT slot, SS_CARDTYPE type);

--- a/source/Disk.cpp
+++ b/source/Disk.cpp
@@ -1691,7 +1691,7 @@ void __stdcall Disk2InterfaceCard::SetWriteMode(WORD, WORD, BYTE, BYTE, ULONG uE
 
 //===========================================================================
 
-void Disk2InterfaceCard::UpdateDriveState(DWORD cycles)
+void Disk2InterfaceCard::Update(const ULONG cycles)
 {
 	int loop = NUM_DRIVES;
 	while (loop--)

--- a/source/Disk.h
+++ b/source/Disk.h
@@ -131,6 +131,8 @@ public:
 	virtual void Reset(const bool powerCycle);
 
 	virtual void InitializeIO(LPBYTE pCxRomPeripheral);
+	virtual void Update(const ULONG nExecutedCycles);
+
 	void Destroy(void);		// no, doesn't "destroy" the disk image.  DiskIIManagerShutdown()
 
 	void Boot(void);
@@ -160,7 +162,6 @@ public:
 	std::string GetCurrentPhaseString(void);
 	LPCTSTR GetCurrentState(void);
 	bool UserSelectNewDiskImage(const int drive, LPCSTR pszFilename="");
-	void UpdateDriveState(DWORD cycles);
 	bool DriveSwap(void);
 	bool IsDriveConnected(int drive) { return m_floppyDrive[drive].m_isConnected; }
 

--- a/source/Disk2CardManager.cpp
+++ b/source/Disk2CardManager.cpp
@@ -48,13 +48,13 @@ bool Disk2CardManager::IsConditionForFullSpeed(void)
 	return false;
 }
 
-void Disk2CardManager::UpdateDriveState(UINT cycles)
+void Disk2CardManager::Update(const ULONG nExecutedCycles)
 {
 	for (UINT i = 0; i < NUM_SLOTS; i++)
 	{
 		if (GetCardMgr().QuerySlot(i) == CT_Disk2)
 		{
-			dynamic_cast<Disk2InterfaceCard&>(GetCardMgr().GetRef(i)).UpdateDriveState(cycles);
+			GetCardMgr().GetRef(i).Update(nExecutedCycles);
 		}
 	}
 }

--- a/source/Disk2CardManager.cpp
+++ b/source/Disk2CardManager.cpp
@@ -65,7 +65,7 @@ void Disk2CardManager::Reset(const bool powerCycle /*=false*/)
 	{
 		if (GetCardMgr().QuerySlot(i) == CT_Disk2)
 		{
-			dynamic_cast<Disk2InterfaceCard&>(GetCardMgr().GetRef(i)).Reset(powerCycle);
+			GetCardMgr().GetRef(i).Reset(powerCycle);
 		}
 	}
 }

--- a/source/Disk2CardManager.h
+++ b/source/Disk2CardManager.h
@@ -7,7 +7,7 @@ public:
 	~Disk2CardManager(void) {}
 
 	bool IsConditionForFullSpeed(void);
-	void UpdateDriveState(UINT cycles);
+	void Update(const ULONG nExecutedCycles);
 	void Reset(const bool powerCycle = false);
 	bool GetEnhanceDisk(void);
 	void SetEnhanceDisk(bool enhanceDisk);

--- a/source/FourPlay.h
+++ b/source/FourPlay.h
@@ -11,8 +11,9 @@ public:
 	}
 	virtual ~FourPlayCard(void) {}
 
-	virtual void Init(void) {};
-	virtual void Reset(const bool powerCycle) {};
+	virtual void Init(void) {}
+	virtual void Reset(const bool powerCycle) {}
+	virtual void Update(const ULONG nExecutedCycles) {}
 
 	virtual void InitializeIO(LPBYTE pCxRomPeripheral);
 

--- a/source/Harddisk.h
+++ b/source/Harddisk.h
@@ -87,6 +87,7 @@ public:
 
 	virtual void Init(void) {}
 	virtual void Reset(const bool powerCycle);
+	virtual void Update(const ULONG nExecutedCycles) {}
 
 	virtual void InitializeIO(LPBYTE pCxRomPeripheral);
 	void Destroy(void);

--- a/source/LanguageCard.h
+++ b/source/LanguageCard.h
@@ -12,8 +12,10 @@ public:
 	LanguageCardUnit(SS_CARDTYPE type = CT_LanguageCardIIe);
 	virtual ~LanguageCardUnit(void);
 
-	virtual void Init(void) {};
-	virtual void Reset(const bool powerCycle) {};
+	virtual void Init(void) {}
+	virtual void Reset(const bool powerCycle) {}
+	virtual void Update(const ULONG nExecutedCycles) {}
+
 
 	virtual void InitializeIO(LPBYTE pCxRomPeripheral);
 	virtual void SetMemorySize(UINT banks) {}		// No-op for //e and slot-0 16K LC

--- a/source/MouseInterface.h
+++ b/source/MouseInterface.h
@@ -11,8 +11,9 @@ public:
 	CMouseInterface(UINT slot);
 	virtual ~CMouseInterface();
 
-	virtual void Init(void) {};
-	virtual void Reset(const bool powerCycle) {};
+	virtual void Init(void) {}
+	virtual void Reset(const bool powerCycle) {}
+	virtual void Update(const ULONG nExecutedCycles) {}
 
 	virtual void InitializeIO(LPBYTE pCxRomPeripheral);
 //	void Uninitialize();

--- a/source/SAM.h
+++ b/source/SAM.h
@@ -11,8 +11,9 @@ public:
 	}
 	virtual ~SAMCard(void) {}
 
-	virtual void Init(void) {};
-	virtual void Reset(const bool powerCycle) {};
+	virtual void Init(void) {}
+	virtual void Reset(const bool powerCycle) {}
+	virtual void Update(const ULONG nExecutedCycles) {}
 
 	virtual void InitializeIO(LPBYTE pCxRomPeripheral);
 

--- a/source/SNESMAX.h
+++ b/source/SNESMAX.h
@@ -20,6 +20,7 @@ public:
 
 	virtual void Init(void) {}
 	virtual void Reset(const bool powerCycle) {}
+	virtual void Update(const ULONG nExecutedCycles) {}
 
 	virtual void InitializeIO(LPBYTE pCxRomPeripheral);
 

--- a/source/SerialComms.h
+++ b/source/SerialComms.h
@@ -28,8 +28,9 @@ public:
 	CSuperSerialCard(UINT slot);
 	virtual ~CSuperSerialCard();
 
-	virtual void Init(void) {};
-	virtual void Reset(const bool powerCycle) {};
+	virtual void Init(void) {}
+	virtual void Reset(const bool powerCycle) {}
+	virtual void Update(const ULONG nExecutedCycles) {}
 
 	void	InitializeIO(LPBYTE pCxRomPeripheral);
 	void    CommReset();

--- a/source/Utilities.cpp
+++ b/source/Utilities.cpp
@@ -540,7 +540,7 @@ void ResetMachineState()
 {
 	GetCardMgr().GetDisk2CardMgr().Reset(true);
 	if (GetCardMgr().QuerySlot(SLOT7) == CT_GenericHDD)
-		dynamic_cast<HarddiskInterfaceCard&>(GetCardMgr().GetRef(SLOT7)).Reset(true);
+		GetCardMgr().GetRef(SLOT7).Reset(true);
 	g_bFullSpeed = 0;	// Might've hit reset in middle of InternalCpuExecute() - so beep may get (partially) muted
 
 	MemReset();	// calls CpuInitialize(), CNoSlotClock.Reset()
@@ -595,7 +595,7 @@ void CtrlReset()
 	GetPravets().Reset();
 	GetCardMgr().GetDisk2CardMgr().Reset();
 	if (GetCardMgr().QuerySlot(SLOT7) == CT_GenericHDD)
-		dynamic_cast<HarddiskInterfaceCard&>(GetCardMgr().GetRef(SLOT7)).Reset(true);
+		GetCardMgr().GetRef(SLOT7).Reset(true);
 	KeybReset();
 	if (GetCardMgr().IsSSCInstalled())
 		GetCardMgr().GetSSC()->CommReset();

--- a/source/Windows/AppleWin.cpp
+++ b/source/Windows/AppleWin.cpp
@@ -820,7 +820,7 @@ static void RepeatInitialization(void)
 		GetCardMgr().GetDisk2CardMgr().Reset(true);	// Switch from a booting A][+ to a non-autostart A][, so need to turn off floppy motor
 		LogFileOutput("Main: DiskReset()\n");
 		if (GetCardMgr().QuerySlot(SLOT7) == CT_GenericHDD)
-			dynamic_cast<HarddiskInterfaceCard&>(GetCardMgr().GetRef(SLOT7)).Reset(true);	// GH#515
+			GetCardMgr().GetRef(SLOT7).Reset(true);	// GH#515
 		LogFileOutput("Main: HDDReset()\n");
 
 		if (!g_bSysClkOK)

--- a/source/Windows/AppleWin.cpp
+++ b/source/Windows/AppleWin.cpp
@@ -217,10 +217,8 @@ static void ContinueExecution(void)
 	const DWORD uActualCyclesExecuted = CpuExecute(uCyclesToExecute, bVideoUpdate);
 	g_dwCyclesThisFrame += uActualCyclesExecuted;
 
-	GetCardMgr().GetDisk2CardMgr().UpdateDriveState(uActualCyclesExecuted);
+	GetCardMgr().Update(uActualCyclesExecuted);
 	JoyUpdateButtonLatch(nExecutionPeriodUsec);	// Button latch time is independent of CPU clock frequency
-	PrintUpdate(uActualCyclesExecuted);
-	MB_PeriodicUpdate(uActualCyclesExecuted);
 
 	//
 

--- a/source/Windows/Win32Frame.cpp
+++ b/source/Windows/Win32Frame.cpp
@@ -296,7 +296,7 @@ void Win32Frame::Benchmark(void)
 			while (cycles > 0) {
 				DWORD executedcycles = CpuExecute(103, true);
 				cycles -= executedcycles;
-				GetCardMgr().GetDisk2CardMgr().UpdateDriveState(executedcycles);
+				GetCardMgr().GetDisk2CardMgr().Update(executedcycles);
 				JoyUpdateButtonLatch(executedcycles);
 			}
 		}


### PR DESCRIPTION
Add a method to allow cards to execute their update code.

A couple of points:

- `GetCardMgr().GetDisk2CardMgr().Update(executedcycles);` is only used in the benchmark code. Should it become `CardManager::Update()`?

https://github.com/AppleWin/AppleWin/blob/8662a9917964d0ee1005829153ff0bbb082b813f/source/Windows/Win32Frame.cpp#L299

- This line https://github.com/AppleWin/AppleWin/blob/8662a9917964d0ee1005829153ff0bbb082b813f/source/Windows/Win32Frame.cpp#L300 passes ``cycles`` rather then ``nExecutionPeriodUsec``, is it ok?

- Looking at the rest of the code e.g. https://github.com/AppleWin/AppleWin/blob/8662a9917964d0ee1005829153ff0bbb082b813f/source/Utilities.cpp#L539 I wonder if there should be a small set of well defined operations that all card should implement

1. Boot
2. Init
3. Reset(false) (CommReset?)
4. Reset(true) (CommReset?)
5. Destroy

But I am not sure I can propose something meaningful. I don't really understand the subtle differences.