### PR TITLE
Add undefined int8_t type for VS2008.

### DIFF
--- a/source/StdAfx.h
+++ b/source/StdAfx.h
@@ -11,6 +11,7 @@
 #if _MSC_VER >= 1600	// <stdint.h> supported from VS2010 (cl.exe v16.00)
 #include <stdint.h> // cleanup WORD DWORD -> uint16_t uint32_t
 #else
+typedef INT8 int8_t;
 typedef UINT8 uint8_t;
 typedef UINT16 uint16_t;
 typedef UINT32 uint32_t;


### PR DESCRIPTION
Fixes Debugger_Disassembler.cpp build failure at struct FAC_t exponent field definition.