### PR TITLE
Correct Bmp creation on Linux

### DIFF
--- a/source/FrameBase.cpp
+++ b/source/FrameBase.cpp
@@ -121,9 +121,9 @@ void FrameBase::Video_SaveScreenShot(const Video::VideoScreenShot_e ScreenShotTy
 void FrameBase::Util_MakeScreenShotFileName(TCHAR* pFinalFileName_, DWORD chars)
 {
 	const std::string sPrefixScreenShotFileName = "AppleWin_ScreenShot";
-	// TODO: g_sScreenshotDir
 	const std::string pPrefixFileName = !g_pLastDiskImageName.empty() ? g_pLastDiskImageName : sPrefixScreenShotFileName;
-	StringCbPrintf(pFinalFileName_, chars, TEXT("%s_%09d.bmp"), pPrefixFileName.c_str(), g_nLastScreenShot);
+	const std::string folder = Video_GetScreenShotFolder();
+	StringCbPrintf(pFinalFileName_, chars, TEXT("%s%s_%09d.bmp"), folder.c_str(), pPrefixFileName.c_str(), g_nLastScreenShot);
 }
 
 // Returns TRUE if file exists, else FALSE

--- a/source/FrameBase.h
+++ b/source/FrameBase.h
@@ -56,6 +56,7 @@ public:
 	void VideoRedrawScreenAfterFullSpeed(DWORD dwCyclesThisFrame);
 	void Video_RedrawAndTakeScreenShot(const char* pScreenshotFilename);
 
+	virtual std::string Video_GetScreenShotFolder() = 0;
 	void Video_TakeScreenShot(const Video::VideoScreenShot_e ScreenShotType);
 	void Video_SaveScreenShot(const Video::VideoScreenShot_e ScreenShotType, const TCHAR* pScreenShotFileName);
 	void SetDisplayPrintScreenFileName(bool state) { g_bDisplayPrintScreenFileName = state; }

--- a/source/Video.cpp
+++ b/source/Video.cpp
@@ -580,6 +580,11 @@ void Video::Video_MakeScreenShot(FILE *pFile, const VideoScreenShot_e ScreenShot
 			pSrc += GetFrameBufferWidth();
 		}
 	}
+
+	// re-write the Header to include the file size (otherwise "file" does not recognise it)
+	pBmp->nSizeFile = ftell(pFile);
+	rewind(pFile);
+	fwrite( pBmp, sizeof( WinBmpHeader_t ), 1, pFile );
 }
 
 //===========================================================================

--- a/source/Video.cpp
+++ b/source/Video.cpp
@@ -509,7 +509,7 @@ void Video::Video_SetBitmapHeader(WinBmpHeader_t *pBmp, int nWidth, int nHeight,
 
 void Video::Video_MakeScreenShot(FILE *pFile, const VideoScreenShot_e ScreenShotType)
 {
-	WinBmpHeader_t *pBmp = &g_tBmpHeader;
+	WinBmpHeader_t bmp, *pBmp = &bmp;
 
 	Video_SetBitmapHeader(
 		pBmp,

--- a/source/Video.cpp
+++ b/source/Video.cpp
@@ -518,8 +518,13 @@ void Video::Video_MakeScreenShot(FILE *pFile, const VideoScreenShot_e ScreenShot
 		32
 	);
 
-	char sIfSizeZeroOrUnknown_BadWinBmpHeaderPackingSize54[ sizeof( WinBmpHeader_t ) == (14 + 40) ];
+#define EXPECTED_BMP_HEADER_SIZE (14 + 40)
+#ifdef _MSC_VER
+	char sIfSizeZeroOrUnknown_BadWinBmpHeaderPackingSize54[ sizeof( WinBmpHeader_t ) == EXPECTED_BMP_HEADER_SIZE];
 	/**/ sIfSizeZeroOrUnknown_BadWinBmpHeaderPackingSize54[0]=0;
+#else
+	static_assert(sizeof( WinBmpHeader_t ) == EXPECTED_BMP_HEADER_SIZE, "BadWinBmpHeaderPackingSize");
+#endif
 
 	// Write Header
 	fwrite( pBmp, sizeof( WinBmpHeader_t ), 1, pFile );

--- a/source/Video.h
+++ b/source/Video.h
@@ -291,8 +291,6 @@ private:
 	COLORREF g_nMonochromeRGB;	// saved to Registry
 	bool m_hasVidHD;
 
-	WinBmpHeader_t g_tBmpHeader;
-
 	static const int kVDisplayableScanLines = 192; // max displayable scanlines
 
 	static const UINT kVideoRomSize8K = kVideoRomSize4K*2;

--- a/source/Video.h
+++ b/source/Video.h
@@ -82,13 +82,9 @@ enum AppleFont_e
 	APPLE_FONT_Y_APPLE_40COL = 512, // ][
 };
 
-#ifdef _MSC_VER
-	// turn of MSVC struct member padding
-	#pragma pack(push,1)
-	#define PACKED
-#else
-	#define PACKED // TODO: FIXME: gcc/clang __attribute__
-#endif
+
+// turn on struct member padding
+#pragma pack(push,1)
 
 // TODO: Replace with WinGDI.h / RGBQUAD
 struct bgra_t
@@ -174,10 +170,7 @@ struct WinBmpHeader4_t
 	uint32_t nBlueGamma      ; // 0x76 0x04
 };
 
-#ifdef _MSC_VER
-	#pragma pack(pop)
-#endif
-
+#pragma pack(pop)
 //
 
 class Video

--- a/source/Windows/Win32Frame.cpp
+++ b/source/Windows/Win32Frame.cpp
@@ -620,3 +620,9 @@ BYTE* Win32Frame::GetResource(WORD id, LPCSTR lpType, DWORD dwExpectedSize)
 
 	return pResource;
 }
+
+std::string Win32Frame::Video_GetScreenShotFolder()
+{
+	// save in current folder
+	return "";
+}

--- a/source/Windows/Win32Frame.h
+++ b/source/Windows/Win32Frame.h
@@ -55,6 +55,8 @@ public:
 	virtual BYTE* GetResource(WORD id, LPCSTR lpType, DWORD expectedSize);
 	virtual void Restart();
 
+	virtual std::string Video_GetScreenShotFolder();
+
 	bool GetFullScreenShowSubunitStatus(void);
 	int GetFullScreenOffsetX(void);
 	int GetFullScreenOffsetY(void);


### PR DESCRIPTION
1. Header was not packed properly
2. static assert did not work on gcc / clang
3. added `FrameBase::Video_GetScreenShotFolder` to let frontends customise where to save the screenshots
4. added the size to the bitmap header: to make it more compliant
