### PR TITLE
SY6522: initialise card.

### DIFF
--- a/source/6522.h
+++ b/source/6522.h
@@ -7,6 +7,7 @@ public:
 	{
 		for (UINT i = 0; i < kNumTimersPer6522; i++)
 			m_syncEvent[i] = NULL;
+		Reset(true);
 	}
 
 	~SY6522(void)


### PR DESCRIPTION
and avoid usage of uninitialised values.

Signed-off-by: Andrea Odetti <mariofutire@gmail.com>