### PR TITLE
Slot0: make it more uniform to other slots.

### DIFF
--- a/source/CardManager.cpp
+++ b/source/CardManager.cpp
@@ -106,7 +106,7 @@ void CardManager::InsertInternal(UINT slot, SS_CARDTYPE type)
 	case CT_LanguageCard:
 		_ASSERT(m_pLanguageCard == NULL);
 		if (m_pLanguageCard) break;	// Only support one language card
-		m_slot[slot] = m_pLanguageCard = new LanguageCardSlot0(slot);
+		m_slot[slot] = m_pLanguageCard = LanguageCardSlot0::create(slot);
 		break;
 	case CT_Saturn128K:
 		_ASSERT(m_pLanguageCard == NULL);
@@ -116,7 +116,7 @@ void CardManager::InsertInternal(UINT slot, SS_CARDTYPE type)
 	case CT_LanguageCardIIe:
 		_ASSERT(m_pLanguageCard == NULL);
 		if (m_pLanguageCard) break;	// Only support one language card
-		m_slot[slot] = m_pLanguageCard = new LanguageCardUnit(slot);
+		m_slot[slot] = m_pLanguageCard = LanguageCardUnit::create(slot);
 		break;
 
 	default:

--- a/source/CardManager.cpp
+++ b/source/CardManager.cpp
@@ -106,17 +106,17 @@ void CardManager::InsertInternal(UINT slot, SS_CARDTYPE type)
 	case CT_LanguageCard:
 		_ASSERT(m_pLanguageCard == NULL);
 		if (m_pLanguageCard) break;	// Only support one language card
-		m_slot[slot] = m_pLanguageCard = new LanguageCardSlot0(type, slot);
+		m_slot[slot] = m_pLanguageCard = new LanguageCardSlot0(slot);
 		break;
 	case CT_Saturn128K:
 		_ASSERT(m_pLanguageCard == NULL);
 		if (m_pLanguageCard) break;	// Only support one language card
-		m_slot[slot] = m_pLanguageCard = new Saturn128K(type, slot, Saturn128K::GetSaturnMemorySize());
+		m_slot[slot] = m_pLanguageCard = new Saturn128K(slot, Saturn128K::GetSaturnMemorySize());
 		break;
 	case CT_LanguageCardIIe:
 		_ASSERT(m_pLanguageCard == NULL);
 		if (m_pLanguageCard) break;	// Only support one language card
-		m_slot[slot] = m_pLanguageCard = new LanguageCardUnit(type, slot);
+		m_slot[slot] = m_pLanguageCard = new LanguageCardUnit(slot);
 		break;
 
 	default:

--- a/source/CardManager.cpp
+++ b/source/CardManager.cpp
@@ -107,7 +107,7 @@ void CardManager::InsertInternal(UINT slot, SS_CARDTYPE type)
 		m_slot[slot] = m_pLanguageCard = new LanguageCardSlot0();
 		break;
 	case CT_Saturn128K:
-		m_slot[slot] = m_pLanguageCard = new Saturn128K(GetSaturnMemorySize());
+		m_slot[slot] = m_pLanguageCard = new Saturn128K(Saturn128K::GetSaturnMemorySize());
 		break;
 
 	case CT_LanguageCardIIe:	// not a card

--- a/source/CardManager.h
+++ b/source/CardManager.h
@@ -9,7 +9,8 @@ class CardManager
 public:
 	CardManager(void) :
 		m_pMouseCard(NULL),
-		m_pSSC(NULL)
+		m_pSSC(NULL),
+		m_pLanguageCard(NULL)
 	{
 		InsertInternal(SLOT0, CT_Empty);
 		InsertInternal(SLOT1, CT_GenericPrinter);
@@ -54,9 +55,11 @@ public:
 	class CSuperSerialCard* GetSSC(void) { return m_pSSC; }
 	bool IsSSCInstalled(void) { return m_pSSC != NULL; }
 
+	class LanguageCardUnit* GetLanguageCard(void) { return m_pLanguageCard; }
+
 	void InitializeIO(LPBYTE pCxRomPeripheral);
 	void Update(const ULONG nExecutedCycles);
-	void SaveSnapshot(YamlSaveHelper& yamlSaveHelper);  // It DOES NOT save SLOT0
+	void SaveSnapshot(YamlSaveHelper& yamlSaveHelper);
 
 private:
 	void InsertInternal(UINT slot, SS_CARDTYPE type);
@@ -69,4 +72,5 @@ private:
 	Disk2CardManager m_disk2CardMgr;
 	class CMouseInterface* m_pMouseCard;
 	class CSuperSerialCard* m_pSSC;
+	class LanguageCardUnit* m_pLanguageCard;
 };

