### PR TITLE
Replace StringCbPrintf() with StrFormat()

### DIFF
--- a/source/Configuration/About.cpp
+++ b/source/Configuration/About.cpp
@@ -65,13 +65,12 @@ static INT_PTR CALLBACK DlgProcAbout(HWND hWnd, UINT message, WPARAM wparam, LPA
 	case WM_INITDIALOG:
 		{
 			HICON hIcon = LoadIcon(GetFrame().g_hInstance, TEXT("APPLEWIN_ICON"));
-			SendDlgItemMessage(hWnd, IDC_APPLEWIN_ICON, STM_SETIMAGE, IMAGE_ICON, (LPARAM)hIcon);
+			SendDlgItemMessage(hWnd, IDC_APPLEWIN_ICON, STM_SETIMAGE, IMAGE_ICON, reinterpret_cast<LPARAM>(hIcon));
 
-			TCHAR szAppleWinVersion[50];
-			StringCbPrintf(szAppleWinVersion, 50, "AppleWin v%s", VERSIONSTRING);
-			SendDlgItemMessage(hWnd, IDC_APPLEWIN_VERSION, WM_SETTEXT, 0, (LPARAM)szAppleWinVersion);
+			std::string strAppleWinVersion = "AppleWin v" + g_VERSIONSTRING;
+			SendDlgItemMessage(hWnd, IDC_APPLEWIN_VERSION, WM_SETTEXT, 0, reinterpret_cast<LPARAM>(strAppleWinVersion.c_str()));
 
-			SendDlgItemMessage(hWnd, IDC_GPL_TEXT, WM_SETTEXT, 0, (LPARAM)g_szGPL);
+			SendDlgItemMessage(hWnd, IDC_GPL_TEXT, WM_SETTEXT, 0, reinterpret_cast<LPARAM>(g_szGPL));
 		}
 		break;
 	}

--- a/source/Configuration/PageDisk.cpp
+++ b/source/Configuration/PageDisk.cpp
@@ -476,7 +476,6 @@ void CPageDisk::HandleHDDSwap(HWND hWnd)
 
 UINT CPageDisk::RemovalConfirmation(UINT uCommand)
 {
-	TCHAR szText[100];
 	bool bMsgBox = true;
 
 	bool isDisk = false;
@@ -492,18 +491,19 @@ UINT CPageDisk::RemovalConfirmation(UINT uCommand)
 		drive = uCommand - IDC_COMBO_DISK1_SLOT5;
 	}
 
+	std::string strText;
 	if (isDisk)
-		StringCbPrintf(szText, sizeof(szText), "Do you really want to eject the disk in drive-%c ?", '1' + drive);
+		strText = StrFormat("Do you really want to eject the disk in drive-%c ?", '1' + drive);
 	else if (uCommand == IDC_COMBO_HDD1 || uCommand == IDC_COMBO_HDD2)
-		StringCbPrintf(szText, sizeof(szText), "Do you really want to unplug harddisk-%c ?", '1' + uCommand - IDC_COMBO_HDD1);
+		strText = StrFormat("Do you really want to unplug harddisk-%c ?", '1' + uCommand - IDC_COMBO_HDD1);
 	else if (uCommand == IDC_HDD_SWAP)
-		StringCbPrintf(szText, sizeof(szText), "Do you really want to swap the harddisk images?");
+		strText = "Do you really want to swap the harddisk images?";
 	else
 		bMsgBox = false;
 
 	if (bMsgBox)
 	{
-		int nRes = GetFrame().FrameMessageBox(szText, "Eject/Unplug Warning", MB_ICONWARNING | MB_YESNO | MB_SETFOREGROUND);
+		int nRes = GetFrame().FrameMessageBox(strText.c_str(), "Eject/Unplug Warning", MB_ICONWARNING | MB_YESNO | MB_SETFOREGROUND);
 		if (nRes == IDNO)
 			uCommand = 0;
 	}

--- a/source/Core.cpp
+++ b/source/Core.cpp
@@ -44,10 +44,10 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "Speech.h"
 #endif
 
