### PR TITLE
writes to PIC strobe should not be interpreted as a data byte

### DIFF
--- a/source/ParallelPrinter.cpp
+++ b/source/ParallelPrinter.cpp
@@ -142,21 +142,24 @@ static BYTE __stdcall PrintStatus(WORD, WORD, BYTE, BYTE, ULONG)
 }
 
 //===========================================================================
-static BYTE __stdcall PrintTransmit(WORD, WORD, BYTE, BYTE value, ULONG)
+static BYTE __stdcall PrintTransmit(WORD, WORD address, BYTE, BYTE value, ULONG)
 {
 	if (!CheckPrint())
 		return 0;
 
-	BYTE c = value & 0x7F;
+    if ((address & 0xF) == 0) {
+        // load output port (i.e., $C090)
+        BYTE c = value & 0x7F;
 
-	if (IsPravets(GetApple2Type()))
-	{
-		if (g_bConvertEncoding)
-			c = GetPravets().ConvertToPrinterChar(value);
-	}
+        if (IsPravets(GetApple2Type()))
+        {
+            if (g_bConvertEncoding)
+                c = GetPravets().ConvertToPrinterChar(value);
+        }
 
-	if ((g_bFilterUnprintable == false) || (c>31) || (c==13) || (c==10) || (c>0x7F)) //c>0x7F is needed for cyrillic characters
-		fwrite(&c, 1, 1, file);
+        if ((g_bFilterUnprintable == false) || (c>31) || (c==13) || (c==10) || (c>0x7F)) //c>0x7F is needed for cyrillic characters
+            fwrite(&c, 1, 1, file);
+    }
 
 	return 0;
 }

--- a/source/ParallelPrinter.cpp
+++ b/source/ParallelPrinter.cpp
@@ -147,19 +147,20 @@ static BYTE __stdcall PrintTransmit(WORD, WORD address, BYTE, BYTE value, ULONG)
 	if (!CheckPrint())
 		return 0;
 
-    if ((address & 0xF) == 0) {
-        // load output port (i.e., $C090)
-        BYTE c = value & 0x7F;
+	// only allow writes to the load output port (i.e., $C090)
+	if ((address & 0xF) != 0)
+		return 0;
 
-        if (IsPravets(GetApple2Type()))
-        {
-            if (g_bConvertEncoding)
-                c = GetPravets().ConvertToPrinterChar(value);
-        }
+	BYTE c = value & 0x7F;
 
-        if ((g_bFilterUnprintable == false) || (c>31) || (c==13) || (c==10) || (c>0x7F)) //c>0x7F is needed for cyrillic characters
-            fwrite(&c, 1, 1, file);
-    }
+	if (IsPravets(GetApple2Type()))
+	{
+		if (g_bConvertEncoding)
+			c = GetPravets().ConvertToPrinterChar(value);
+	}
+
+	if ((g_bFilterUnprintable == false) || (c>31) || (c==13) || (c==10) || (c>0x7F)) //c>0x7F is needed for cyrillic characters
+		fwrite(&c, 1, 1, file);
 
 	return 0;
 }


### PR DESCRIPTION
Only send writes to address $C090 (although the code is generalized in case the PCI is inserted into a different slot) to the printer. PrintShop was also writing to the strobe ($C092) which should not be interpreted as a data byte.

Tested with PrintShop configured for a "Epson MX-, FX-, RX- (80 or 100)" connected to "Apple II Parallel Interface" in slot 1.

This still does not cleanly pass the bytes to an Epson printer. You'll also want to set `g_bFilterUnprintable` to `false` because that filters out the ESC character that the printer needs, and `g_bPrinterAppend` to `true` because the default setting has a bad habit of resetting the printout.