--- a/source/Debugger/Debugger_Display.cpp
+++ b/source/Debugger/Debugger_Display.cpp
@@ -38,6 +38,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "../CPU.h"
 #include "../Windows/Win32Frame.h"
 #include "../LanguageCard.h"
+#include "../CardManager.h"
 #include "../Memory.h"
 #include "../Mockingboard.h"
 #include "../NTSC.h"
@@ -2408,7 +2409,7 @@ void _DrawSoftSwitchLanguageCardBank( RECT & rect, const int iBankDisplay, int b
 		int iActiveBank = -1;
 		char sText[ 4 ] = "?"; // Default to RAMWORKS
 		if (GetCurrentExpansionMemType() == CT_RamWorksIII) { sText[0] = 'r'; iActiveBank = GetRamWorksActiveBank(); }
-		if (GetCurrentExpansionMemType() == CT_Saturn128K)  { sText[0] = 's'; iActiveBank = GetLanguageCard()->GetActiveBank(); }
+		if (GetCurrentExpansionMemType() == CT_Saturn128K)  { sText[0] = 's'; iActiveBank = GetCardMgr().GetLanguageCard()->GetActiveBank(); }
 
 		if (iActiveBank >= 0)
 		{

--- a/source/LanguageCard.cpp
+++ b/source/LanguageCard.cpp
@@ -268,11 +268,6 @@ Saturn128K::~Saturn128K(void)
 	}
 }
 
