### PR TITLE
Remove Joystick's buttonlatch & BUTTONTIME

### DIFF
--- a/source/Joystick.h
+++ b/source/Joystick.h
@@ -14,7 +14,6 @@ void    JoyReset();
 void    JoySetButton(eBUTTON,eBUTTONSTATE);
 BOOL    JoySetEmulationType(HWND,DWORD,int, const bool bMousecardActive);
 void    JoySetPosition(int,int,int,int);
-void    JoyUpdateButtonLatch(const UINT nExecutionPeriodUsec);
 BOOL    JoyUsingMouse();
 BOOL    JoyUsingKeyboard();
 BOOL    JoyUsingKeyboardCursors();

--- a/source/Windows/AppleWin.cpp
+++ b/source/Windows/AppleWin.cpp
@@ -218,7 +218,6 @@ static void ContinueExecution(void)
 	g_dwCyclesThisFrame += uActualCyclesExecuted;
 
 	GetCardMgr().Update(uActualCyclesExecuted);
-	JoyUpdateButtonLatch(nExecutionPeriodUsec);	// Button latch time is independent of CPU clock frequency
 
 	//
 

--- a/source/Windows/Win32Frame.cpp
+++ b/source/Windows/Win32Frame.cpp
@@ -297,7 +297,6 @@ void Win32Frame::Benchmark(void)
 				DWORD executedcycles = CpuExecute(103, true);
 				cycles -= executedcycles;
 				GetCardMgr().GetDisk2CardMgr().Update(executedcycles);
-				JoyUpdateButtonLatch(executedcycles);
 			}
 		}
 		if (cycle & 1)


### PR DESCRIPTION
Over time `JoyUpdateButtonLatch()` has morphed away from the original AppleWin 1.00 code, where `JoyUpdateButtonLatch()` was called once every 2048 emulated cycles, and each `buttonlatch` was decremented by 1 each update. NB. 2048 x BUTTONTIME(5000) = 10M cycles = 10 seconds.

The logic in `CheckJoystick0()` was (and still is) like this:
- if button-0 is pressed:
  - if button-0 wasn't pressed last time, then `buttonlatch[0] = BUTTONTIME` (ie. 5000)
  - `joybutton[0] = TRUE`
- if button-0 not pressed:
  - `joybutton[0] = FALSE`

Then later when the Apple II reads $C061 (BUTTON0 I/O port):
- `pressed = buttonlatch[0] || joybutton[0]`
- `buttonlatch[0] = 0`
- `return pressed<<7`

So the original code would latch the button-0 press for up to 10 seconds!
NB. This was for joystick buttons, not for Open/Close Apple keys.
(Confirmed this behaviour for AppleWin 1.00 -> 1.25!)

I've never heard of this behaviour, and there's nothing in Sather (Understanding the Apple II) about this either.
**Easy to check on real h/w though.**

But today, the main `ContinueEmulation()` loop decrements each `buttonlatch` by ~1000 (or ~1ms) each loop, so the button down state is only latched for ~5ms.

NB. The comment in Joystick.cpp after BUTTONTIME about "debounce" is mine, and it is wrong.

**UPDATE:**  I quickly checked on real h/w, and there's no latching of $C061.
- Tried with Open/Close Apple keys, a 9-pin joystick and finally a 16-pin Bitstik.