-static const UINT VERSIONSTRING_SIZE = 16;
-static UINT16 g_OldAppleWinVersion[4] = {0};
+static UINT16 g_OldAppleWinVersion[4] = { 0 };
+
 UINT16 g_AppleWinVersion[4] = { 0 };
-TCHAR VERSIONSTRING[VERSIONSTRING_SIZE] = "xx.yy.zz.ww";
+std::string g_VERSIONSTRING = "xx.yy.zz.ww";
 
 std::string g_pAppTitle;
 
@@ -257,14 +257,15 @@ void SetAppleWinVersion(UINT16 major, UINT16 minor, UINT16 fix, UINT16 fix_minor
 	g_AppleWinVersion[1] = minor;
 	g_AppleWinVersion[2] = fix;
 	g_AppleWinVersion[3] = fix_minor;
-	StringCbPrintf(VERSIONSTRING, VERSIONSTRING_SIZE, "%d.%d.%d.%d", major, minor, fix, fix_minor);
+	g_VERSIONSTRING = StrFormat("%d.%d.%d.%d", major, minor, fix, fix_minor);
 }
 
 bool CheckOldAppleWinVersion(void)
 {
-	TCHAR szOldAppleWinVersion[VERSIONSTRING_SIZE + 1];
-	RegLoadString(TEXT(REG_CONFIG), TEXT(REGVALUE_VERSION), 1, szOldAppleWinVersion, VERSIONSTRING_SIZE, TEXT(""));
-	const bool bShowAboutDlg = strcmp(szOldAppleWinVersion, VERSIONSTRING) != 0;
+	const int VERSIONSTRING_SIZE = 16;
+	char szOldAppleWinVersion[VERSIONSTRING_SIZE + 1];
+	RegLoadString(REG_CONFIG, REGVALUE_VERSION, TRUE, szOldAppleWinVersion, VERSIONSTRING_SIZE, "");
+	const bool bShowAboutDlg = (g_VERSIONSTRING != szOldAppleWinVersion);
 
 	// version: xx.yy.zz.ww
 	char* p0 = szOldAppleWinVersion;

--- a/source/Core.h
+++ b/source/Core.h
@@ -9,7 +9,7 @@ void LogFileTimeUntilFirstKeyReadReset(void);
 void LogFileTimeUntilFirstKeyRead(void);
 
 extern const UINT16* GetOldAppleWinVersion(void);
-extern TCHAR VERSIONSTRING[];	// Constructed in WinMain()
+extern std::string g_VERSIONSTRING;	// Constructed in WinMain()
 
 void SetAppleWinVersion(UINT16 major, UINT16 minor, UINT16 fix, UINT16 fix_minor);
 bool CheckOldAppleWinVersion(void);

--- a/source/Debugger/Debugger_Help.cpp
+++ b/source/Debugger/Debugger_Help.cpp
@@ -1611,7 +1611,7 @@ Update_t CmdVersion (int nArgs)
 
 	ConsolePrintFormat( sText, "  Emulator:  %s%s%s    Debugger: %s%d.%d.%d.%d%s"
 		, CHC_SYMBOL
-		, VERSIONSTRING
+		, g_VERSIONSTRING.c_str()
 		, CHC_DEFAULT
 		, CHC_SYMBOL
 		, nMajor, nMinor, nFixMajor, nFixMinor

--- a/source/Disk.cpp
+++ b/source/Disk.cpp
@@ -728,9 +728,10 @@ ImageError_e Disk2InterfaceCard::InsertDisk(const int drive, const std::string& 
 
 	if (Error == eIMAGE_ERROR_NONE && ImageIsMultiFileZip(pFloppy->m_imagehandle))
 	{
-		TCHAR szText[100+MAX_PATH];
-		StringCbPrintf(szText, sizeof(szText), "Only the first file in a multi-file zip is supported\nUse disk image '%s' ?", pFloppy->m_strFilenameInZip.c_str());
-		int nRes = GetFrame().FrameMessageBox(szText, TEXT("Multi-Zip Warning"), MB_ICONWARNING | MB_YESNO | MB_SETFOREGROUND);
+		std::string strText = StrFormat("Only the first file in a multi-file zip is supported\n"
+										"Use disk image '%s' ?",
+										pFloppy->m_strFilenameInZip.c_str());
+		int nRes = GetFrame().FrameMessageBox(strText.c_str(), "Multi-Zip Warning", MB_ICONWARNING | MB_YESNO | MB_SETFOREGROUND);
 		if (nRes == IDNO)
 		{
 			EjectDisk(drive);
@@ -769,89 +770,62 @@ bool Disk2InterfaceCard::IsConditionForFullSpeed(void)
 
 void Disk2InterfaceCard::NotifyInvalidImage(const int drive, LPCTSTR pszImageFilename, const ImageError_e Error)
 {
-	TCHAR szBuffer[MAX_PATH + 128];
+	std::string strText;
 
 	switch (Error)
 	{
 	case eIMAGE_ERROR_UNABLE_TO_OPEN:
 	case eIMAGE_ERROR_UNABLE_TO_OPEN_GZ:
 	case eIMAGE_ERROR_UNABLE_TO_OPEN_ZIP:
-		StringCbPrintf(
-			szBuffer,
-			MAX_PATH + 128,
-			TEXT("Unable to open the file %s."),
-			pszImageFilename);
+		strText = StrFormat("Unable to open the file %s.",
+							pszImageFilename);
 		break;
 
 	case eIMAGE_ERROR_BAD_SIZE:
-		StringCbPrintf(
-			szBuffer,
-			MAX_PATH + 128,
-			TEXT("Unable to use the file %s\nbecause the ")
-			TEXT("disk image is an unsupported size."),
-			pszImageFilename);
+		strText = StrFormat("Unable to use the file %s\n"
+							"because the disk image is an unsupported size.",
+							pszImageFilename);
 		break;
 
 	case eIMAGE_ERROR_BAD_FILE:
-		StringCbPrintf(
-			szBuffer,
-			MAX_PATH + 128,
-			TEXT("Unable to use the file %s\nbecause the ")
-			TEXT("OS can't access it."),
-			pszImageFilename);
+		strText = StrFormat("Unable to use the file %s\n"
+							"because the OS can't access it.",
+							pszImageFilename);
 		break;
 
 	case eIMAGE_ERROR_UNSUPPORTED:
-		StringCbPrintf(
-			szBuffer,
-			MAX_PATH + 128,
-			TEXT("Unable to use the file %s\nbecause the ")
-			TEXT("disk image format is not recognized."),
-			pszImageFilename);
+		strText = StrFormat("Unable to use the file %s\n"
+							"because the disk image format is not recognized.",
+							pszImageFilename);
 		break;
 
 	case eIMAGE_ERROR_UNSUPPORTED_HDV:
-		StringCbPrintf(
-			szBuffer,
-			MAX_PATH + 128,
-			TEXT("Unable to use the file %s\n")
-			TEXT("because this UniDisk 3.5/Apple IIGS/hard-disk image is not supported.\n")
-			TEXT("Try inserting as a hard-disk image instead."),
-			pszImageFilename);
+		strText = StrFormat("Unable to use the file %s\n"
+							"because this UniDisk 3.5/Apple IIGS/hard-disk image is not supported.\n"
+							"Try inserting as a hard-disk image instead.",
+							pszImageFilename);
 		break;
 
 	case eIMAGE_ERROR_GZ:
 	case eIMAGE_ERROR_ZIP:
-		StringCbPrintf(
-			szBuffer,
-			MAX_PATH + 128,
-			TEXT("Unable to use the compressed file %s\nbecause the ")
-			TEXT("compressed disk image is corrupt/unsupported."),
-			pszImageFilename);
+		strText = StrFormat("Unable to use the compressed file %s\n"
+							"because the compressed disk image is corrupt/unsupported.",
+							pszImageFilename);
 		break;
 
 	case eIMAGE_ERROR_FAILED_TO_GET_PATHNAME:
-		StringCbPrintf(
-			szBuffer,
-			MAX_PATH + 128,
-			TEXT("Unable to GetFullPathName() for the file: %s."),
-			pszImageFilename);
+		strText = StrFormat("Unable to GetFullPathName() for the file: %s.",
+							pszImageFilename);
 		break;
 
 	case eIMAGE_ERROR_ZEROLENGTH_WRITEPROTECTED:
-		StringCbPrintf(
-			szBuffer,
-			MAX_PATH + 128,
-			TEXT("Unsupported zero-length write-protected file: %s."),
-			pszImageFilename);
+		strText = StrFormat("Unsupported zero-length write-protected file: %s.",
+							pszImageFilename);
 		break;
 
 	case eIMAGE_ERROR_FAILED_TO_INIT_ZEROLENGTH:
-		StringCbPrintf(
-			szBuffer,
-			MAX_PATH + 128,
-			TEXT("Failed to resize the zero-length file: %s."),
-			pszImageFilename);
+		strText = StrFormat("Failed to resize the zero-length file: %s.",
+							pszImageFilename);
 		break;
 
 	default:
@@ -859,10 +833,9 @@ void Disk2InterfaceCard::NotifyInvalidImage(const int drive, LPCTSTR pszImageFil
 		return;
 	}
 
-	GetFrame().FrameMessageBox(
-		szBuffer,
-		g_pAppTitle.c_str(),
-		MB_ICONEXCLAMATION | MB_SETFOREGROUND);
+	GetFrame().FrameMessageBox(strText.c_str(),
+							   g_pAppTitle.c_str(),
+							   MB_ICONEXCLAMATION | MB_SETFOREGROUND);
 }
 
 //===========================================================================
@@ -1578,12 +1551,11 @@ bool Disk2InterfaceCard::UserSelectNewDiskImage(const int drive, LPCSTR pszFilen
 
 	TCHAR directory[MAX_PATH];
 	TCHAR filename[MAX_PATH];
-	TCHAR title[40];
 
 	StringCbCopy(filename, MAX_PATH, pszFilename);
 
 	RegLoadString(TEXT(REG_PREFS), TEXT(REGVALUE_PREF_START_DIR), 1, directory, MAX_PATH, TEXT(""));
-	StringCbPrintf(title, 40, TEXT("Select Disk Image For Drive %d"), drive + 1);
+	std::string title = StrFormat("Select Disk Image For Drive %d", drive + 1);
 
 	OPENFILENAME ofn;
 	memset(&ofn, 0, sizeof(OPENFILENAME));
@@ -1597,7 +1569,7 @@ bool Disk2InterfaceCard::UserSelectNewDiskImage(const int drive, LPCSTR pszFilen
 	ofn.nMaxFile        = MAX_PATH;
 	ofn.lpstrInitialDir = directory;
 	ofn.Flags           = OFN_PATHMUSTEXIST;
-	ofn.lpstrTitle      = title;
+	ofn.lpstrTitle      = title.c_str();
 
 	bool bRes = false;
 

--- a/source/DiskImageHelper.cpp
+++ b/source/DiskImageHelper.cpp
@@ -2227,8 +2227,7 @@ BYTE* CWOZHelper::CreateEmptyDisk(DWORD& size)
 	pWOZ->info.v1.version = 2;
 	pWOZ->info.v1.diskType = InfoChunk::diskType5_25;
 	pWOZ->info.v1.cleaned = 1;
-	std::string creator("AppleWin v");
-	creator += std::string(VERSIONSTRING);
+	std::string creator = "AppleWin v" + g_VERSIONSTRING;
 	memset(&pWOZ->info.v1.creator[0], ' ', sizeof(pWOZ->info.v1.creator));
 	memcpy(&pWOZ->info.v1.creator[0], creator.c_str(), creator.size());	// don't include null
 	pWOZ->info.diskSides = 1;
@@ -2280,8 +2279,7 @@ BYTE* CWOZHelper::CreateEmptyDiskv1(DWORD& size)
 	pWOZ->info.version = 1;
 	pWOZ->info.diskType = InfoChunk::diskType5_25;
 	pWOZ->info.cleaned = 1;
-	std::string creator("AppleWin v");
-	creator += std::string(VERSIONSTRING);
+	std::string creator = "AppleWin v" + g_VERSIONSTRING;
 	memset(&pWOZ->info.creator[0], ' ', sizeof(pWOZ->info.creator));
 	memcpy(&pWOZ->info.creator[0], creator.c_str(), creator.size());	// don't include null
 

--- a/source/FrameBase.cpp
+++ b/source/FrameBase.cpp
@@ -73,7 +73,7 @@ void FrameBase::Video_RedrawAndTakeScreenShot(const char* pScreenshotFilename)
 
 void FrameBase::Video_TakeScreenShot(const Video::VideoScreenShot_e ScreenShotType)
 {
-	TCHAR sScreenShotFileName[MAX_PATH];
+	std::string strScreenShotFileName;
 
 	// find last screenshot filename so we don't overwrite the existing user ones
 	bool bExists = true;
@@ -81,15 +81,16 @@ void FrameBase::Video_TakeScreenShot(const Video::VideoScreenShot_e ScreenShotTy
 	{
 		if (g_nLastScreenShot > nMaxScreenShot) // Holy Crap! User has maxed the number of screenshots!?
 		{
-			TCHAR msg[512];
-			StringCbPrintf(msg, 512, "You have more then %d screenshot filenames!  They will no longer be saved.\n\nEither move some of your screenshots or increase the maximum in video.cpp\n", nMaxScreenShot);
-			FrameMessageBox(msg, "Warning", MB_OK);
+			std::string msg = StrFormat("You have more then %d screenshot filenames!  They will no longer be saved.\n\n"
+										"Either move some of your screenshots or increase the maximum in video.cpp\n",
+										nMaxScreenShot);
+			FrameMessageBox(msg.c_str(), "Warning", MB_OK);
 			g_nLastScreenShot = 0;
 			return;
 		}
 
-		Util_MakeScreenShotFileName(sScreenShotFileName, MAX_PATH);
-		bExists = Util_TestScreenShotFileName(sScreenShotFileName);
+		strScreenShotFileName = Util_MakeScreenShotFileName();
+		bExists = Util_TestScreenShotFileName(strScreenShotFileName.c_str());
 		if (!bExists)
 		{
 			break;
@@ -97,7 +98,7 @@ void FrameBase::Video_TakeScreenShot(const Video::VideoScreenShot_e ScreenShotTy
 		g_nLastScreenShot++;
 	}
 
-	Video_SaveScreenShot(ScreenShotType, sScreenShotFileName);
+	Video_SaveScreenShot(ScreenShotType, strScreenShotFileName.c_str());
 	g_nLastScreenShot++;
 }
 
@@ -118,12 +119,12 @@ void FrameBase::Video_SaveScreenShot(const Video::VideoScreenShot_e ScreenShotTy
 	}
 }
 
-void FrameBase::Util_MakeScreenShotFileName(TCHAR* pFinalFileName_, DWORD chars)
+std::string FrameBase::Util_MakeScreenShotFileName() const
 {
 	const std::string sPrefixScreenShotFileName = "AppleWin_ScreenShot";
 	const std::string pPrefixFileName = !g_pLastDiskImageName.empty() ? g_pLastDiskImageName : sPrefixScreenShotFileName;
 	const std::string folder = Video_GetScreenShotFolder();
-	StringCbPrintf(pFinalFileName_, chars, TEXT("%s%s_%09d.bmp"), folder.c_str(), pPrefixFileName.c_str(), g_nLastScreenShot);
+	return StrFormat("%s%s_%09d.bmp", folder.c_str(), pPrefixFileName.c_str(), g_nLastScreenShot);
 }
 
 // Returns TRUE if file exists, else FALSE

--- a/source/FrameBase.h
+++ b/source/FrameBase.h
@@ -56,7 +56,7 @@ public:
 	void VideoRedrawScreenAfterFullSpeed(DWORD dwCyclesThisFrame);
 	void Video_RedrawAndTakeScreenShot(const char* pScreenshotFilename);
 
-	virtual std::string Video_GetScreenShotFolder() = 0;
+	virtual std::string Video_GetScreenShotFolder() const = 0;
 	void Video_TakeScreenShot(const Video::VideoScreenShot_e ScreenShotType);
 	void Video_SaveScreenShot(const Video::VideoScreenShot_e ScreenShotType, const TCHAR* pScreenShotFileName);
 	void SetDisplayPrintScreenFileName(bool state) { g_bDisplayPrintScreenFileName = state; }
@@ -66,7 +66,7 @@ public:
 	void SetShowPrintScreenWarningDialog(bool state) { g_bShowPrintScreenWarningDialog = state; }
 
 private:
-	void Util_MakeScreenShotFileName(TCHAR* pFinalFileName_, DWORD chars);
+	std::string Util_MakeScreenShotFileName() const;
 	bool Util_TestScreenShotFileName(const TCHAR* pFileName);
 
 	bool g_bShowPrintScreenWarningDialog;

--- a/source/Harddisk.cpp
+++ b/source/Harddisk.cpp
@@ -209,18 +209,12 @@ void HarddiskInterfaceCard::NotifyInvalidImage(TCHAR* pszImageFilename)
 {
 	// TC: TO DO - see Disk2InterfaceCard::NotifyInvalidImage()
 
-	char szBuffer[MAX_PATH + 128];
+	std::string strText = StrFormat("Unable to open the file %s.",
+									pszImageFilename);
 
-	StringCbPrintf(
-		szBuffer,
-		MAX_PATH + 128,
-		TEXT("Unable to open the file %s."),
-		pszImageFilename);
-
-	GetFrame().FrameMessageBox(
-		szBuffer,
-		g_pAppTitle.c_str(),
-		MB_ICONEXCLAMATION | MB_SETFOREGROUND);
+	GetFrame().FrameMessageBox(strText.c_str(),
+							   g_pAppTitle.c_str(),
+							   MB_ICONEXCLAMATION | MB_SETFOREGROUND);
 }
 
 //===========================================================================
@@ -401,12 +395,11 @@ bool HarddiskInterfaceCard::SelectImage(const int drive, LPCSTR pszFilename)
 {
 	TCHAR directory[MAX_PATH];
 	TCHAR filename[MAX_PATH];
-	TCHAR title[40];
 
 	StringCbCopy(filename, MAX_PATH, pszFilename);
 
 	RegLoadString(TEXT(REG_PREFS), TEXT(REGVALUE_PREF_HDV_START_DIR), 1, directory, MAX_PATH, TEXT(""));
-	StringCbPrintf(title, 40, TEXT("Select HDV Image For HDD %d"), drive + 1);
+	std::string title = StrFormat("Select HDV Image For HDD %d", drive + 1);
 
 	OPENFILENAME ofn;
 	memset(&ofn, 0, sizeof(OPENFILENAME));
@@ -419,7 +412,7 @@ bool HarddiskInterfaceCard::SelectImage(const int drive, LPCSTR pszFilename)
 	ofn.nMaxFile        = MAX_PATH;
 	ofn.lpstrInitialDir = directory;
 	ofn.Flags           = OFN_FILEMUSTEXIST | OFN_HIDEREADONLY;	// Don't allow creation & hide the read-only checkbox
-	ofn.lpstrTitle      = title;
+	ofn.lpstrTitle      = title.c_str();
 
 	bool bRes = false;
 

--- a/source/Memory.cpp
+++ b/source/Memory.cpp
@@ -1585,15 +1585,13 @@ void MemInitializeROM(void)
 			}
 		}
 
-		TCHAR sText[MAX_PATH];
-		StringCbPrintf(sText, sizeof(sText), TEXT("Unable to open the required firmware ROM data file.\n\nFile: %s"), sRomFileName);
+		std::string strText = StrFormat("Unable to open the required firmware ROM data file.\n\nFile: %s", sRomFileName);
 
-		LogFileOutput("%s\n", sText);
+		LogFileOutput("%s\n", strText.c_str());
 
-		GetFrame().FrameMessageBox(
-			sText,
-			g_pAppTitle.c_str(),
-			MB_ICONSTOP | MB_SETFOREGROUND);
+		GetFrame().FrameMessageBox(strText.c_str(),
+								   g_pAppTitle.c_str(),
+								   MB_ICONSTOP | MB_SETFOREGROUND);
 
 		ExitProcess(1);
 	}

--- a/source/Registry.cpp
+++ b/source/Registry.cpp
@@ -30,6 +30,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include "Registry.h"
 #include "CmdLine.h"
+#include "StrFormat.h"
 
 namespace _ini {
 	//===========================================================================
@@ -60,14 +61,13 @@ BOOL RegLoadString (LPCTSTR section, LPCTSTR key, BOOL peruser, LPTSTR buffer, D
 	if (!g_sConfigFile.empty())
 		return _ini::RegLoadString(section, key, peruser, buffer, chars);
 
-	TCHAR fullkeyname[256];
-	StringCbPrintf(fullkeyname, 256, TEXT("Software\\AppleWin\\CurrentVersion\\%s"), section);
+	std::string fullkeyname = std::string("Software\\AppleWin\\CurrentVersion\\") + section;
 
 	BOOL success = FALSE;
 	HKEY keyhandle;
 	LSTATUS status = RegOpenKeyEx(
 		(peruser ? HKEY_CURRENT_USER : HKEY_LOCAL_MACHINE),
-		fullkeyname,
+		fullkeyname.c_str(),
 		0,
 		KEY_READ,
 		&keyhandle);
@@ -119,14 +119,13 @@ void RegSaveString (LPCTSTR section, LPCTSTR key, BOOL peruser, const std::strin
 	if (!g_sConfigFile.empty())
 		return _ini::RegSaveString(section, key, peruser, buffer);
 
-	TCHAR fullkeyname[256];
-	StringCbPrintf(fullkeyname, 256, TEXT("Software\\AppleWin\\CurrentVersion\\%s"), section);
+	std::string fullkeyname = std::string("Software\\AppleWin\\CurrentVersion\\") + section;
 
 	HKEY  keyhandle;
 	DWORD disposition;
 	LSTATUS status = RegCreateKeyEx(
 		(peruser ? HKEY_CURRENT_USER : HKEY_LOCAL_MACHINE),
-		fullkeyname,
+		fullkeyname.c_str(),
 		0,
 		NULL,
 		REG_OPTION_NON_VOLATILE,
@@ -149,9 +148,8 @@ void RegSaveString (LPCTSTR section, LPCTSTR key, BOOL peruser, const std::strin
 
 //===========================================================================
 void RegSaveValue (LPCTSTR section, LPCTSTR key, BOOL peruser, DWORD value) {
-	TCHAR buffer[32] = TEXT("");
-	StringCbPrintf(buffer, 32, "%d", value);
-	RegSaveString(section, key, peruser, buffer);
+	std::string strValue = StrFormat("%d", value);
+	RegSaveString(section, key, peruser, strValue.c_str());
 }
 
 //===========================================================================
@@ -188,13 +186,12 @@ void RegDeleteConfigSlotSection(UINT slot)
 		return _ini::RegDeleteString(section.c_str(), peruser);
 	}
 
-	TCHAR fullkeyname[256];
-	StringCbPrintf(fullkeyname, 256, TEXT("Software\\AppleWin\\CurrentVersion\\%s"), REG_CONFIG);
+	std::string fullkeyname = std::string("Software\\AppleWin\\CurrentVersion\\") + REG_CONFIG;
 
 	HKEY keyhandle;
 	LSTATUS status = RegOpenKeyEx(
 		(peruser ? HKEY_CURRENT_USER : HKEY_LOCAL_MACHINE),
-		fullkeyname,
+		fullkeyname.c_str(),
 		0,
 		KEY_READ,
 		&keyhandle);

--- a/source/Utilities.cpp
+++ b/source/Utilities.cpp
@@ -115,15 +115,13 @@ void LoadConfiguration(bool loadImages)
 
 		if (dwLoadedComputerType != dwComputerType)
 		{
-			char sText[100];
-			StringCbPrintf(sText, sizeof(sText), "Unsupported Apple2Type(%d). Changing to %d", dwLoadedComputerType, dwComputerType);
+			std::string strText = StrFormat("Unsupported Apple2Type(%d). Changing to %d", dwLoadedComputerType, dwComputerType);
 
-			LogFileOutput("%s\n", sText);
+			LogFileOutput("%s\n", strText.c_str());
 
-			GetFrame().FrameMessageBox(
-				sText,
-				"Load Configuration",
-				MB_ICONSTOP | MB_SETFOREGROUND);
+			GetFrame().FrameMessageBox(strText.c_str(),
+									   "Load Configuration",
+									   MB_ICONSTOP | MB_SETFOREGROUND);
 
 			GetPropertySheet().ConfigSaveApple2Type((eApple2Type)dwComputerType);
 		}

--- a/source/Windows/AppleWin.cpp
+++ b/source/Windows/AppleWin.cpp
@@ -611,7 +611,7 @@ static void GetAppleWinVersion(void)
 		delete [] pVerInfoBlock;
     }
 
-	LogFileOutput("AppleWin version: %s\n",  VERSIONSTRING);
+	LogFileOutput("AppleWin version: %s\n",  g_VERSIONSTRING.c_str());
 }
 
 // DO ONE-TIME INITIALIZATION
@@ -830,9 +830,9 @@ static void RepeatInitialization(void)
 		if (bShowAboutDlg)
 		{
 			if (!AboutDlg())
-				g_cmdLine.bShutdown = true;															// Close everything down
+				g_cmdLine.bShutdown = true;											// Close everything down
 			else
-				RegSaveString(TEXT(REG_CONFIG), TEXT(REGVALUE_VERSION), 1, VERSIONSTRING);	// Only save version after user accepts license
+				RegSaveString(REG_CONFIG, REGVALUE_VERSION, TRUE, g_VERSIONSTRING);	// Only save version after user accepts license
 		}
 
 		if (g_bCapturePrintScreenKey)

--- a/source/Windows/Win32Frame.cpp
+++ b/source/Windows/Win32Frame.cpp
@@ -413,16 +413,15 @@ void Win32Frame::DisplayLogo(void)
 	SetTextAlign(hFrameDC, TA_RIGHT | TA_TOP);
 	SetBkMode(hFrameDC, TRANSPARENT);
 
-	TCHAR szVersion[64];
-	StringCbPrintf(szVersion, 64, "Version %s", VERSIONSTRING);
+	std::string strVersion = "Version " + g_VERSIONSTRING;
 	int xoff = GetFullScreenOffsetX(), yoff = GetFullScreenOffsetY();
 
 #define  DRAWVERSION(x,y,c)                 \
 	SetTextColor(hFrameDC,c);               \
 	TextOut(hFrameDC,                       \
 		scale*540+x+xoff,scale*358+y+yoff,  \
-		szVersion,                          \
-		strlen(szVersion));
+		strVersion.c_str(),                 \
+		strVersion.length());
 
 	if (GetDeviceCaps(hFrameDC, PLANES) * GetDeviceCaps(hFrameDC, BITSPIXEL) <= 4) {
 		DRAWVERSION(2, 2, RGB(0x00, 0x00, 0x00));
@@ -436,7 +435,7 @@ void Win32Frame::DisplayLogo(void)
 	}
 
 #if _DEBUG
-	StringCbPrintf(szVersion, 64, "DEBUG");
+	strVersion = "DEBUG";
 	DRAWVERSION(2, -358 * scale, RGB(0x00, 0x00, 0x00));
 	DRAWVERSION(1, -357 * scale, RGB(0x00, 0x00, 0x00));
 	DRAWVERSION(0, -356 * scale, RGB(0xFF, 0x00, 0xFF));
@@ -621,8 +620,8 @@ BYTE* Win32Frame::GetResource(WORD id, LPCSTR lpType, DWORD dwExpectedSize)
 	return pResource;
 }
 
-std::string Win32Frame::Video_GetScreenShotFolder()
+std::string Win32Frame::Video_GetScreenShotFolder() const
 {
 	// save in current folder
-	return "";
+	return std::string();
 }

--- a/source/Windows/Win32Frame.h
+++ b/source/Windows/Win32Frame.h
@@ -55,7 +55,7 @@ public:
 	virtual BYTE* GetResource(WORD id, LPCSTR lpType, DWORD expectedSize);
 	virtual void Restart();
 
-	virtual std::string Video_GetScreenShotFolder();
+	virtual std::string Video_GetScreenShotFolder() const;
 
 	bool GetFullScreenShowSubunitStatus(void);
 	int GetFullScreenOffsetX(void);


### PR DESCRIPTION
There is no need to enter buffer length explicitly for `_sntprintf_s()` which is less error prone.
The calls clearly indicate output string will be truncated (if required) instead of buffer overflow.
The calls are made to be consistently UNICODE capable.