-void Saturn128K::SetMemorySize(UINT banks)
-{
-	m_uSaturnTotalBanks = banks;
-}
-
 UINT Saturn128K::GetActiveBank(void)
 {
 	return m_uSaturnActiveBank;

--- a/source/LanguageCard.cpp
+++ b/source/LanguageCard.cpp
@@ -52,12 +52,13 @@ LanguageCardUnit::~LanguageCardUnit(void)
 
 void LanguageCardUnit::InitializeIO(LPBYTE pCxRomPeripheral)
 {
-	RegisterIoHandler(kSlot0, &LanguageCardUnit::IO, &LanguageCardUnit::IO, NULL, NULL, this, NULL);
+	RegisterIoHandler(m_slot, &LanguageCardUnit::IO, &LanguageCardUnit::IO, NULL, NULL, this, NULL);
 }
 
 BYTE __stdcall LanguageCardUnit::IO(WORD PC, WORD uAddr, BYTE bWrite, BYTE uValue, ULONG nExecutedCycles)
 {
-	LanguageCardUnit* pLC = (LanguageCardUnit*) MemGetSlotParameters(kSlot0);
+	UINT uSlot = ((uAddr & 0xff) >> 4) - 8;
+	LanguageCardUnit* pLC = (LanguageCardUnit*) MemGetSlotParameters(uSlot);
 
 	DWORD memmode = GetMemMode();
 	DWORD lastmemmode = memmode;
@@ -277,7 +278,7 @@ UINT Saturn128K::GetActiveBank(void)
 
 void Saturn128K::InitializeIO(LPBYTE pCxRomPeripheral)
 {
-	RegisterIoHandler(kSlot0, &Saturn128K::IO, &Saturn128K::IO, NULL, NULL, this, NULL);
+	RegisterIoHandler(m_slot, &Saturn128K::IO, &Saturn128K::IO, NULL, NULL, this, NULL);
 }
 
 BYTE __stdcall Saturn128K::IO(WORD PC, WORD uAddr, BYTE bWrite, BYTE uValue, ULONG nExecutedCycles)
@@ -301,7 +302,8 @@ BYTE __stdcall Saturn128K::IO(WORD PC, WORD uAddr, BYTE bWrite, BYTE uValue, ULO
 	1110  $C0NE select 16K Bank 7
 	1111  $C0NF select 16K Bank 8
 */
-	Saturn128K* pLC = (Saturn128K*) MemGetSlotParameters(kSlot0);
+	UINT uSlot = ((uAddr & 0xff) >> 4) - 8;
+	Saturn128K* pLC = (Saturn128K*) MemGetSlotParameters(uSlot);
 
 	_ASSERT(pLC->m_uSaturnTotalBanks);
 	if (!pLC->m_uSaturnTotalBanks)

--- a/source/LanguageCard.cpp
+++ b/source/LanguageCard.cpp
@@ -235,6 +235,8 @@ bool LanguageCardSlot0::LoadSnapshot(YamlLoadHelper& yamlLoadHelper, UINT versio
 
 //-------------------------------------
 
+UINT Saturn128K::g_uSaturnBanksFromCmdLine = 0;
+
 Saturn128K::Saturn128K(UINT banks)
 	: LanguageCardSlot0(CT_Saturn128K)
 {
@@ -453,4 +455,14 @@ bool Saturn128K::LoadSnapshot(YamlLoadHelper& yamlLoadHelper, UINT version)
 	// NB. MemUpdatePaging(TRUE) called at end of Snapshot_LoadState_v2()
 
 	return true;
+}
+
+void Saturn128K::SetSaturnMemorySize(UINT banks)
+{
+	g_uSaturnBanksFromCmdLine = banks;
+}
+
+UINT Saturn128K::GetSaturnMemorySize()
+{
+	return g_uSaturnBanksFromCmdLine;
 }

--- a/source/LanguageCard.cpp
+++ b/source/LanguageCard.cpp
@@ -38,6 +38,10 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 const UINT LanguageCardUnit::kMemModeInitialState = MF_BANK2 | MF_WRITERAM;	// !INTCXROM
 
+LanguageCardUnit::LanguageCardUnit(UINT slot) : LanguageCardUnit(CT_LanguageCardIIe, slot)
+{
+}
+
 LanguageCardUnit::LanguageCardUnit(SS_CARDTYPE type, UINT slot) :
 	Card(type, slot),
 	m_uLastRamWrite(0)
@@ -140,6 +144,11 @@ bool LanguageCardUnit::IsOpcodeRMWabs(WORD addr)
 
 //-------------------------------------
 
+LanguageCardSlot0::LanguageCardSlot0(UINT slot) : LanguageCardSlot0(CT_LanguageCard, slot)
+{
+}
+
+
 LanguageCardSlot0::LanguageCardSlot0(SS_CARDTYPE type, UINT slot)
 	: LanguageCardUnit(type, slot)
 {
@@ -237,8 +246,8 @@ bool LanguageCardSlot0::LoadSnapshot(YamlLoadHelper& yamlLoadHelper, UINT versio
 
 UINT Saturn128K::g_uSaturnBanksFromCmdLine = 0;
 
-Saturn128K::Saturn128K(SS_CARDTYPE type, UINT slot, UINT banks)
-	: LanguageCardSlot0(type, slot)
+Saturn128K::Saturn128K(UINT slot, UINT banks)
+	: LanguageCardSlot0(CT_Saturn128K, slot)
 {
 	m_uSaturnTotalBanks = (banks == 0) ? kMaxSaturnBanks : banks;
 	m_uSaturnActiveBank = 0;

--- a/source/LanguageCard.cpp
+++ b/source/LanguageCard.cpp
@@ -38,10 +38,13 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 const UINT LanguageCardUnit::kMemModeInitialState = MF_BANK2 | MF_WRITERAM;	// !INTCXROM
 
-LanguageCardUnit::LanguageCardUnit(SS_CARDTYPE type/*=CT_LanguageCardIIe*/) :
-	Card(type, kSlot0),
+LanguageCardUnit::LanguageCardUnit(SS_CARDTYPE type, UINT slot) :
+	Card(type, slot),
 	m_uLastRamWrite(0)
 {
+	if (m_slot != LanguageCardUnit::kSlot0)
+		throw std::string("Card: wrong slot");
+
 	SetMemMainLanguageCard(NULL, true);
 }
 
@@ -137,12 +140,9 @@ bool LanguageCardUnit::IsOpcodeRMWabs(WORD addr)
 
 //-------------------------------------
 
-LanguageCardSlot0::LanguageCardSlot0(SS_CARDTYPE type/*=CT_LanguageCard*/)
-	: LanguageCardUnit(type)
+LanguageCardSlot0::LanguageCardSlot0(SS_CARDTYPE type, UINT slot)
+	: LanguageCardUnit(type, slot)
 {
-	if (m_slot != LanguageCardUnit::kSlot0)
-		throw std::string("Card: wrong slot");
-
 	m_pMemory = new BYTE[kMemBankSize];
 	SetMemMainLanguageCard(m_pMemory);
 }
@@ -237,8 +237,8 @@ bool LanguageCardSlot0::LoadSnapshot(YamlLoadHelper& yamlLoadHelper, UINT versio
 
 UINT Saturn128K::g_uSaturnBanksFromCmdLine = 0;
 
-Saturn128K::Saturn128K(UINT banks)
-	: LanguageCardSlot0(CT_Saturn128K)
+Saturn128K::Saturn128K(SS_CARDTYPE type, UINT slot, UINT banks)
+	: LanguageCardSlot0(type, slot)
 {
 	m_uSaturnTotalBanks = (banks == 0) ? kMaxSaturnBanks : banks;
 	m_uSaturnActiveBank = 0;

--- a/source/LanguageCard.cpp
+++ b/source/LanguageCard.cpp
@@ -38,8 +38,9 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 const UINT LanguageCardUnit::kMemModeInitialState = MF_BANK2 | MF_WRITERAM;	// !INTCXROM
 
-LanguageCardUnit::LanguageCardUnit(UINT slot) : LanguageCardUnit(CT_LanguageCardIIe, slot)
+LanguageCardUnit * LanguageCardUnit::create(UINT slot)
 {
+	return new LanguageCardUnit(CT_LanguageCardIIe, slot);
 }
 
 LanguageCardUnit::LanguageCardUnit(SS_CARDTYPE type, UINT slot) :
@@ -144,10 +145,10 @@ bool LanguageCardUnit::IsOpcodeRMWabs(WORD addr)
 
 //-------------------------------------
 
-LanguageCardSlot0::LanguageCardSlot0(UINT slot) : LanguageCardSlot0(CT_LanguageCard, slot)
+LanguageCardSlot0 * LanguageCardSlot0::create(UINT slot)
 {
+	return new LanguageCardSlot0(CT_LanguageCard, slot);
 }
-
 
 LanguageCardSlot0::LanguageCardSlot0(SS_CARDTYPE type, UINT slot)
 	: LanguageCardUnit(type, slot)

--- a/source/LanguageCard.h
+++ b/source/LanguageCard.h
@@ -79,6 +79,9 @@ public:
 	virtual void SaveSnapshot(YamlSaveHelper& yamlSaveHelper);
 	virtual bool LoadSnapshot(YamlLoadHelper& yamlLoadHelper, UINT version);
 
+	static UINT	GetSaturnMemorySize();
+	static void	SetSaturnMemorySize(UINT banks);
+
 	static BYTE __stdcall IO(WORD PC, WORD uAddr, BYTE bWrite, BYTE uValue, ULONG nExecutedCycles);
 
 	// "The boards consist of 16K banks of memory (4 banks for the 64K board, 8 banks for the 128K), accessed one at a time" - Ref: "64K/128K RAM BOARD", Saturn Systems, Ch.1 Introduction(pg-5)
@@ -87,6 +90,8 @@ public:
 
 private:
 	std::string GetSnapshotMemStructName(void);
+
+	static UINT g_uSaturnBanksFromCmdLine;
 
 	UINT m_uSaturnTotalBanks;	// Will be > 0 if Saturn card is installed
 	UINT m_uSaturnActiveBank;	// Saturn 128K Language Card Bank 0 .. 7

--- a/source/LanguageCard.h
+++ b/source/LanguageCard.h
@@ -9,7 +9,8 @@
 class LanguageCardUnit : public Card
 {
 public:
-	LanguageCardUnit(SS_CARDTYPE type, UINT slot);
+	LanguageCardUnit(UINT slot);
+
 	virtual ~LanguageCardUnit(void);
 
 	virtual void Init(void) {}
@@ -32,6 +33,9 @@ public:
 	static const UINT kMemModeInitialState;
 	static const UINT kSlot0 = SLOT0;
 
+protected:
+	LanguageCardUnit(SS_CARDTYPE type, UINT slot);
+
 private:
 	UINT m_uLastRamWrite;
 };
@@ -43,7 +47,7 @@ private:
 class LanguageCardSlot0 : public LanguageCardUnit
 {
 public:
-	LanguageCardSlot0(SS_CARDTYPE type, UINT slot);
+	LanguageCardSlot0(UINT slot);
 	virtual ~LanguageCardSlot0(void);
 
 	virtual void SaveSnapshot(YamlSaveHelper& yamlSaveHelper);
@@ -53,6 +57,7 @@ public:
 	static std::string GetSnapshotCardName(void);
 
 protected:
+	LanguageCardSlot0(SS_CARDTYPE type, UINT slot);
 	void SaveLCState(class YamlSaveHelper& yamlSaveHelper);
 	void LoadLCState(class YamlLoadHelper& yamlLoadHelper);
 
@@ -69,7 +74,7 @@ private:
 class Saturn128K : public LanguageCardSlot0
 {
 public:
-	Saturn128K(SS_CARDTYPE type, UINT slot, UINT banks);
+	Saturn128K(UINT slot, UINT banks);
 	virtual ~Saturn128K(void);
 
 	virtual void InitializeIO(LPBYTE pCxRomPeripheral);

--- a/source/LanguageCard.h
+++ b/source/LanguageCard.h
@@ -18,7 +18,6 @@ public:
 
 
 	virtual void InitializeIO(LPBYTE pCxRomPeripheral);
-	virtual void SetMemorySize(UINT banks) {}		// No-op for //e and slot-0 16K LC
 	virtual UINT GetActiveBank(void) { return 0; }	// Always 0 as only 1x 16K bank
 	virtual void SaveSnapshot(YamlSaveHelper& yamlSaveHelper) { _ASSERT(0); } // Not used for //e
 	virtual bool LoadSnapshot(YamlLoadHelper& yamlLoadHelper, UINT version) { _ASSERT(0); return false; } // Not used for //e
@@ -74,7 +73,6 @@ public:
 	virtual ~Saturn128K(void);
 
 	virtual void InitializeIO(LPBYTE pCxRomPeripheral);
-	virtual void SetMemorySize(UINT banks);
 	virtual UINT GetActiveBank(void);
 	virtual void SaveSnapshot(YamlSaveHelper& yamlSaveHelper);
 	virtual bool LoadSnapshot(YamlLoadHelper& yamlLoadHelper, UINT version);

--- a/source/LanguageCard.h
+++ b/source/LanguageCard.h
@@ -9,7 +9,7 @@
 class LanguageCardUnit : public Card
 {
 public:
-	LanguageCardUnit(SS_CARDTYPE type = CT_LanguageCardIIe);
+	LanguageCardUnit(SS_CARDTYPE type, UINT slot);
 	virtual ~LanguageCardUnit(void);
 
 	virtual void Init(void) {}
@@ -43,7 +43,7 @@ private:
 class LanguageCardSlot0 : public LanguageCardUnit
 {
 public:
-	LanguageCardSlot0(SS_CARDTYPE = CT_LanguageCard);
+	LanguageCardSlot0(SS_CARDTYPE type, UINT slot);
 	virtual ~LanguageCardSlot0(void);
 
 	virtual void SaveSnapshot(YamlSaveHelper& yamlSaveHelper);
@@ -69,7 +69,7 @@ private:
 class Saturn128K : public LanguageCardSlot0
 {
 public:
-	Saturn128K(UINT banks);
+	Saturn128K(SS_CARDTYPE type, UINT slot, UINT banks);
 	virtual ~Saturn128K(void);
 
 	virtual void InitializeIO(LPBYTE pCxRomPeripheral);

--- a/source/LanguageCard.h
+++ b/source/LanguageCard.h
@@ -9,7 +9,8 @@
 class LanguageCardUnit : public Card
 {
 public:
-	LanguageCardUnit(UINT slot);
+	// in modern C++ this could be a 2nd constructor
+	static LanguageCardUnit * create(UINT slot);
 
 	virtual ~LanguageCardUnit(void);
 
@@ -47,7 +48,9 @@ private:
 class LanguageCardSlot0 : public LanguageCardUnit
 {
 public:
-	LanguageCardSlot0(UINT slot);
+	// in modern C++ this could be a 2nd constructor
+	static LanguageCardSlot0 * create(UINT slot);
+
 	virtual ~LanguageCardSlot0(void);
 
 	virtual void SaveSnapshot(YamlSaveHelper& yamlSaveHelper);

--- a/source/Memory.cpp
+++ b/source/Memory.cpp
@@ -258,7 +258,6 @@ BYTE __stdcall IO_Annunciator(WORD programcounter, WORD address, BYTE write, BYT
 static SS_CARDTYPE g_MemTypeAppleII = CT_Empty;
 static SS_CARDTYPE g_MemTypeAppleIIPlus = CT_LanguageCard;	// Keep a copy so it's not lost if machine type changes, eg: A][ -> A//e -> A][
 static SS_CARDTYPE g_MemTypeAppleIIe = CT_Extended80Col;	// Keep a copy so it's not lost if machine type changes, eg: A//e -> A][ -> A//e
-static UINT g_uSaturnBanksFromCmdLine = 0;
 
 
 const UINT CxRomSize = 4 * 1024;
@@ -375,15 +374,6 @@ UINT GetRamWorksActiveBank(void)
 	return g_uActiveBank;
 }
 
-void SetSaturnMemorySize(UINT banks)
-{
-	g_uSaturnBanksFromCmdLine = banks;
-}
-
-UINT GetSaturnMemorySize()
-{
-	return g_uSaturnBanksFromCmdLine;
-}
 //
 
 static BOOL GetLastRamWrite(void)

--- a/source/Memory.cpp
+++ b/source/Memory.cpp
@@ -239,7 +239,6 @@ static BOOL    modechanging = 0;				// An Optimisation: means delay calling Upda
 static UINT    memrompages = 1;
 
 static CNoSlotClock* g_NoSlotClock = new CNoSlotClock;
-static LanguageCardUnit* g_pLanguageCard = NULL;	// For all Apple II, //e and above
 
 #ifdef RAMWORKS
 static UINT		g_uMaxExPages = 1;				// user requested ram pages (default to 1 aux bank: so total = 128KB)
@@ -307,7 +306,7 @@ void SetExpansionMemType(const SS_CARDTYPE type)
 	}
 	else	// Apple //e or above
 	{
-		newSlot0Card = CT_Empty;		// NB. No slot0 for //e
+		newSlot0Card = CT_LanguageCardIIe;		// NB. No slot0 for //e
 		newSlotAuxCard = CT_Extended80Col;
 	}
 
@@ -335,21 +334,24 @@ void SetExpansionMemType(const SS_CARDTYPE type)
 
 void CreateLanguageCard(void)
 {
-	delete g_pLanguageCard;
-	g_pLanguageCard = NULL;
-
+	SS_CARDTYPE slot0CardType = GetCardMgr().QuerySlot(SLOT0);
 	if (IsApple2PlusOrClone(GetApple2Type()))
 	{
-		if (GetCardMgr().QuerySlot(SLOT0) == CT_Saturn128K)
-			g_pLanguageCard = new Saturn128K(g_uSaturnBanksFromCmdLine);
-		else if (GetCardMgr().QuerySlot(SLOT0) == CT_LanguageCard)
-			g_pLanguageCard = new LanguageCardSlot0;
-		else
-			g_pLanguageCard = NULL;
+		switch (slot0CardType) {
+		case CT_Empty:        // OK
+		case CT_Saturn128K:   // OK
+		case CT_LanguageCard: // OK
+			break;
+		default:              // Anything else is invalid
+			GetCardMgr().Remove(SLOT0);
+			break;
+		}
 	}
 	else
 	{
-		g_pLanguageCard = new LanguageCardUnit;
+		// only ever a CT_LanguageCardIIe for a //e
+		if (slot0CardType != CT_LanguageCardIIe)
+			GetCardMgr().Insert(SLOT0, CT_LanguageCardIIe);
 	}
 }
 
@@ -378,19 +380,23 @@ void SetSaturnMemorySize(UINT banks)
 	g_uSaturnBanksFromCmdLine = banks;
 }
 
+UINT GetSaturnMemorySize()
+{
+	return g_uSaturnBanksFromCmdLine;
+}
 //
 
 static BOOL GetLastRamWrite(void)
 {
-	if (g_pLanguageCard)
-		return g_pLanguageCard->GetLastRamWrite();
+	if (GetCardMgr().GetLanguageCard())
+		return GetCardMgr().GetLanguageCard()->GetLastRamWrite();
 	return 0;
 }
 
 static void SetLastRamWrite(BOOL count)
 {
-	if (g_pLanguageCard)
-		g_pLanguageCard->SetLastRamWrite(count);
+	if (GetCardMgr().GetLanguageCard())
+		GetCardMgr().GetLanguageCard()->SetLastRamWrite(count);
 }
 
 //
@@ -401,12 +407,6 @@ void SetMemMainLanguageCard(LPBYTE ptr, bool bMemMain /*=false*/)
 		g_pMemMainLanguageCard = memmain+0xC000;
 	else
 		g_pMemMainLanguageCard = ptr;
-}
-
-LanguageCardUnit* GetLanguageCard(void)
-{
-	_ASSERT(g_pLanguageCard);
-	return g_pLanguageCard;
 }
 
 LPBYTE GetCxRomPeripheral(void)
@@ -1305,9 +1305,6 @@ void MemDestroy()
 	RWpages[0]=NULL;
 #endif
 
-	delete g_pLanguageCard;
-	g_pLanguageCard = NULL;
-
 	memaux   = NULL;
 	memmain  = NULL;
 	memdirty = NULL;
@@ -1735,11 +1732,6 @@ void MemInitializeCustomROM(void)
 void MemInitializeIO(void)
 {
 	InitIoHandlers();
-
-	if (g_pLanguageCard)
-		g_pLanguageCard->InitializeIO(NULL);
-	else
-		RegisterIoHandler(LanguageCardUnit::kSlot0, IO_Null, IO_Null, NULL, NULL, NULL, NULL);
 
 	GetCardMgr().InitializeIO(pCxRomPeripheral);
 }
@@ -2436,7 +2428,6 @@ static void MemLoadSnapshotAuxCommon(YamlLoadHelper& yamlLoadHelper, const std::
 		yamlLoadHelper.PopMap();
 	}
 
-	GetCardMgr().Remove(SLOT0);
 	GetCardMgr().InsertAux(type);
 
 	memaux = RWpages[g_uActiveBank];

--- a/source/Memory.h
+++ b/source/Memory.h
@@ -107,12 +107,11 @@ BYTE __stdcall IO_F8xx(WORD programcounter, WORD address, BYTE write, BYTE value
 enum SS_CARDTYPE;
 void	SetExpansionMemType(const SS_CARDTYPE type);
 SS_CARDTYPE GetCurrentExpansionMemType(void);
-void	CreateLanguageCard(void);
 
 void	SetRamWorksMemorySize(UINT pages);
+UINT	GetSaturnMemorySize();
 UINT	GetRamWorksActiveBank(void);
 void	SetSaturnMemorySize(UINT banks);
 void	SetMemMainLanguageCard(LPBYTE ptr, bool bMemMain=false);
-class LanguageCardUnit* GetLanguageCard(void);
 
 LPBYTE GetCxRomPeripheral(void);

--- a/source/Memory.h
+++ b/source/Memory.h
@@ -109,9 +109,7 @@ void	SetExpansionMemType(const SS_CARDTYPE type);
 SS_CARDTYPE GetCurrentExpansionMemType(void);
 
 void	SetRamWorksMemorySize(UINT pages);
-UINT	GetSaturnMemorySize();
 UINT	GetRamWorksActiveBank(void);
-void	SetSaturnMemorySize(UINT banks);
 void	SetMemMainLanguageCard(LPBYTE ptr, bool bMemMain=false);
 
 LPBYTE GetCxRomPeripheral(void);

--- a/source/Memory.h
+++ b/source/Memory.h
@@ -104,7 +104,6 @@ BYTE __stdcall MemSetPaging(WORD pc, WORD addr, BYTE bWrite, BYTE d, ULONG nExec
 
 BYTE __stdcall IO_F8xx(WORD programcounter, WORD address, BYTE write, BYTE value, ULONG nCycles);
 
-enum SS_CARDTYPE;
 void	SetExpansionMemType(const SS_CARDTYPE type);
 SS_CARDTYPE GetCurrentExpansionMemType(void);
 

--- a/source/SaveState.cpp
+++ b/source/SaveState.cpp
@@ -298,8 +298,6 @@ static void ParseSlots(YamlLoadHelper& yamlLoadHelper, UINT unitVersion)
 	if (unitVersion != UNIT_SLOTS_VER)
 		throw std::string(SS_YAML_KEY_UNIT ": Slots: Version mismatch");
 
-	bool cardInserted[NUM_SLOTS] = {};
-
 	while (1)
 	{
 		std::string scalar = yamlLoadHelper.GetMapNextSlotNumber();
@@ -390,28 +388,18 @@ static void ParseSlots(YamlLoadHelper& yamlLoadHelper, UINT unitVersion)
 		if (slot == 0)
 		{
 			SetExpansionMemType(type);	// calls GetCardMgr().Insert() & InsertAux()
-			CreateLanguageCard();
-			bRes = GetLanguageCard()->LoadSnapshot(yamlLoadHelper, cardVersion);
 		}
 		else
 		{
 			GetCardMgr().Insert(slot, type);
-			bRes = GetCardMgr().GetRef(slot).LoadSnapshot(yamlLoadHelper, cardVersion);
 		}
 
-		cardInserted[slot] = true;
+		bRes = GetCardMgr().GetRef(slot).LoadSnapshot(yamlLoadHelper, cardVersion);
 
 		yamlLoadHelper.PopMap();
 		yamlLoadHelper.PopMap();
 	}
 
-	// Save-state may not contain any info about empty slots, so ensure they are set to empty
-	for (UINT slot = SLOT0; slot < NUM_SLOTS; slot++)
-	{
-		if (cardInserted[slot])
-			continue;
-		GetCardMgr().Remove(slot);
-	}
 }
 
 //---
@@ -592,9 +580,6 @@ void Snapshot_SaveState(void)
 		{
 			yamlSaveHelper.UnitHdr(GetSnapshotUnitSlotsName(), UNIT_SLOTS_VER);
 			YamlSaveHelper::Label state(yamlSaveHelper, "%s:\n", SS_YAML_KEY_STATE);
-
-			if (GetCardMgr().QuerySlot(SLOT0) != CT_Empty && IsApple2PlusOrClone(GetApple2Type()))
-				GetLanguageCard()->SaveSnapshot(yamlSaveHelper);	// Language Card or Saturn 128K
 
 			GetCardMgr().SaveSnapshot(yamlSaveHelper);
 		}

--- a/source/Windows/AppleWin.cpp
+++ b/source/Windows/AppleWin.cpp
@@ -44,6 +44,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "SaveState.h"
 #include "SoundCore.h"
 #include "Speaker.h"
+#include "LanguageCard.h"
 #ifdef USE_SPEECH_API
 #include "Speech.h"
 #endif
@@ -709,7 +710,7 @@ static void RepeatInitialization(void)
 #endif
 		if (g_cmdLine.uSaturnBanks)
 		{
-			SetSaturnMemorySize(g_cmdLine.uSaturnBanks);	// Set number of banks before constructing Saturn card
+			Saturn128K::SetSaturnMemorySize(g_cmdLine.uSaturnBanks);	// Set number of banks before constructing Saturn card
 			SetExpansionMemType(CT_Saturn128K);
 			g_cmdLine.uSaturnBanks = 0;		// Don't reapply after a restart
 		}


### PR DESCRIPTION
While I was working on the other PRs re Card interface, I realised that the `Slot0` card information is stored in separate locations

1. the `Slot0` type (but the card is always a `DummyCard`)
2. the `g_pLanguageCard` global variable (which contains the instance)

This change moves all the information to the slot 0 of the `CardManager` and I think simplifies the logic.

There is an important point not to forget, is that for a //e the Slot 0 MUST ALWAYS contains a `LanguageCardUnit` (of type `CT_LanguageCardIIe`). And I have added an `ASSERT` about this, so it cannot be missed.

This is not new, it used to be done in https://github.com/AppleWin/AppleWin/blob/443545b0f6d31349eb365956ab948561e889cc15/source/Memory.cpp#L352
