### PR TITLE
Simplify console print

### DIFF
--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -581,9 +581,7 @@ Update_t CmdBookmarkAdd (int nArgs )
 
 	if (iBookmark >= MAX_BOOKMARKS)
 	{
-		char sText[ CONSOLE_WIDTH ];
-		sprintf( sText, "All bookmarks are currently in use.  (Max: %d)", MAX_BOOKMARKS );
-		ConsoleDisplayPush( sText );
+		ConsoleDisplayPushFormat( "All bookmarks are currently in use.  (Max: %d)", MAX_BOOKMARKS );
 		return ConsoleUpdate();
 	}
 
@@ -645,8 +643,7 @@ Update_t CmdBookmarkList (int nArgs)
 {
 	if (! g_nBookmarks)
 	{
-		TCHAR sText[ CONSOLE_WIDTH ];
-		ConsoleBufferPushFormat( sText, TEXT("  There are no current bookmarks.  (Max: %d)"), MAX_BOOKMARKS );
+		ConsoleBufferPushFormat( "  There are no current bookmarks.  (Max: %d)", MAX_BOOKMARKS );
 	}
 	else
 	{
@@ -815,8 +812,7 @@ Update_t CmdProfile (int nArgs)
 			{
 				if (ProfileSave())
 				{
-					TCHAR sText[ CONSOLE_WIDTH ];
-					ConsoleBufferPushFormat ( sText, " Saved: %s", g_FileNameProfile.c_str() );
+					ConsoleBufferPushFormat( " Saved: %s", g_FileNameProfile.c_str() );
 				}
 				else
 					ConsoleBufferPush( TEXT(" ERROR: Couldn't save file. (In use?)" ) );
@@ -879,7 +875,6 @@ Update_t CmdBreakInvalid (int nArgs) // Breakpoint IFF Full-speed!
 	// 2a. CMD # ON | OFF // set
 	// 2b. CMD ALL ON | OFF // set all
 	// 2c. CMD # ?        // error
-	TCHAR sText[ CONSOLE_WIDTH ];
 	bool bValidParam = true;
 
 	int iParamArg = nArgs;	// last arg is the 'ON' / 'OFF' param
@@ -920,9 +915,9 @@ Update_t CmdBreakInvalid (int nArgs) // Breakpoint IFF Full-speed!
 		}
 		
 		if (iType == 0)
-			ConsoleBufferPushFormat( sText, TEXT("Enter debugger on BRK opcode: %s"), g_aParameters[ iParam ].m_sName );
+			ConsoleBufferPushFormat( "Enter debugger on BRK opcode: %s", g_aParameters[ iParam ].m_sName );
 		else
-			ConsoleBufferPushFormat( sText, TEXT("Enter debugger on INVALID %1X opcode: %s"), iType, g_aParameters[ iParam ].m_sName );
+			ConsoleBufferPushFormat( "Enter debugger on INVALID %1X opcode: %s", iType, g_aParameters[ iParam ].m_sName );
 		return ConsoleUpdate();
  	}
 	else
@@ -933,7 +928,7 @@ Update_t CmdBreakInvalid (int nArgs) // Breakpoint IFF Full-speed!
 		{
 			for (iType = 0; iType <= AM_3; iType++)
 				SetDebugBreakOnInvalid(iType, nActive);
-			ConsoleBufferPushFormat(sText, TEXT("Enter debugger on BRK opcode and INVALID opcodes: %s"), g_aParameters[iParam].m_sName);
+			ConsoleBufferPushFormat("Enter debugger on BRK opcode and INVALID opcodes: %s", g_aParameters[iParam].m_sName);
 			return ConsoleUpdate();
 		}
 		else if (! bValidParam) // case 2c
@@ -948,9 +943,9 @@ Update_t CmdBreakInvalid (int nArgs) // Breakpoint IFF Full-speed!
 			SetDebugBreakOnInvalid( iType, nActive );
 
 			if (iType == 0)
-				ConsoleBufferPushFormat( sText, TEXT("Enter debugger on BRK opcode: %s"), g_aParameters[ iParam ].m_sName );
+				ConsoleBufferPushFormat( "Enter debugger on BRK opcode: %s", g_aParameters[ iParam ].m_sName );
 			else
-				ConsoleBufferPushFormat( sText, TEXT("Enter debugger on INVALID %1X opcode: %s"), iType, g_aParameters[ iParam ].m_sName );
+				ConsoleBufferPushFormat( "Enter debugger on INVALID %1X opcode: %s", iType, g_aParameters[ iParam ].m_sName );
 			return ConsoleUpdate();
 		}
  	}
@@ -965,8 +960,6 @@ _Help:
 //===========================================================================
 Update_t CmdBreakOpcode (int nArgs) // Breakpoint IFF Full-speed!
 {
-	TCHAR sText[ CONSOLE_WIDTH ];
-
 	if (nArgs > 1)
 		return HelpLastCommand();
 
@@ -981,19 +974,19 @@ Update_t CmdBreakOpcode (int nArgs) // Breakpoint IFF Full-speed!
 
 		if (iOpcode >= NUM_OPCODES)
 		{
-			ConsoleBufferPushFormat( sText, TEXT("Warning: clamping opcode: %02X"), g_iDebugBreakOnOpcode );
+			ConsoleBufferPushFormat( "Warning: clamping opcode: %02X", g_iDebugBreakOnOpcode );
 			return ConsoleUpdate();
 		}
 	}
 
 	if (g_iDebugBreakOnOpcode == 0)
 		// Show what the current break opcode is
-		ConsoleBufferPushFormat( sText, TEXT("%s Break on Opcode: None")
+		ConsoleBufferPushFormat( "%s Break on Opcode: None"
 			, sAction
 		);
 	else
 		// Show what the current break opcode is
-		ConsoleBufferPushFormat( sText, TEXT("%s Break on Opcode: %02X %s")
+		ConsoleBufferPushFormat( "%s Break on Opcode: %02X %s"
 			, sAction
 			, g_iDebugBreakOnOpcode
 			, g_aOpcodes65C02[ g_iDebugBreakOnOpcode ].sMnemonic
@@ -1025,7 +1018,6 @@ Update_t CmdBreakOnInterrupt(int nArgs)
 	if (nArgs == 1 && nActive == -1)
 		return HelpLastCommand();
 
-	TCHAR sText[CONSOLE_WIDTH];
 	TCHAR sAction[CONSOLE_WIDTH] = TEXT("Current"); // default to display
 
 	if (nArgs == 1)
@@ -1034,7 +1026,7 @@ Update_t CmdBreakOnInterrupt(int nArgs)
 		_tcscpy(sAction, TEXT("Setting"));
 	}
 
-	ConsoleBufferPushFormat(sText, TEXT("%s Break on Interrupt: %s")
+	ConsoleBufferPushFormat("%s Break on Interrupt: %s"
 		, sAction
 		, g_bDebugBreakOnInterrupt ? "Enabled" : "Disabled"
 	);
@@ -1426,7 +1418,7 @@ int _CmdBreakpointAddCommonArg ( int iArg, int nArg, BreakpointSource_t iSrc, Br
 
 	if (iBreakpoint >= MAX_BREAKPOINTS)
 	{
-		ConsoleDisplayError(TEXT("All Breakpoints slots are currently in use."));
+		ConsoleDisplayError("All Breakpoints slots are currently in use.");
 		return dArg;
 	}
 
@@ -1655,7 +1647,7 @@ void _BWZ_EnableDisableViaArgs( int nArgs, Breakpoint_t * aBreakWatchZero, const
 Update_t CmdBreakpointClear (int nArgs)
 {
 	if (!g_nBreakpoints)
-		return ConsoleDisplayError(TEXT("There are no breakpoints defined."));
+		return ConsoleDisplayError("There are no breakpoints defined.");
 
 	if (!nArgs)
 	{
@@ -1673,7 +1665,7 @@ Update_t CmdBreakpointClear (int nArgs)
 Update_t CmdBreakpointDisable (int nArgs)
 {
 	if (! g_nBreakpoints)
-		return ConsoleDisplayError(TEXT("There are no (PC) Breakpoints defined."));
+		return ConsoleDisplayError("There are no (PC) Breakpoints defined.");
 
 	if (! nArgs)
 		return Help_Arg_1( CMD_BREAKPOINT_DISABLE );
@@ -1694,7 +1686,7 @@ Update_t CmdBreakpointEdit (int nArgs)
 Update_t CmdBreakpointEnable (int nArgs) {
 
 	if (! g_nBreakpoints)
-		return ConsoleDisplayError(TEXT("There are no (PC) Breakpoints defined."));
+		return ConsoleDisplayError("There are no (PC) Breakpoints defined.");
 
 	if (! nArgs)
 		return Help_Arg_1( CMD_BREAKPOINT_ENABLE );
@@ -1707,7 +1699,6 @@ Update_t CmdBreakpointEnable (int nArgs) {
 
 void _BWZ_List( const Breakpoint_t * aBreakWatchZero, const int iBWZ ) //, bool bZeroBased )
 {
-	static       char sText[ CONSOLE_WIDTH ];
 	static const char sFlags[] = "-*";
 	static       char sName[ MAX_SYMBOLS_LEN+1 ];
 
@@ -1723,7 +1714,7 @@ void _BWZ_List( const Breakpoint_t * aBreakWatchZero, const int iBWZ ) //, bool 
 				: aBreakWatchZero[iBWZ].eSource == BP_SRC_MEM_WRITE_ONLY ? 'W'
 				: ' ';
 
-	ConsoleBufferPushFormat( sText, "  #%d %c %04X %c %s",
+	ConsoleBufferPushFormat( "  #%d %c %04X %c %s",
 //		(bZeroBased ? iBWZ + 1 : iBWZ),
 		iBWZ,
 		sFlags[ (int) aBreakWatchZero[ iBWZ ].bEnabled ],
@@ -1764,8 +1755,7 @@ Update_t CmdBreakpointList (int nArgs)
 
 	if (! g_nBreakpoints)
 	{
-		TCHAR sText[ CONSOLE_WIDTH ];
-		ConsoleBufferPushFormat( sText, TEXT("  There are no current breakpoints.  (Max: %d)"), MAX_BREAKPOINTS );
+		ConsoleBufferPushFormat( "  There are no current breakpoints.  (Max: %d)", MAX_BREAKPOINTS );
 	}
 	else
 	{	
@@ -1995,8 +1985,7 @@ static Update_t CmdGo (int nArgs, const bool bFullSpeed)
 		g_nDebugSkipLen &= _6502_MEM_END;			
 
 #if _DEBUG
-	TCHAR sText[ CONSOLE_WIDTH ];
-	ConsoleBufferPushFormat( sText, TEXT("Start: %04X,%04X  End: %04X  Len: %04X"),
+	ConsoleBufferPushFormat( "Start: %04X,%04X  End: %04X  Len: %04X",
 		g_nDebugSkipStart, g_nDebugSkipLen, nEnd, nLen );
 	ConsoleBufferToDisplay();
 #endif
@@ -2095,8 +2084,6 @@ Update_t CmdTrace (int nArgs)
 //===========================================================================
 Update_t CmdTraceFile (int nArgs)
 {
-	char sText[ CONSOLE_WIDTH ] = "";
-
 	if (g_hTraceFile)
 	{
 		fclose( g_hTraceFile );
@@ -2123,12 +2110,12 @@ Update_t CmdTraceFile (int nArgs)
 		{
 			const char* pTextHdr = g_bTraceFileWithVideoScanner ? "Trace (with video info) started: %s"
 																: "Trace started: %s";
-			ConsoleBufferPushFormat( sText, pTextHdr, sFilePath.c_str() );
+			ConsoleBufferPushFormat( pTextHdr, sFilePath.c_str() );
 			g_bTraceHeader = true;
 		}
 		else
 		{
-			ConsoleBufferPushFormat( sText, "Trace ERROR: %s", sFilePath.c_str() );
+			ConsoleBufferPushFormat( "Trace ERROR: %s", sFilePath.c_str() );
 		}
 	}
 
@@ -2257,8 +2244,7 @@ Update_t CmdOut (int nArgs)
 //===========================================================================
 Update_t CmdLBR(int nArgs)
 {
-	TCHAR sText[CONSOLE_WIDTH];
-	ConsolePrintFormat(sText, " LBR = $%04X", g_LBR);
+	ConsolePrintFormat(" LBR = $%04X", g_LBR);
 	return ConsoleUpdate();
 }
 
@@ -2270,8 +2256,7 @@ void _ColorPrint( int iColor, COLORREF nColor )
 	int G = (nColor >>  8) & 0xFF;
 	int B = (nColor >> 16) & 0xFF;
 
-	TCHAR sText[ CONSOLE_WIDTH ];
-	ConsoleBufferPushFormat( sText, " Color %01X: %02X %02X %02X", iColor, R, G, B ); // TODO: print name of colors!
+	ConsoleBufferPushFormat( " Color %01X: %02X %02X %02X", iColor, R, G, B ); // TODO: print name of colors!
 }
 
 void _CmdColorGet( const int iScheme, const int iColor )
@@ -2544,7 +2529,6 @@ Update_t CmdConfigSave (int nArgs)
 Update_t CmdConfigDisasm( int nArgs )
 {
 	int iParam = 0;
-	TCHAR sText[ CONSOLE_WIDTH ];
 
 	bool bDisplayCurrentSettings = false;
 
@@ -2584,7 +2568,7 @@ Update_t CmdConfigDisasm( int nArgs )
 					}
 					else // show current setting
 					{
-						ConsoleBufferPushFormat( sText, TEXT( "Branch Type: %d" ), g_iConfigDisasmBranchType );
+						ConsoleBufferPushFormat( "Branch Type: %d", g_iConfigDisasmBranchType );
 						ConsoleBufferToDisplay();
 					}
 					break;
@@ -2608,7 +2592,7 @@ Update_t CmdConfigDisasm( int nArgs )
 							,"Shift+Ctrl "      // 6
 							,"Shift+Ctarl+Alt " // 7
 						};
-						ConsoleBufferPushFormat( sText, TEXT( "Click: %d = %sLeft click" ), g_bConfigDisasmClick, aClickKey[ g_bConfigDisasmClick & 7 ] );
+						ConsoleBufferPushFormat( "Click: %d = %sLeft click", g_bConfigDisasmClick, aClickKey[ g_bConfigDisasmClick & 7 ] );
 						ConsoleBufferToDisplay();
 					}
 					break;
@@ -2622,7 +2606,7 @@ Update_t CmdConfigDisasm( int nArgs )
 					else // show current setting
 					{
 						int iState = g_bConfigDisasmAddressColon ? PARAM_ON : PARAM_OFF;
-						ConsoleBufferPushFormat( sText, TEXT( "Colon: %s" ), g_aParameters[ iState ].m_sName );
+						ConsoleBufferPushFormat( "Colon: %s", g_aParameters[ iState ].m_sName );
 						ConsoleBufferToDisplay();
 					}
 					break;
@@ -2636,7 +2620,7 @@ Update_t CmdConfigDisasm( int nArgs )
 					else
 					{
 						int iState = g_bConfigDisasmOpcodesView ? PARAM_ON : PARAM_OFF;
-						ConsoleBufferPushFormat( sText, TEXT( "Opcodes: %s" ), g_aParameters[ iState ].m_sName );
+						ConsoleBufferPushFormat( "Opcodes: %s", g_aParameters[ iState ].m_sName );
 						ConsoleBufferToDisplay();
 					}
 					break;
@@ -2650,7 +2634,7 @@ Update_t CmdConfigDisasm( int nArgs )
 					else
 					{
 						int iState = g_bConfigInfoTargetPointer ? PARAM_ON : PARAM_OFF;
-						ConsoleBufferPushFormat( sText, TEXT( "Info Target Pointer: %s" ), g_aParameters[ iState ].m_sName );
+						ConsoleBufferPushFormat( "Info Target Pointer: %s", g_aParameters[ iState ].m_sName );
 						ConsoleBufferToDisplay();
 					}
 					break;
@@ -2664,7 +2648,7 @@ Update_t CmdConfigDisasm( int nArgs )
 					else
 					{
 						int iState = g_bConfigDisasmOpcodeSpaces ? PARAM_ON : PARAM_OFF;
-						ConsoleBufferPushFormat( sText, TEXT( "Opcode spaces: %s" ), g_aParameters[ iState ].m_sName );
+						ConsoleBufferPushFormat( "Opcode spaces: %s", g_aParameters[ iState ].m_sName );
 						ConsoleBufferToDisplay();
 					}
 					break;
@@ -2681,7 +2665,7 @@ Update_t CmdConfigDisasm( int nArgs )
 					}
 					else // show current setting
 					{
-						ConsoleBufferPushFormat( sText, TEXT( "Target: %d" ), g_iConfigDisasmTargets );
+						ConsoleBufferPushFormat( "Target: %d", g_iConfigDisasmTargets );
 						ConsoleBufferToDisplay();
 					}
 					break;
@@ -3361,8 +3345,7 @@ Update_t CmdDisk ( int nArgs)
 		if (nArgs > 2)
 			return HelpLastCommand();
 
-		char buffer[200] = ""; // HACK: Magic number TODO: Should be MAX_CONSOLE_WIDTH*2
-		ConsoleBufferPushFormat(buffer, "FW%2d: D%d at T$%s, phase $%s, offset $%X, mask $%02X, extraCycles %.2f, %s",
+		ConsoleBufferPushFormat("FW%2d: D%d at T$%s, phase $%s, offset $%X, mask $%02X, extraCycles %.2f, %s",
 			diskCard.GetCurrentFirmware(),
 			diskCard.GetCurrentDrive() + 1,
 			diskCard.GetCurrentTrackString().c_str(),
@@ -3557,9 +3540,7 @@ bool _MemoryCheckMiniDump ( int iWhich )
 {
 	if ((iWhich < 0) || (iWhich > NUM_MEM_MINI_DUMPS))
 	{
-		TCHAR sText[ CONSOLE_WIDTH ];
-		wsprintf( sText, TEXT("  Only %d memory mini dumps"), NUM_MEM_MINI_DUMPS );
-		ConsoleDisplayError( sText );
+		ConsoleDisplayErrorFormat( "  Only %d memory mini dumps", NUM_MEM_MINI_DUMPS );
 		return true;
 	}
 	return false;
@@ -3750,9 +3731,8 @@ Update_t CmdConfigGetDebugDir (int nArgs)
 	if( nArgs != 0 )
 		return Help_Arg_1( CMD_CONFIG_GET_DEBUG_DIR );
 
-	TCHAR sPath[ MAX_PATH + 8 ];
 	// TODO: debugger dir has no ` CONSOLE_COLOR_ESCAPE_CHAR ?!?!
-	ConsoleBufferPushFormat( sPath, "Path: %s", g_sCurrentDir.c_str() );
+	ConsoleBufferPushFormat( "Path: %s", g_sCurrentDir.c_str() );
 
 	return ConsoleUpdate();
 }
@@ -3977,8 +3957,7 @@ Update_t CmdMemoryLoad (int nArgs)
 
 			CmdConfigGetDebugDir( 0 );
 
-			TCHAR sFile[ MAX_PATH + 8 ];
-			ConsoleBufferPushFormat( sFile, "File: %s", g_sMemoryLoadSaveFileName );
+			ConsoleBufferPushFormat( "File: %s", g_sMemoryLoadSaveFileName );
 		}
 		
 		delete [] pMemory;
@@ -4158,12 +4137,11 @@ Update_t CmdMemoryLoad (int nArgs)
 		size_t nRead = fread( pMemBankBase+nAddressStart, nAddressLen, 1, hFile );
 		if (nRead == 1)
 		{
-			char text[ 128 ];
-			ConsoleBufferPushFormat( text, "Loaded @ A$%04X,L$%04X", nAddressStart, nAddressLen );
+			ConsoleBufferPushFormat( "Loaded @ A$%04X,L$%04X", nAddressStart, nAddressLen );
 		}
 		else
 		{
-			ConsoleBufferPush( TEXT( "Error loading data." ) );
+			ConsoleBufferPush( "Error loading data." );
 		}
 		fclose( hFile );
 
@@ -4181,12 +4159,11 @@ Update_t CmdMemoryLoad (int nArgs)
 	}
 	else
 	{
-		ConsoleBufferPush( TEXT( "ERROR: Bad filename" ) );
+		ConsoleBufferPush( "ERROR: Bad filename" );
 
 		CmdConfigGetDebugDir( 0 );
 
-		TCHAR sFile[ MAX_PATH + 8 ];
-		ConsoleBufferPushFormat( sFile, "File: ", g_sMemoryLoadSaveFileName.c_str() );
+		ConsoleBufferPushFormat( "File: ", g_sMemoryLoadSaveFileName.c_str() );
 	}
 	
 	return ConsoleUpdate();
@@ -4261,15 +4238,14 @@ Update_t CmdMemorySave (int nArgs)
 
 	if (! nArgs)
 	{
-		TCHAR sLast[ CONSOLE_WIDTH ] = TEXT("");
 		if (nAddressLen)
 		{
-			ConsoleBufferPushFormat( sLast, TEXT("Last saved: $%04X:$%04X, %04X"),
+			ConsoleBufferPushFormat( "Last saved: $%04X:$%04X, %04X",
 				nAddressStart, nAddressEnd, nAddressLen );
 		}
 		else
 		{
-			ConsoleBufferPush( sLast, TEXT( "Last saved: none" ) );
+			ConsoleBufferPush( "Last saved: none" );
 		}				
 	}
 	else
@@ -4389,14 +4365,13 @@ Update_t CmdMemorySave (int nArgs)
 
 	if (! nArgs)
 	{
-		TCHAR sLast[ CONSOLE_WIDTH ] = TEXT("");
 		if (nAddressLen)
 		{
 			if (!bBankSpecified)
-				ConsoleBufferPushFormat( sLast, TEXT("Last saved: $%04X:$%04X, %04X"),
+				ConsoleBufferPushFormat( "Last saved: $%04X:$%04X, %04X",
 					nAddressStart, nAddressEnd, nAddressLen );
 			else
-				ConsoleBufferPushFormat( sLast, TEXT("Last saved: Bank=%02X $%04X:$%04X, %04X"),
+				ConsoleBufferPushFormat( "Last saved: Bank=%02X $%04X:$%04X, %04X",
 					nBank, nAddressStart, nAddressEnd, nAddressLen );
 		}
 		else
@@ -4740,30 +4715,29 @@ Update_t CmdNTSC (int nArgs)
 		public:
 			static void update( const char *pPrefixText )
 			{
-					char text[ CONSOLE_WIDTH*2 ] = "";
+				size_t len1 = strlen( pPrefixText      );
+				size_t len2 = sPaletteFilePath.size();
+				size_t len  = len1 + len2;
 
-					size_t len1 = strlen( pPrefixText      );
-					size_t len2 = sPaletteFilePath.size();
-					size_t len  = len1 + len2;
-
-					if (len >= CONSOLE_WIDTH)
-					{
-						ConsoleBufferPush( pPrefixText );	// TODO: Add a ": " separator
+				if (len >= CONSOLE_WIDTH)
+				{
+					ConsoleBufferPush( pPrefixText );	// TODO: Add a ": " separator
 
 #if _DEBUG
-						LogOutput( "Filename.length.1: %d\n", len1 );
-						LogOutput( "Filename.length.2: %d\n", len2 );
-						OutputDebugString( sPaletteFilePath.c_str() );
+					LogOutput( "Filename.length.1: %d\n", len1 );
+					LogOutput( "Filename.length.2: %d\n", len2 );
+					OutputDebugString( sPaletteFilePath.c_str() );
 #endif
-						// File path is too long
-						// TODO: Need to split very long path names
-						strncpy( text, sPaletteFilePath.c_str(), CONSOLE_WIDTH );
-						ConsoleBufferPush( text );	// TODO: Switch ConsoleBufferPush() to ConsoleBufferPushFormat()
-					}
-					else
-					{
-						ConsoleBufferPushFormat( text, "%s: %s", pPrefixText, sPaletteFilePath.c_str() );
-					}
+					// File path is too long
+					// TODO: Need to split very long path names
+					char text[CONSOLE_WIDTH * 2] = "";
+					strncpy( text, sPaletteFilePath.c_str(), CONSOLE_WIDTH );
+					ConsoleBufferPush( text );	// TODO: Switch ConsoleBufferPush() to ConsoleBufferPushFormat()
+				}
+				else
+				{
+					ConsoleBufferPushFormat( "%s: %s", pPrefixText, sPaletteFilePath.c_str() );
+				}
 			}
 	};
 
@@ -5317,7 +5291,7 @@ int CmdTextSave (int nArgs)
 	FILE *hFile = fopen( sLoadSaveFilePath.c_str(), "rb" );
 	if (hFile)
 	{
-		ConsoleBufferPush( TEXT( "Warning: File already exists.  Overwriting." ) );
+		ConsoleBufferPush( "Warning: File already exists.  Overwriting." );
 		fclose( hFile );
 	}
 
@@ -5327,18 +5301,17 @@ int CmdTextSave (int nArgs)
 		size_t nWrote = fwrite( pText, nSize, 1, hFile );
 		if (nWrote == 1)
 		{
-			TCHAR text[ CONSOLE_WIDTH ] = TEXT("");
-			ConsoleBufferPushFormat( text, "Saved: %s", g_sMemoryLoadSaveFileName.c_str() );
+			ConsoleBufferPushFormat( "Saved: %s", g_sMemoryLoadSaveFileName.c_str() );
 		}
 		else
 		{
-			ConsoleBufferPush( TEXT( "Error saving." ) );
+			ConsoleBufferPush( "Error saving." );
 		}
 		fclose( hFile );
 	}
 	else
 	{
-		ConsoleBufferPush( TEXT( "Error opening file." ) );
+		ConsoleBufferPush( "Error opening file." );
 	}
 
 	return ConsoleUpdate();
@@ -5506,8 +5479,7 @@ Update_t _SearchMemoryDisplay (int nArgs)
 		ConsolePrint( sMatches );
 	}
 
-//	wsprintf( sMatches, "Total: %d  (#$%04X)", nFound, nFound );
-//	ConsoleDisplayPush( sMatches );
+//	ConsoleDisplayPushFormat( "Total: %d  (#$%04X)", nFound, nFound );
 		sResult[0] = 0;
 
 		        StringCat( sResult, CHC_USAGE , nBuf );
@@ -5555,7 +5527,7 @@ Update_t _CmdMemorySearch (int nArgs, bool bTextIsAscii = true )
 
 //	if (eRange == RANGE_MISSING_ARG_2)
 	if (! Range_CalcEndLen( eRange, nAddressStart, nAddress2, nAddressEnd, nAddressLen))
-		return ConsoleDisplayError( TEXT("Error: Missing address seperator (comma or colon)" ) );
+		return ConsoleDisplayError( "Error: Missing address seperator (comma or colon)" );
 
 	int iArgFirstByte = 4;
 	int iArg;
@@ -6027,7 +5999,7 @@ Update_t CmdOutputPrintf (int nArgs)
 					case PS_TYPE:
 						if (iValue >= nParamValues)
 						{
-							ConsoleBufferPushFormat( sText, TEXT("Error: Missing value arg: %d"), iValue + 1 );
+							ConsoleBufferPushFormat( "Error: Missing value arg: %d", iValue + 1 );
 							return ConsoleUpdate();
 						}
 						switch( c )
@@ -6155,9 +6127,8 @@ Update_t CmdOutputRun (int nArgs)
 	}
 	else
 	{
-		char sText[ CONSOLE_WIDTH ];
-		ConsolePrintFormat(sText, "%sCouldn't load filename:", CHC_ERROR);
-		ConsolePrintFormat(sText, "%s%s", CHC_STRING, sFileName.c_str());
+		ConsolePrintFormat("%sCouldn't load filename:", CHC_ERROR);
+		ConsolePrintFormat("%s%s", CHC_STRING, sFileName.c_str());
 	}
 
 	return ConsoleUpdate();
@@ -6401,27 +6372,25 @@ Update_t CmdSource (int nArgs)
 				const int MAX_MINI_FILENAME = 20; 
 				const std::string sMiniFileName = sFileName.substr(0, MIN(MAX_MINI_FILENAME, sFileName.size()));
 
-				TCHAR buffer[MAX_PATH] = { 0 };
-
 				if (BufferAssemblyListing( sFileName ))
 				{
 					g_aSourceFileName = pFileName;
 
 					if (! ParseAssemblyListing( g_bSourceAddMemory, g_bSourceAddSymbols ))
 					{
-						ConsoleBufferPushFormat( buffer, "Couldn't load filename: %s", sMiniFileName.c_str() );
+						ConsoleBufferPushFormat( "Couldn't load filename: %s", sMiniFileName.c_str() );
 					}
 					else
 					{
 						if (g_nSourceAssembleBytes)
 						{
-							ConsoleBufferPushFormat( buffer, "  Read: %d lines, %d symbols, %d bytes"
+							ConsoleBufferPushFormat( "  Read: %d lines, %d symbols, %d bytes"
 								, g_AssemblerSourceBuffer.GetNumLines() // g_nSourceAssemblyLines
 								, g_nSourceAssemblySymbols, g_nSourceAssembleBytes );
 						}
 						else
 						{
-							ConsoleBufferPushFormat( buffer, "  Read: %d lines, %d symbols"
+							ConsoleBufferPushFormat( "  Read: %d lines, %d symbols"
 								, g_AssemblerSourceBuffer.GetNumLines() // g_nSourceAssemblyLines
 								, g_nSourceAssemblySymbols );
 						}
@@ -6429,7 +6398,7 @@ Update_t CmdSource (int nArgs)
 				}
 				else
 				{
-					ConsoleBufferPushFormat( buffer, "Error reading: %s", sMiniFileName.c_str() );
+					ConsoleBufferPushFormat( "Error reading: %s", sMiniFileName.c_str() );
 				}
 			}
 		}
@@ -6490,8 +6459,7 @@ Update_t CmdVideoScannerInfo(int nArgs)
 			return Help_Arg_1(CMD_VIDEO_SCANNER_INFO);
 	}
 
-	TCHAR sText[CONSOLE_WIDTH];
-	ConsoleBufferPushFormat(sText, "Video-scanner display updated: %s", g_aArgs[1].sArg);
+	ConsoleBufferPushFormat("Video-scanner display updated: %s", g_aArgs[1].sArg);
 	ConsoleBufferToDisplay();
 
 	return UPDATE_ALL;
@@ -6520,8 +6488,7 @@ Update_t CmdCyclesInfo(int nArgs)
 			CmdCyclesReset(0);
 	}
 
-	TCHAR sText[CONSOLE_WIDTH];
-	ConsoleBufferPushFormat(sText, "Cycles display updated: %s", g_aArgs[1].sArg);
+	ConsoleBufferPushFormat("Cycles display updated: %s", g_aArgs[1].sArg);
 	ConsoleBufferToDisplay();
 
 	return UPDATE_ALL;
@@ -6706,7 +6673,7 @@ Update_t CmdWatchAdd (int nArgs)
 
 		// Make sure address isn't an IO address
 		if ((nAddress >= _6502_IO_BEGIN) && (nAddress <= _6502_IO_END))
-			return ConsoleDisplayError(TEXT("You may not watch an I/O location."));
+			return ConsoleDisplayError("You may not watch an I/O location.");
 
 		if (iWatch == NO_6502_TARGET)
 		{
@@ -6719,9 +6686,7 @@ Update_t CmdWatchAdd (int nArgs)
 
 		if ((iWatch >= MAX_WATCHES) && !bAdded)
 		{
-			char sText[ CONSOLE_WIDTH ];
-			sprintf( sText, "All watches are currently in use.  (Max: %d)", MAX_WATCHES );
-			ConsoleDisplayPush( sText );
+			ConsoleDisplayPushFormat( "All watches are currently in use.  (Max: %d)", MAX_WATCHES );
 			return ConsoleUpdate();
 		}
 
@@ -6749,7 +6714,7 @@ _Help:
 Update_t CmdWatchClear (int nArgs)
 {
 	if (!g_nWatches)
-		return ConsoleDisplayError(TEXT("There are no watches defined."));
+		return ConsoleDisplayError("There are no watches defined.");
 
 	if (!nArgs)
 		return Help_Arg_1( CMD_WATCH_CLEAR );	
@@ -6769,7 +6734,7 @@ Update_t CmdWatchClear (int nArgs)
 Update_t CmdWatchDisable (int nArgs)
 {
 	if (! g_nWatches)
-		return ConsoleDisplayError(TEXT("There are no watches defined."));
+		return ConsoleDisplayError("There are no watches defined.");
 
 	if (!nArgs)
 		return Help_Arg_1( CMD_WATCH_DISABLE );
@@ -6783,7 +6748,7 @@ Update_t CmdWatchDisable (int nArgs)
 Update_t CmdWatchEnable (int nArgs)
 {
 	if (! g_nWatches)
-		return ConsoleDisplayError(TEXT("There are no watches defined."));
+		return ConsoleDisplayError("There are no watches defined.");
 
 	if (!nArgs)
 		return Help_Arg_1( CMD_WATCH_ENABLE );
@@ -6798,8 +6763,7 @@ Update_t CmdWatchList (int nArgs)
 {
 	if (! g_nWatches)
 	{
-		TCHAR sText[ CONSOLE_WIDTH ];
-		ConsoleBufferPushFormat( sText, TEXT("  There are no current watches.  (Max: %d)"), MAX_WATCHES );
+		ConsoleBufferPushFormat( "  There are no current watches.  (Max: %d)", MAX_WATCHES );
 	}
 	else
 	{
@@ -7242,9 +7206,7 @@ Update_t CmdZeroPageAdd     (int nArgs)
 
 		if ((iZP >= MAX_ZEROPAGE_POINTERS) && !bAdded)
 		{
-			char sText[ CONSOLE_WIDTH ];
-			sprintf( sText, "All zero page pointers are currently in use.  (Max: %d)", MAX_ZEROPAGE_POINTERS );
-			ConsoleDisplayPush( sText );
+			ConsoleDisplayPushFormat( "All zero page pointers are currently in use.  (Max: %d)", MAX_ZEROPAGE_POINTERS );
 			return ConsoleUpdate();
 		}
 		
@@ -7272,10 +7234,8 @@ _Help:
 Update_t _ZeroPage_Error()
 {
 //	return ConsoleDisplayError( "There are no (ZP) pointers defined." );
-	char sText[ CONSOLE_WIDTH ];
-	sprintf( sText, "  There are no current (ZP) pointers.  (Max: %d)", MAX_ZEROPAGE_POINTERS );
-//	ConsoleBufferPush( sText );
-	return ConsoleDisplayError( sText );
+//	ConsoleBufferPushFormat( "  There are no current (ZP) pointers.  (Max: %d)", MAX_ZEROPAGE_POINTERS );
+	return ConsoleDisplayErrorFormat( "  There are no current (ZP) pointers.  (Max: %d)", MAX_ZEROPAGE_POINTERS );
 }
 
 //===========================================================================
@@ -7519,8 +7479,7 @@ int FindCommand( LPCTSTR pName, CmdFuncPtr_t & pFunction_, int * iCommand_ )
 //===========================================================================
 void DisplayAmbigiousCommands( int nFound )
 {
-	char sText[ CONSOLE_WIDTH * 2 ];
-	ConsolePrintFormat( sText, "Ambiguous %s%d%s Commands:"
+	ConsolePrintFormat("Ambiguous %s%d%s Commands:"
 		, CHC_NUM_DEC
 		, g_vPotentialCommands.size()
 		, CHC_DEFAULT
@@ -7542,6 +7501,7 @@ void DisplayAmbigiousCommands( int nFound )
 			if ((iWidth + nLen) >= (CONSOLE_WIDTH - 1))
 				break;
 				
+			char sText[ CONSOLE_WIDTH * 2 ];
 			sprintf( sText, "%s ", pName );
 			strcat( sPotentialCommands, sText );
 			iWidth += nLen + 1;
@@ -7707,9 +7667,8 @@ Update_t ExecuteCommand (int nArgs)
 
 						if( bFoundSrc && bFoundLen )
 						{
-//ArgsGetValue( pArg, & nAddress );
-//char sText[ CONSOLE_WIDTH ];
-//ConsolePrintFormat( sText, "Dst:%s  Src: %s  End: %s", pDst, pSrc, pEnd );
+							//ArgsGetValue( pArg, & nAddress );
+							//ConsolePrintFormat( "Dst:%s  Src: %s  End: %s", pDst, pSrc, pEnd );
 							g_iCommand = CMD_MEMORY_MOVE;
 							pFunction = g_aCommands[ g_iCommand ].pFunction;
 
@@ -8461,7 +8420,6 @@ void DebugContinueStepping(const bool bCallerWillUpdateDisplay/*=false*/)
 
 		if (regs.pc == g_nDebugStepUntil || g_bDebugBreakpointHit)
 		{
-			TCHAR sText[ CONSOLE_WIDTH ];
 			char szStopMessage[CONSOLE_WIDTH];
 			const char* pszStopReason = szStopMessage;
 
@@ -8490,7 +8448,7 @@ void DebugContinueStepping(const bool bCallerWillUpdateDisplay/*=false*/)
 			else
 				pszStopReason = TEXT("Unknown!");
 
-			ConsoleBufferPushFormat( sText, TEXT("Stop reason: %s"), pszStopReason );
+			ConsoleBufferPushFormat( "Stop reason: %s", pszStopReason );
 			ConsoleUpdate();
 
 			g_nDebugSteps = 0;
@@ -8706,7 +8664,6 @@ void DebugInitialize ()
 #endif
 
 	//	ConsoleInputReset(); already called in DebugInitialize()
-	TCHAR sText[ CONSOLE_WIDTH ];
 
 	VerifyDebuggerCommandTable();
 
@@ -8719,8 +8676,7 @@ void DebugInitialize ()
 			int nLen = _tcslen( pHelp ) + 2;
 			if (nLen > (CONSOLE_WIDTH-1))
 			{
-				ConsoleBufferPushFormat( sText, TEXT("Warning: %s help is %d chars"),
-					pHelp, nLen );
+				ConsoleBufferPushFormat( "Warning: %s help is %d chars", pHelp, nLen );
 			}
 		}
 	}
@@ -8819,8 +8775,6 @@ Update_t DebuggerProcessCommand ( const bool bEchoConsoleInput )
 {
 	Update_t bUpdateDisplay = UPDATE_NOTHING;
 
-	char sText[ CONSOLE_WIDTH ];
-
 	if (bEchoConsoleInput)
 		ConsoleDisplayPush( ConsoleInputPeek() );
 
@@ -8838,8 +8792,7 @@ Update_t DebuggerProcessCommand ( const bool bEchoConsoleInput )
 			int nDelayedTargets = AssemblerDelayedTargetsSize();
 			if (nDelayedTargets)
 			{
-				sprintf( sText, " Asm: %d sym declared, not defined", nDelayedTargets );
-				ConsoleDisplayPush( sText );
+				ConsoleDisplayPushFormat( " Asm: %d sym declared, not defined", nDelayedTargets );
 				bUpdateDisplay |= UPDATE_CONSOLE_DISPLAY;
 			}
 		}
@@ -8856,8 +8809,7 @@ Update_t DebuggerProcessCommand ( const bool bEchoConsoleInput )
 		int nArgs = ParseInput( g_pConsoleInput );
 		if (nArgs == ARG_SYNTAX_ERROR)
 		{
-			sprintf( sText, "Syntax error: %s", g_aArgs[0].sArg );
-			bUpdateDisplay |= ConsoleDisplayError( sText );
+			bUpdateDisplay |= ConsoleDisplayErrorFormat( "Syntax error: %s", g_aArgs[0].sArg );
 		}
 		else
 		{

--- a/source/Debugger/Debugger_Assembler.cpp
+++ b/source/Debugger/Debugger_Assembler.cpp
@@ -876,8 +876,7 @@ Hash_t AssemblerHashMnemonic ( const TCHAR * pMnemonic )
 	static int nMaxLen = 0;
 	if (nMaxLen < nLen) {
 		nMaxLen = nLen;
-		char sText[CONSOLE_WIDTH * 3];
-		ConsolePrintFormat( sText, "New Max Len: %d  %s", nMaxLen, pMnemonic );
+		ConsolePrintFormat( "New Max Len: %d  %s", nMaxLen, pMnemonic );
 	}
 #endif
 
@@ -912,8 +911,7 @@ void AssemblerHashOpcodes ()
 		g_aOpcodesHash[ iOpcode ] = nMnemonicHash;
 #if DEBUG_ASSEMBLER
 		//OutputDebugString( "" );
-		char sText[ 128 ];
-		ConsolePrintFormat( sText, "%s : %08X  ", pMnemonic, nMnemonicHash );
+		ConsolePrintFormat( "%s : %08X  ", pMnemonic, nMnemonicHash );
 		// CLC: 002B864
 #endif
 	}
@@ -949,7 +947,6 @@ void _CmdAssembleHashDump ()
 // #if DEBUG_ASM_HASH
 	std::vector<HashOpcode_t> vHashes;
 	HashOpcode_t         tHash;
-	TCHAR                sText[ CONSOLE_WIDTH ];
 
 	int iOpcode;
 	for( iOpcode = 0; iOpcode < NUM_OPCODES; iOpcode++ )
@@ -972,7 +969,7 @@ void _CmdAssembleHashDump ()
 		int    nOpcode   = tHash.m_iOpcode;
 		int    nOpmode   = g_aOpcodes[ nOpcode ].nAddressMode;
 
-		ConsoleBufferPushFormat( sText, "%08X %02X %s %s"
+		ConsoleBufferPushFormat( "%08X %02X %s %s"
 			, iThisHash
 			, nOpcode
 			, g_aOpcodes65C02[ nOpcode ].sMnemonic
@@ -982,7 +979,7 @@ void _CmdAssembleHashDump ()
 		
 //		if (nPrevHash != iThisHash)
 //		{
-//			ConsoleBufferPushFormat( sText, "Total: %d", nThisHash );
+//			ConsoleBufferPushFormat( "Total: %d", nThisHash );
 //			nThisHash = 0;
 //		}
 	}
@@ -1000,7 +997,7 @@ int AssemblerPokeAddress( const int Opcode, const int nOpmode, const WORD nBaseA
 	int nOpbytes = g_aOpmodes[ nOpmode ].m_nBytes;
 
 	// if (nOpbytes != nBytes)
-	//	ConsoleDisplayError( TEXT(" ERROR: Input Opcode bytes differs from actual!" ) );
+	//	ConsoleDisplayError( " ERROR: Input Opcode bytes differs from actual!" );
 
 	*(memdirty + (nBaseAddress >> 8)) |= 1;
 //	*(mem + nBaseAddress) = (BYTE) nOpcode;
@@ -1477,8 +1474,7 @@ bool Assemble( int iArg, int nArgs, WORD nAddress )
 	Hash_t nMnemonicHash = AssemblerHashMnemonic( pMnemonic );
 
 #if DEBUG_ASSEMBLER
-	char sText[ CONSOLE_WIDTH * 2 ];
-	ConsolePrintFormat( sText, "%s%04X%s: %s%s%s -> %s%08X", 
+	ConsolePrintFormat( "%s%04X%s: %s%s%s -> %s%08X", 
 		CHC_ADDRESS, nAddress,
 		CHC_DEFAULT,
 		CHC_STRING, pMnemonic,

--- a/source/Debugger/Debugger_Console.cpp
+++ b/source/Debugger/Debugger_Console.cpp
@@ -29,6 +29,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "StdAfx.h"
 
 #include "Debug.h"
+#include "StrFormat.h"
 
 // Console ________________________________________________________________________________________
 
@@ -114,7 +115,7 @@ const conchar_t* ConsoleBufferPeek ()
 
 
 //===========================================================================
-bool ConsolePrint ( const char * pText )
+void ConsolePrint ( const char * pText )
 {
 	while (g_nConsoleBuffer >= CONSOLE_BUFFER_HEIGHT)
 	{
@@ -258,26 +259,12 @@ bool ConsolePrint ( const char * pText )
 	}
 	*pDst = 0;
 	g_nConsoleBuffer++;
-
-	return true;
-}
-
-bool ConsolePrintVa ( char* buf, size_t bufsz, const char * pFormat, va_list va )
-{
-	vsnprintf_s(buf, bufsz, _TRUNCATE, pFormat, va);
-	return ConsolePrint(buf);
-}
-
-bool ConsoleBufferPushVa ( char* buf, size_t bufsz, const char * pFormat, va_list va )
-{
-	vsnprintf_s(buf, bufsz, _TRUNCATE, pFormat, va);
-	return ConsoleBufferPush(buf);
 }
 
 // Add string to buffered output
 // Shifts the buffered console output lines "Up"
 //===========================================================================
-bool ConsoleBufferPush ( const char * pText )
+void ConsoleBufferPush ( const char * pText )
 {
 	while (g_nConsoleBuffer >= CONSOLE_BUFFER_HEIGHT)
 	{
@@ -318,8 +305,6 @@ bool ConsoleBufferPush ( const char * pText )
 	}
 	*pDst = 0;
 	g_nConsoleBuffer++;
-
-	return true;
 }
 
 // Shifts the buffered console output "down"
@@ -366,7 +351,7 @@ void ConsoleConvertFromText ( conchar_t * sText, const char * pText )
 }
 
 //===========================================================================
-Update_t ConsoleDisplayError ( const char * pText)
+Update_t ConsoleDisplayError ( const char * pText )
 {
 	ConsoleBufferPush( pText );
 	return ConsoleUpdate();
@@ -473,7 +458,7 @@ bool ConsoleInputClear ()
 }
 
 //===========================================================================
-bool ConsoleInputChar ( const char ch )
+bool ConsoleInputChar ( char ch )
 {
 	if (g_nConsoleInputChars < g_nConsoleDisplayWidth) // bug? include prompt?
 	{

--- a/source/Debugger/Debugger_Console.h
+++ b/source/Debugger/Debugger_Console.h
@@ -3,6 +3,8 @@
 
 #include <cstdarg>
 
+#include "StrFormat.h"
+
 	enum
 	{
 		// Basic Symbol table has > 600 symbols
@@ -255,76 +257,78 @@
 // Console
 
 	// Buffered
-	bool ConsolePrint( const char * pText );
-	bool ConsolePrintVa( char* buf, size_t bufsz, const char* pFormat, va_list va );
-	template<size_t _BufSz>
-	inline bool ConsolePrintVa( char (&buf)[_BufSz], const char* pFormat, va_list va )
+	void ConsolePrint( const char * pText );
+	inline void ConsolePrintVa( const char* pFormat, va_list va )
 	{
-		return ConsolePrintVa(buf, _BufSz, pFormat, va);
+		std::string strText = StrFormatV(pFormat, va);
+		ConsolePrint(strText.c_str());
 	}
-	inline bool ConsolePrintFormat( char* buf, size_t bufsz, const char* pFormat, ... )
+	inline void ConsolePrintFormat( const char* pFormat, ... ) ATTRIBUTE_FORMAT_PRINTF(1, 2)
 	{
 		va_list va;
 		va_start(va, pFormat);
-		bool const r = ConsolePrintVa(buf, bufsz, pFormat, va);
+		ConsolePrintVa(pFormat, va);
 		va_end(va);
-		return r;
-	}
-	template<size_t _BufSz>
-	inline bool ConsolePrintFormat( char(&buf)[_BufSz], const char* pFormat, ... )
-	{
-		va_list va;
-		va_start(va, pFormat);
-		bool const r = ConsolePrintVa(buf, pFormat, va);
-		va_end(va);
-		return r;
 	}
 
-	void     ConsoleBufferToDisplay ();
-	const conchar_t* ConsoleBufferPeek ();
-	void     ConsoleBufferPop ();
+	void ConsoleBufferToDisplay();
+	const conchar_t* ConsoleBufferPeek();
+	void ConsoleBufferPop();
 
-	bool ConsoleBufferPush( const char * pString );
-	bool ConsoleBufferPushVa( char* buf, size_t bufsz, const char* pFormat, va_list va );
-	template<size_t _BufSz>
-	inline bool ConsoleBufferPushVa( char (&buf)[_BufSz], const char* pFormat, va_list va )
+	void ConsoleBufferPush( const char * pString );
+	inline void ConsoleBufferPushVa( const char* pFormat, va_list va )
 	{
-		return ConsoleBufferPushVa(buf, _BufSz, pFormat, va);
+		std::string strText = StrFormatV(pFormat, va);
+		ConsoleBufferPush(strText.c_str());
 	}
-	inline bool ConsoleBufferPushFormat( char* buf, size_t bufsz, const char* pFormat, ... )
+	inline void ConsoleBufferPushFormat( const char* pFormat, ... ) ATTRIBUTE_FORMAT_PRINTF(1, 2)
 	{
 		va_list va;
 		va_start(va, pFormat);
-		bool const r = ConsoleBufferPushVa(buf, bufsz, pFormat, va);
+		ConsoleBufferPushVa(pFormat, va);
 		va_end(va);
-		return r;
-	}
-	template<size_t _BufSz>
-	inline bool ConsoleBufferPushFormat( char(&buf)[_BufSz], const char* pFormat, ... )
-	{
-		va_list va;
-		va_start(va, pFormat);
-		bool const r = ConsoleBufferPushVa(buf, pFormat, va);
-		va_end(va);
-		return r;
 	}
 
 	void ConsoleConvertFromText( conchar_t * sText, const char * pText );
 
 	// Display
-	Update_t ConsoleDisplayError ( const char * pTextError );
-	void     ConsoleDisplayPause ();
-	void     ConsoleDisplayPush  ( const char * pText );
+	Update_t ConsoleDisplayError( const char * pTextError );
+	inline Update_t ConsoleDisplayErrorVa(const char* pFormat, va_list va)
+	{
+		std::string strText = StrFormatV(pFormat, va);
+		return ConsoleDisplayError(strText.c_str());
+	}
+	inline Update_t ConsoleDisplayErrorFormat(const char* pFormat, ...) ATTRIBUTE_FORMAT_PRINTF(1, 2)
+	{
+		va_list va;
+		va_start(va, pFormat);
+		Update_t const r = ConsoleDisplayErrorVa(pFormat, va);
+		va_end(va);
+		return r;
+	}
+	void ConsoleDisplayPause();
+	void ConsoleDisplayPush( const char * pText );
+	inline void ConsoleDisplayPushVa(const char* pFormat, va_list va)
+	{
+		std::string strText = StrFormatV(pFormat, va);
+		ConsoleDisplayPush(strText.c_str());
+	}
+	inline void ConsoleDisplayPushFormat(const char* pFormat, ...) ATTRIBUTE_FORMAT_PRINTF(1, 2)
+	{
+		va_list va;
+		va_start(va, pFormat);
+		ConsoleDisplayPushVa(pFormat, va);
+		va_end(va);
+	}
 	void     ConsoleDisplayPush  ( const conchar_t * pText );
 	Update_t ConsoleUpdate       ();
 	void     ConsoleFlush        ();
 
 	// Input
-	void     ConsoleInputToDisplay ();
 	const char *ConsoleInputPeek      ();
 	bool     ConsoleInputClear     ();
 	bool     ConsoleInputBackSpace ();
-	bool     ConsoleInputChar      ( TCHAR ch );
+	bool     ConsoleInputChar      ( char ch );
 	void     ConsoleInputReset     ();
 	int      ConsoleInputTabCompletion ();
 

--- a/source/Debugger/Debugger_DisassemblerData.cpp
+++ b/source/Debugger/Debugger_DisassemblerData.cpp
@@ -348,10 +348,9 @@ Update_t CmdDisasmDataList (int nArgs)
 		{
 			int nLen = strlen( pData->sSymbol );
 
-			char sText[CONSOLE_WIDTH * 2];
 			// <smbol> <type> <start>:<end>
 			// `TEST `300`:`320
-			ConsolePrintFormat( sText, "%s%s %s%*s %s%04X%s:%s%04X"
+			ConsolePrintFormat( "%s%s %s%*s %s%04X%s:%s%04X"
 				, CHC_CATEGORY
 				, g_aNopcodeTypes[ pData->eElementType ] 
 				, (nLen > 0) ? CHC_SYMBOL     : CHC_DEFAULT

--- a/source/Debugger/Debugger_Help.cpp
+++ b/source/Debugger/Debugger_Help.cpp
@@ -141,75 +141,74 @@ void Help_Categories()
 	char sText[ nBuf ] = "";
 	int  nLen = 0;
 
-		// TODO/FIXME: Colorize( sText, ... )
-		// Colorize("Usage:")
-		nLen += StringCat( sText, CHC_USAGE , nBuf );
-		nLen += StringCat( sText, "Usage", nBuf );
+	// TODO/FIXME: Colorize( sText, ... )
+	// Colorize("Usage:")
+	nLen += StringCat( sText, CHC_USAGE , nBuf );
+	nLen += StringCat( sText, "Usage", nBuf );
 
-		nLen += StringCat( sText, CHC_DEFAULT, nBuf );
-		nLen += StringCat( sText, ": " , nBuf );
+	nLen += StringCat( sText, CHC_DEFAULT, nBuf );
+	nLen += StringCat( sText, ": " , nBuf );
 
-		nLen += StringCat( sText, CHC_ARG_OPT, nBuf );
-		nLen += StringCat( sText, "[ ", nBuf );
+	nLen += StringCat( sText, CHC_ARG_OPT, nBuf );
+	nLen += StringCat( sText, "[ ", nBuf );
 
-		nLen += StringCat( sText, CHC_ARG_MAND, nBuf );
-		nLen += StringCat( sText, "< ", nBuf );
+	nLen += StringCat( sText, CHC_ARG_MAND, nBuf );
+	nLen += StringCat( sText, "< ", nBuf );
 
+	for (int iCategory = _PARAM_HELPCATEGORIES_BEGIN ; iCategory < _PARAM_HELPCATEGORIES_END; iCategory++)
+	{
+		char *pName = g_aParameters[ iCategory ].m_sName;
 
-		for (int iCategory = _PARAM_HELPCATEGORIES_BEGIN ; iCategory < _PARAM_HELPCATEGORIES_END; iCategory++)
+		if (nLen + strlen( pName ) >= (CONSOLE_WIDTH - 1))
 		{
-			char *pName = g_aParameters[ iCategory ].m_sName; 
+			ConsolePrint( sText );
+			sText[ 0 ] = 0;
+			nLen = StringCat( sText, "    ", nBuf ); // indent
+		}
 
-			if (nLen + strlen( pName ) >= (CONSOLE_WIDTH - 1))
+			    StringCat( sText, CHC_COMMAND, nBuf );
+		nLen += StringCat( sText, pName      , nBuf );
+
+		if (iCategory < (_PARAM_HELPCATEGORIES_END - 1))
+		{
+			char sSep[] = " | ";
+
+			if (nLen + strlen( sSep ) >= (CONSOLE_WIDTH - 1))
 			{
 				ConsolePrint( sText );
 				sText[ 0 ] = 0;
 				nLen = StringCat( sText, "    ", nBuf ); // indent
 			}
-
-			        StringCat( sText, CHC_COMMAND, nBuf );
-			nLen += StringCat( sText, pName      , nBuf );
-
-			if (iCategory < (_PARAM_HELPCATEGORIES_END - 1))
-			{
-				char sSep[] = " | ";
-
-				if (nLen + strlen( sSep ) >= (CONSOLE_WIDTH - 1))
-				{
-					ConsolePrint( sText );
-					sText[ 0 ] = 0;
-					nLen = StringCat( sText, "    ", nBuf ); // indent
-				}
-				        StringCat( sText, CHC_ARG_SEP, nBuf );
-				nLen += StringCat( sText, sSep, nBuf );
-			}
+				    StringCat( sText, CHC_ARG_SEP, nBuf );
+			nLen += StringCat( sText, sSep, nBuf );
 		}
-		StringCat( sText, CHC_ARG_MAND, nBuf );
-		StringCat( sText, " >", nBuf);
+	}
 
-		StringCat( sText, CHC_ARG_OPT, nBuf );
-		StringCat( sText, " ]", nBuf);
+	StringCat( sText, CHC_ARG_MAND, nBuf );
+	StringCat( sText, " >", nBuf);
 
-//		ConsoleBufferPush( sText );
-		ConsolePrint( sText );  // Transcode colored text to native console color text
+	StringCat( sText, CHC_ARG_OPT, nBuf );
+	StringCat( sText, " ]", nBuf);
+
+//	ConsoleBufferPush( sText );
+	ConsolePrint( sText );  // Transcode colored text to native console color text
 		
-		ConsolePrintFormat( sText, "%sNotes%s: %s<>%s = mandatory, %s[]%s = optional, %s|%s argument option"
-			, CHC_USAGE
-			, CHC_DEFAULT
-			, CHC_ARG_MAND
-			, CHC_DEFAULT
-			, CHC_ARG_OPT
-			, CHC_DEFAULT
-			, CHC_ARG_SEP
-			, CHC_DEFAULT
-		);
-//		ConsoleBufferPush( sText );
+	ConsolePrintFormat( "%sNotes%s: %s<>%s = mandatory, %s[]%s = optional, %s|%s argument option"
+		, CHC_USAGE
+		, CHC_DEFAULT
+		, CHC_ARG_MAND
+		, CHC_DEFAULT
+		, CHC_ARG_OPT
+		, CHC_DEFAULT
+		, CHC_ARG_SEP
+		, CHC_DEFAULT
+	);
+//	ConsoleBufferPush( sText );
 }
 
 void Help_Examples()
 {
-	char sText[ CONSOLE_WIDTH ];
-	ConsolePrintFormat( sText, " %sExamples%s:%s"
+	ConsolePrintFormat( " %sExamples%s:%s"
 		, CHC_USAGE
 		, CHC_ARG_SEP
 		, CHC_DEFAULT
@@ -227,39 +226,38 @@ void Help_Range()
 //===========================================================================
 void Help_Operators()
 {
-	char sText[ CONSOLE_WIDTH ];
-	
-//	ConsolePrintFormat( sText," %sOperators%s:"                                 , CHC_USAGE, CHC_DEFAULT );
-//	ConsolePrintFormat( sText,"  Operators: (Math)"                             );
-	ConsolePrintFormat( sText,"  Operators: (%sMath%s)"                         , CHC_USAGE, CHC_DEFAULT );
-	ConsolePrintFormat( sText,"    %s+%s   Addition"                            , CHC_USAGE, CHC_DEFAULT );
-	ConsolePrintFormat( sText,"    %s-%s   Subtraction"                         , CHC_USAGE, CHC_DEFAULT );
-	ConsolePrintFormat( sText,"    %s*%s   Multiplication"                      , CHC_USAGE, CHC_DEFAULT );
-	ConsolePrintFormat( sText,"    %s/%s   Division"                            , CHC_USAGE, CHC_DEFAULT );
-	ConsolePrintFormat( sText,"    %s%%%s   Modulas or Remainder"               , CHC_USAGE, CHC_DEFAULT );
-//ConsoleBufferPush( "  Operators: (Bit Wise)"                         );
-	ConsolePrintFormat( sText,"  Operators: (%sBit Wise%s)"                     , CHC_USAGE, CHC_DEFAULT );
-	ConsolePrintFormat( sText,"    %s&%s   Bit-wise and (AND)"                  , CHC_USAGE, CHC_DEFAULT );
-	ConsolePrintFormat( sText,"    %s|%s   Bit-wise or  (OR )"                  , CHC_USAGE, CHC_DEFAULT );
-	ConsolePrintFormat( sText,"    %s^%s   Bit-wise exclusive-or (EOR/XOR)"     , CHC_USAGE, CHC_DEFAULT );
-	ConsolePrintFormat( sText,"    %s!%s   Bit-wise negation (NOT)"             , CHC_USAGE, CHC_DEFAULT );
-//ConsoleBufferPush( "  Operators: (Input)"                            );
-	ConsolePrintFormat( sText,"  Operators: (%sInput%s)"                        , CHC_USAGE, CHC_DEFAULT );
-	ConsolePrintFormat( sText,"    %s@%s   next number refers to search results", CHC_USAGE, CHC_DEFAULT );
-	ConsolePrintFormat( sText,"    %s\"%s   Designate string in ASCII format"   , CHC_USAGE, CHC_DEFAULT );
-	ConsolePrintFormat( sText,"    %s\'%s   Desginate string in High-Bit apple format", CHC_USAGE, CHC_DEFAULT );
-	ConsolePrintFormat( sText,"    %s$%s   Designate number/symbol"             , CHC_USAGE, CHC_DEFAULT );
-	ConsolePrintFormat( sText,"    %s#%s   Designate number in hex"             , CHC_USAGE, CHC_DEFAULT );
-//ConsoleBufferPush( "  Operators: (Range)"                            );
-	ConsolePrintFormat( sText,"  Operators: (%sRange%s)"                        , CHC_USAGE, CHC_DEFAULT );
-	ConsolePrintFormat( sText,"    %s,%s   range seperator (2nd address is relative)", CHC_USAGE, CHC_DEFAULT );
-	ConsolePrintFormat( sText,"    %s:%s   range seperator (2nd address is absolute)", CHC_USAGE, CHC_DEFAULT );
-//	ConsolePrintFormat( sText,"  Operators: (Misc)"                             );
-	ConsolePrintFormat( sText,"  Operators: (%sMisc%s)"                         , CHC_USAGE, CHC_DEFAULT );
-	ConsolePrintFormat( sText,"    %s//%s  comment until end of line"           , CHC_USAGE, CHC_DEFAULT );
-//ConsoleBufferPush( "  Operators: (Breakpoint)"                       );
-	ConsolePrintFormat( sText,"  Operators: (%sBreakpoint%s)"                   , CHC_USAGE, CHC_DEFAULT );
+//	ConsolePrintFormat( " %sOperators%s:"                                 , CHC_USAGE, CHC_DEFAULT );
+//	ConsolePrintFormat( "  Operators: (Math)"                             );
+	ConsolePrintFormat( "  Operators: (%sMath%s)"                         , CHC_USAGE, CHC_DEFAULT );
+	ConsolePrintFormat( "    %s+%s   Addition"                            , CHC_USAGE, CHC_DEFAULT );
+	ConsolePrintFormat( "    %s-%s   Subtraction"                         , CHC_USAGE, CHC_DEFAULT );
+	ConsolePrintFormat( "    %s*%s   Multiplication"                      , CHC_USAGE, CHC_DEFAULT );
+	ConsolePrintFormat( "    %s/%s   Division"                            , CHC_USAGE, CHC_DEFAULT );
+	ConsolePrintFormat( "    %s%%%s   Modulas or Remainder"               , CHC_USAGE, CHC_DEFAULT );
+//	ConsoleBufferPush( "  Operators: (Bit Wise)"                         );
+	ConsolePrintFormat( "  Operators: (%sBit Wise%s)"                     , CHC_USAGE, CHC_DEFAULT );
+	ConsolePrintFormat( "    %s&%s   Bit-wise and (AND)"                  , CHC_USAGE, CHC_DEFAULT );
+	ConsolePrintFormat( "    %s|%s   Bit-wise or  (OR )"                  , CHC_USAGE, CHC_DEFAULT );
+	ConsolePrintFormat( "    %s^%s   Bit-wise exclusive-or (EOR/XOR)"     , CHC_USAGE, CHC_DEFAULT );
+	ConsolePrintFormat( "    %s!%s   Bit-wise negation (NOT)"             , CHC_USAGE, CHC_DEFAULT );
+//	ConsoleBufferPush( "  Operators: (Input)"                            );
+	ConsolePrintFormat( "  Operators: (%sInput%s)"                        , CHC_USAGE, CHC_DEFAULT );
+	ConsolePrintFormat( "    %s@%s   next number refers to search results", CHC_USAGE, CHC_DEFAULT );
+	ConsolePrintFormat( "    %s\"%s   Designate string in ASCII format"   , CHC_USAGE, CHC_DEFAULT );
+	ConsolePrintFormat( "    %s\'%s   Desginate string in High-Bit apple format", CHC_USAGE, CHC_DEFAULT );
+	ConsolePrintFormat( "    %s$%s   Designate number/symbol"             , CHC_USAGE, CHC_DEFAULT );
+	ConsolePrintFormat( "    %s#%s   Designate number in hex"             , CHC_USAGE, CHC_DEFAULT );
+//	ConsoleBufferPush( "  Operators: (Range)"                            );
+	ConsolePrintFormat( "  Operators: (%sRange%s)"                        , CHC_USAGE, CHC_DEFAULT );
+	ConsolePrintFormat( "    %s,%s   range seperator (2nd address is relative)", CHC_USAGE, CHC_DEFAULT );
+	ConsolePrintFormat( "    %s:%s   range seperator (2nd address is absolute)", CHC_USAGE, CHC_DEFAULT );
+//	ConsolePrintFormat( "  Operators: (Misc)"                             );
+	ConsolePrintFormat( "  Operators: (%sMisc%s)"                         , CHC_USAGE, CHC_DEFAULT );
+	ConsolePrintFormat( "    %s//%s  comment until end of line"           , CHC_USAGE, CHC_DEFAULT );
+//	ConsoleBufferPush( "  Operators: (Breakpoint)"                       );
+	ConsolePrintFormat( "  Operators: (%sBreakpoint%s)"                   , CHC_USAGE, CHC_DEFAULT );
 
+	char sText[CONSOLE_WIDTH];
 	_tcscpy( sText, "    " );
 	strcat( sText, CHC_USAGE );
 	int iBreakOp = 0;
@@ -365,8 +363,9 @@ bool isHexDigit( char c )
 	return false;
 }
 
-
-bool Colorize( char * pDst, const char * pSrc )
+// TODO: Use nDstSz to prevent buffer overflow.
+// Alternatively, Colorize() may simply return a std::string.
+bool Colorize( char * pDst, size_t /*nDstSz*/, const char* pSrc)
 {
 	if (! pSrc)
 		return false;
@@ -475,77 +474,51 @@ bool Colorize( char * pDst, const char * pSrc )
 	return true;
 }
 
+template<size_t _DstSz>
+inline bool Colorize(char (&szDst)[_DstSz], const char* pSrc)
+{
+	return Colorize(szDst, _DstSz, pSrc);
+}
+
+
 // NOTE: This appends a new line
-inline bool ConsoleColorizePrint( char* colorizeBuf, size_t /*colorizeBufSz*/,
-                                  const char* pText )
+inline bool ConsoleColorizePrint( const char* pText )
 {
-   if (!Colorize(colorizeBuf, pText)) return false;
-   return ConsolePrint(colorizeBuf);
+	char colorizeBuf[CONSOLE_WIDTH * 2];
+	if (!Colorize(colorizeBuf, pText)) return false;
+	ConsolePrint(colorizeBuf);
+	return true;
 }
 
-template<size_t _ColorizeBufSz>
-inline bool ConsoleColorizePrint( char (&colorizeBuf)[_ColorizeBufSz],
-                                  const char* pText )
+inline bool ConsoleColorizePrintVa( const char* format, va_list va )
 {
-   return ConsoleColorizePrint(colorizeBuf, _ColorizeBufSz, pText);
+	std::string strText = StrFormatV(format, va);
+	return ConsoleColorizePrint(strText.c_str());
 }
 
-inline bool ConsoleColorizePrintVa( char* colorizeBuf, size_t colorizeBufSz,
-                                    char* buf, size_t bufsz,
-                                    const char* format, va_list va )
+inline bool ConsoleColorizePrintFormat( const char* format, ... ) ATTRIBUTE_FORMAT_PRINTF(1, 2)
 {
-   vsnprintf_s(buf, bufsz, _TRUNCATE, format, va);
-   return ConsoleColorizePrint(colorizeBuf, colorizeBufSz, buf);
-}
-
-template<size_t _ColorizeBufSz, size_t _BufSz>
-inline bool ConsoleColorizePrintVa( char (&colorizeBuf)[_ColorizeBufSz],
-                                    char (&buf)[_BufSz],
-                                    const char* format, va_list va )
-{
-   return ConsoleColorizePrintVa(colorizeBuf, _ColorizeBufSz, buf, _BufSz, format, va);
-}
-
-inline bool ConsoleColorizePrintFormat( char* colorizeBuf, size_t colorizeBufSz,
-                                        char* buf, size_t bufsz,
-                                        const char* format, ... )
-{
-   va_list va;
-   va_start(va, format);
-   bool const r = ConsoleColorizePrintVa(colorizeBuf, colorizeBufSz, buf, bufsz, format, va);
-   va_end(va);
-   return r;
-}
-
-template<size_t _ColorizeBufSz, size_t _BufSz>
-inline bool ConsoleColorizePrintFormat( char (&colorizeBuf)[_ColorizeBufSz],
-                                        char (&buf)[_BufSz],
-                                        const char* format, ... )
-{
-   va_list va;
-   va_start(va, format);
-   bool const r = ConsoleColorizePrintVa(colorizeBuf, buf, format, va);
-   va_end(va);
-   return r;
+	va_list va;
+	va_start(va, format);
+	bool const r = ConsoleColorizePrintVa(format, va);
+	va_end(va);
+	return r;
 }
 
 //===========================================================================
 Update_t CmdMOTD( int nArgs )	// Message Of The Day
 {
-	char sText[ CONSOLE_WIDTH*2 ];
-	char sTemp[ CONSOLE_WIDTH*2 ];
-
 #if DEBUG_COLOR_CONSOLE
 	ConsolePrint( "`" );
 	ConsolePrint( "`A" );
 	ConsolePrint( "`2`A" );
 #endif
 
-	ConsolePrintFormat( sText, "`9`A`7 Apple `9][ ][+ //e `7Emulator for Windows (TM) `9`@" );
+	ConsolePrint( "`9`A`7 Apple `9][ ][+ //e `7Emulator for Windows (TM) `9`@" );
 
 	CmdVersion(0);
 	CmdSymbols(0);
-	ConsoleColorizePrintFormat( sTemp, sText, "  '%sCtrl ~'%s console, '%s%s'%s (specific), '%s%s'%s (all)"
+	ConsoleColorizePrintFormat( "  '%sCtrl ~'%s console, '%s%s'%s (specific), '%s%s'%s (all)"
 		, CHC_KEY
 		, CHC_DEFAULT
 		, CHC_COMMAND
@@ -570,9 +543,7 @@ Update_t CmdHelpSpecific (int nArgs)
 {
 	int iArg;
 	char sText[ CONSOLE_WIDTH * 2 ];
-	char sTemp[ CONSOLE_WIDTH * 2 ];
 	memset( sText, 0, CONSOLE_WIDTH*2 );
-	memset( sTemp, 0, CONSOLE_WIDTH*2 );
 
 	if (! nArgs)
 	{
@@ -815,7 +786,7 @@ Update_t CmdHelpSpecific (int nArgs)
 			else
 				wsprintf( sCategory, "Unknown!" );
 
-			ConsolePrintFormat( sText, "%sCategory%s: %s%s"
+			ConsolePrintFormat( "%sCategory%s: %s%s"
 				, CHC_USAGE
 				, CHC_DEFAULT
 				, CHC_CATEGORY
@@ -858,11 +829,11 @@ Update_t CmdHelpSpecific (int nArgs)
 			else
 			{
 #if _DEBUG
-				ConsoleBufferPushFormat( sText, "%s  <-- Missing", pCommand->m_sName );
+				ConsoleBufferPushFormat( "%s  <-- Missing", pCommand->m_sName );
 	#if DEBUG_COMMAND_HELP
 				if (! bAllCommands) // Release version doesn't display message
 				{			
-					ConsoleBufferPushFormat( sText, "Missing Summary Help: %s", g_aCommands[ iCommand ].aName );
+					ConsoleBufferPushFormat( "Missing Summary Help: %s", g_aCommands[ iCommand ].aName );
 				}
 	#endif
 #endif
@@ -877,39 +848,39 @@ Update_t CmdHelpSpecific (int nArgs)
 		{	
 	// CPU / General
 		case CMD_ASSEMBLE:
-			ConsoleColorizePrint( sText, " Usage: [address | symbol]" );
+			ConsoleColorizePrint( " Usage: [address | symbol]" );
 			ConsoleBufferPush( " Enter mini-assembler mode [starting at optional address or symbol]." );
 			break;
 		case CMD_UNASSEMBLE:
-			ConsoleColorizePrint( sText, " Usage: [address | symbol]" );
+			ConsoleColorizePrint( " Usage: [address | symbol]" );
 			ConsoleBufferPush( "  Disassembles memory." );
 			break;
 		case CMD_GO_NORMAL_SPEED:
 		case CMD_GO_FULL_SPEED:
-			ConsoleColorizePrint( sText, " Usage: address | symbol [Skip,Length]" );
-			ConsoleColorizePrint( sText, " Usage: address | symbol [Start:End]" );
+			ConsoleColorizePrint( " Usage: address | symbol [Skip,Length]" );
+			ConsoleColorizePrint( " Usage: address | symbol [Start:End]" );
 			ConsoleBufferPush( " Skip  : Start address to skip stepping"                     );
 			ConsoleBufferPush( " Length: Range of bytes past start address to skip stepping" );
 			ConsoleBufferPush( " End   : Inclusive end address to skip stepping"             );
 			ConsoleBufferPush( "  If the Program Counter is outside the skip range, resumes single-stepping." );
 			ConsoleBufferPush( "  Can be used to skip ROM/OS/user code." );
 			Help_Examples();
-			ConsolePrintFormat( sText, "%s  G[G] C600 FA00,600" , CHC_EXAMPLE );
-			ConsolePrintFormat( sText, "%s  G[G] C600 F000:FFFF", CHC_EXAMPLE );
+			ConsolePrintFormat( "%s  G[G] C600 FA00,600" , CHC_EXAMPLE );
+			ConsolePrintFormat( "%s  G[G] C600 F000:FFFF", CHC_EXAMPLE );
 			break;
 		case CMD_JSR:
-			ConsoleColorizePrint( sText, " Usage: [symbol | address]" );
+			ConsoleColorizePrint( " Usage: [symbol | address]" );
 			ConsoleBufferPush( "  Pushes PC on stack; calls the named subroutine." );
 			break;
 		case CMD_NOP:
-			ConsoleBufferPush( TEXT("  Puts a NOP opcode at current instruction") );
+			ConsoleBufferPush( "  Puts a NOP opcode at current instruction" );
 			break;
 		case CMD_OUT:
-			ConsoleColorizePrint( sText, " Usage: [address8 | address16 | symbol] ## [##]" );
-			ConsoleBufferPush( TEXT("  Output a byte or word to the IO address $C0xx" ) );
+			ConsoleColorizePrint( " Usage: [address8 | address16 | symbol] ## [##]" );
+			ConsoleBufferPush( "  Output a byte or word to the IO address $C0xx" );
 			break;
 		case CMD_PROFILE:
-			ConsoleColorizePrintFormat( sTemp, sText, " Usage: [%s | %s | %s]"
+			ConsoleColorizePrintFormat( " Usage: [%s | %s | %s]"
 				, g_aParameters[ PARAM_RESET ].m_sName
 				, g_aParameters[ PARAM_SAVE  ].m_sName
 				, g_aParameters[ PARAM_LIST  ].m_sName
@@ -918,65 +889,65 @@ Update_t CmdHelpSpecific (int nArgs)
 			break;
 	// Registers
 		case CMD_REGISTER_SET:
-			ConsoleColorizePrint( sText,    " Usage: <reg> <value | expression | symbol>" );
+			ConsoleColorizePrint( " Usage: <reg> <value | expression | symbol>" );
 			ConsoleBufferPush( "  Where <reg> is one of: A X Y PC SP " );
-			ConsoleColorizePrintFormat( sTemp, sText, " See also: %s%s"
+			ConsoleColorizePrintFormat( " See also: %s%s"
 				, CHC_CATEGORY
 				, g_aParameters[ PARAM_CAT_OPERATORS ].m_sName );
 			Help_Examples();
-			ConsolePrintFormat( sText, "%s  R PC RESET + 1", CHC_EXAMPLE );
-			ConsolePrintFormat( sText, "%s  R PC $FC58"    , CHC_EXAMPLE );
-			ConsolePrintFormat( sText, "%s  R A  A1"       , CHC_EXAMPLE );
-			ConsolePrintFormat( sText, "%s  R A  $A1"      , CHC_EXAMPLE );
-			ConsolePrintFormat( sText, "%s  R A  #A1"      , CHC_EXAMPLE );
+			ConsolePrintFormat( "%s  R PC RESET + 1", CHC_EXAMPLE );
+			ConsolePrintFormat( "%s  R PC $FC58"    , CHC_EXAMPLE );
+			ConsolePrintFormat( "%s  R A  A1"       , CHC_EXAMPLE );
+			ConsolePrintFormat( "%s  R A  $A1"      , CHC_EXAMPLE );
+			ConsolePrintFormat( "%s  R A  #A1"      , CHC_EXAMPLE );
 			break;
 		case CMD_SOURCE:
-//			ConsoleBufferPush( TEXT(" Reads assembler source file." ) );
-			ConsoleColorizePrintFormat( sTemp, sText, " Usage: [ %s | %s ] \"filename\""             , g_aParameters[ PARAM_SRC_MEMORY  ].m_sName, g_aParameters[ PARAM_SRC_SYMBOLS ].m_sName );
-			ConsoleBufferPushFormat( sText, "   %s: read source bytes into memory."        , g_aParameters[ PARAM_SRC_MEMORY  ].m_sName );
-			ConsoleBufferPushFormat( sText, "   %s: read symbols into Source symbol table.", g_aParameters[ PARAM_SRC_SYMBOLS ].m_sName );
-			ConsoleBufferPushFormat( sText, " Supports: %s."                               , g_aParameters[ PARAM_SRC_MERLIN  ].m_sName );
+//			ConsoleBufferPush( " Reads assembler source file." );
+			ConsoleColorizePrintFormat( " Usage: [ %s | %s ] \"filename\""          , g_aParameters[ PARAM_SRC_MEMORY  ].m_sName, g_aParameters[ PARAM_SRC_SYMBOLS ].m_sName );
+			ConsoleBufferPushFormat( "   %s: read source bytes into memory."        , g_aParameters[ PARAM_SRC_MEMORY  ].m_sName );
+			ConsoleBufferPushFormat( "   %s: read symbols into Source symbol table.", g_aParameters[ PARAM_SRC_SYMBOLS ].m_sName );
+			ConsoleBufferPushFormat( " Supports: %s."                               , g_aParameters[ PARAM_SRC_MERLIN  ].m_sName );
 			break;
 		case CMD_STEP_OUT: 
 			ConsoleBufferPush( "  Steps out of current subroutine" );
 			ConsoleBufferPush( "  Hotkey: Ctrl-Space" ); // TODO: FIXME
 			break;
 		case CMD_STEP_OVER: // Bad name? FIXME/TODO: do we need to rename?
-			ConsoleColorizePrint( sText, " Usage: [#]" );
+			ConsoleColorizePrint( " Usage: [#]" );
 			ConsoleBufferPush( "  Steps, # times, thru current instruction" );
 			ConsoleBufferPush( "  JSR will be stepped into AND out of." );
 			ConsoleBufferPush( "  Hotkey: Ctrl-Space" ); // TODO: FIXME
 			break;
 		case CMD_TRACE:
-			ConsoleColorizePrint( sText, " Usage: [#]" );
+			ConsoleColorizePrint( " Usage: [#]" );
 			ConsoleBufferPush( "  Traces, # times, current instruction(s)" );
 			ConsoleBufferPush( "  JSR will be stepped into" );
 			ConsoleBufferPush( "  Hotkey: Shift-Space" );
 			break;
 		case CMD_TRACE_FILE:
-			ConsoleColorizePrint( sText, " Usage: \"[filename]\" [v]" );
+			ConsoleColorizePrint( " Usage: \"[filename]\" [v]" );
 			break;
 		case CMD_TRACE_LINE:
-			ConsoleColorizePrint( sText, " Usage: [#]" );
+			ConsoleColorizePrint( " Usage: [#]" );
 			ConsoleBufferPush( "  Traces into current instruction" );
 			ConsoleBufferPush( "  with cycle counting." );
 			break;
 	// Bookmarks
 		case CMD_BOOKMARK:
 		case CMD_BOOKMARK_ADD:
-			ConsoleColorizePrint( sText, " Usage: [address | symbol]"   );
-			ConsoleColorizePrint( sText, " Usage: # <address | symbol>" );
+			ConsoleColorizePrint( " Usage: [address | symbol]"   );
+			ConsoleColorizePrint( " Usage: # <address | symbol>" );
 			ConsoleBufferPush("  If no address or symbol is specified, lists the current bookmarks." );
 			ConsoleBufferPush("  Updates the specified bookmark (#)" );
 			Help_Examples();
-			ConsolePrintFormat( sText,  "%s   %s RESET ", CHC_EXAMPLE, pCommand->m_sName );
-			ConsolePrintFormat( sText,  "%s   %s 1 HOME", CHC_EXAMPLE, pCommand->m_sName );
+			ConsolePrintFormat( "%s   %s RESET ", CHC_EXAMPLE, pCommand->m_sName );
+			ConsolePrintFormat( "%s   %s 1 HOME", CHC_EXAMPLE, pCommand->m_sName );
 			break;
 		case CMD_BOOKMARK_CLEAR:
-			ConsoleColorizePrint( sText, " Usage: [# | *]" );
+			ConsoleColorizePrint( " Usage: [# | *]" );
 			ConsoleBufferPush( "  Clears specified bookmark, or all." );
 			Help_Examples();
-			ConsolePrintFormat( sText,  "%s   %s 1", CHC_EXAMPLE, pCommand->m_sName );
+			ConsolePrintFormat( "%s   %s 1", CHC_EXAMPLE, pCommand->m_sName );
 			break;
 		case CMD_BOOKMARK_LIST:
 //		case CMD_BOOKMARK_LOAD:
@@ -984,7 +955,7 @@ Update_t CmdHelpSpecific (int nArgs)
 			break;
 	// Breakpoints
 		case CMD_BREAK_INVALID:
-			ConsoleColorizePrintFormat( sTemp, sText, TEXT(" Usage: [%s%s | %s%s] | [# | # %s%s | # %s%s]")
+			ConsoleColorizePrintFormat( " Usage: [%s%s | %s%s] | [# | # %s%s | # %s%s]"
 				, CHC_COMMAND
 				, g_aParameters[ PARAM_ON  ].m_sName
 				, CHC_COMMAND
@@ -994,7 +965,7 @@ Update_t CmdHelpSpecific (int nArgs)
 				, CHC_COMMAND
 				, g_aParameters[ PARAM_OFF  ].m_sName
 			);
-			ConsoleColorizePrintFormat(sTemp, sText, TEXT(" Usage: [%s%s %s%s | %s%s %s%s]")
+			ConsoleColorizePrintFormat( " Usage: [%s%s %s%s | %s%s %s%s]"
 				, CHC_COMMAND
 				, g_aParameters[PARAM_ALL].m_sName
 				, CHC_COMMAND
@@ -1004,38 +975,38 @@ Update_t CmdHelpSpecific (int nArgs)
 				, CHC_COMMAND
 				, g_aParameters[PARAM_OFF].m_sName
 			);
-			ConsoleColorizePrint( sTemp, TEXT("Where: # is 0=BRK, 1=Invalid Opcode_1, 2=Invalid Opcode_2, 3=Invalid Opcode_3"));
+			ConsoleColorizePrint( "Where: # is 0=BRK, 1=Invalid Opcode_1, 2=Invalid Opcode_2, 3=Invalid Opcode_3");
 			break;
 //		case CMD_BREAK_OPCODE:
 		case CMD_BREAKPOINT:
-			ConsoleColorizePrintFormat( sTemp, sText, TEXT(" Usage: [%s%s | %s%s | %s%s]")
+			ConsoleColorizePrintFormat( " Usage: [%s%s | %s%s | %s%s]"
 				, CHC_COMMAND
 				, g_aParameters[ PARAM_LOAD  ].m_sName
 				, CHC_COMMAND
 				, g_aParameters[ PARAM_SAVE  ].m_sName
 				, CHC_COMMAND
 				, g_aParameters[ PARAM_RESET ].m_sName );
-			ConsolePrintFormat( sText, " Maximum breakpoints: %s%d", CHC_NUM_DEC, MAX_BREAKPOINTS );
+			ConsolePrintFormat( " Maximum breakpoints: %s%d", CHC_NUM_DEC, MAX_BREAKPOINTS );
 			ConsoleBufferPush( "  Set breakpoint at PC if no args."    );
 			ConsoleBufferPush( "  Loading/Saving not yet implemented." );
 			break;
 		case CMD_BREAKPOINT_ADD_REG:
-			ConsoleColorizePrint( sText, " Usage: [A|X|Y|PC|S] [op] <range | value>" );
+			ConsoleColorizePrint( " Usage: [A|X|Y|PC|S] [op] <range | value>" );
 			ConsoleBufferPush( "  Set breakpoint when reg is [op] value"   );
 			ConsoleBufferPush( "  Default operator is '='"                 );
-			ConsoleColorizePrintFormat( sTemp, sText, " See also: %s%s"
+			ConsoleColorizePrintFormat( " See also: %s%s"
 				, CHC_CATEGORY
 				, g_aParameters[ PARAM_CAT_OPERATORS ].m_sName );
 			// ConsoleBufferPush( " Examples:"     );
 			Help_Examples();
-			ConsolePrintFormat( sText, "%s   %s PC < D000"                    , CHC_EXAMPLE, pCommand->m_sName );
-			ConsolePrintFormat( sText, "%s   %s PC = F000:FFFF PC < D000,1000", CHC_EXAMPLE, pCommand->m_sName );
-			ConsolePrintFormat( sText, "%s   %s A <= D5"                      , CHC_EXAMPLE, pCommand->m_sName );
-			ConsolePrintFormat( sText, "%s   %s A != 01:FF"                   , CHC_EXAMPLE, pCommand->m_sName );
-			ConsolePrintFormat( sText, "%s   %s X  = A5"                      , CHC_EXAMPLE, pCommand->m_sName );
+			ConsolePrintFormat( "%s   %s PC < D000"                    , CHC_EXAMPLE, pCommand->m_sName );
+			ConsolePrintFormat( "%s   %s PC = F000:FFFF PC < D000,1000", CHC_EXAMPLE, pCommand->m_sName );
+			ConsolePrintFormat( "%s   %s A <= D5"                      , CHC_EXAMPLE, pCommand->m_sName );
+			ConsolePrintFormat( "%s   %s A != 01:FF"                   , CHC_EXAMPLE, pCommand->m_sName );
+			ConsolePrintFormat( "%s   %s X  = A5"                      , CHC_EXAMPLE, pCommand->m_sName );
 			break;
 		case CMD_BREAKPOINT_ADD_SMART:
-			ConsoleColorizePrint( sText, " Usage: [address | register]" );
+			ConsoleColorizePrint( " Usage: [address | register]" );
 			ConsoleBufferPush( "  If address, sets two breakpoints" );
 			ConsoleBufferPush( "    1. one memory access at address" );
 			ConsoleBufferPush( "    2. if PC reaches address" );
@@ -1044,63 +1015,63 @@ Update_t CmdHelpSpecific (int nArgs)
 			ConsoleBufferPush( "  If register, sets a breakpoint on memory access at address of register." );
 			break;
 		case CMD_BREAKPOINT_ADD_PC:
-			ConsoleColorizePrint( sText, " Usage: [address]" );
+			ConsoleColorizePrint( " Usage: [address]" );
 			ConsoleBufferPush( "  Sets a breakpoint at the current PC or at the specified address." );
 			break;
 		case CMD_BREAKPOINT_CLEAR:
-			ConsoleColorizePrint( sText, " Usage: [# | *]" );
+			ConsoleColorizePrint( " Usage: [# | *]" );
 			ConsoleBufferPush( "  Clears specified breakpoint, or all." );
 			Help_Examples();
-			ConsolePrintFormat( sText, "%s   %s 1", CHC_EXAMPLE, pCommand->m_sName );
+			ConsolePrintFormat( "%s   %s 1", CHC_EXAMPLE, pCommand->m_sName );
 			break;
 		case CMD_BREAKPOINT_DISABLE:
-			ConsoleColorizePrint( sText, " Usage: [# [,#] | *]" );
+			ConsoleColorizePrint( " Usage: [# [,#] | *]" );
 			ConsoleBufferPush( "  Disable breakpoint previously set, or all." );
 			Help_Examples();
-			ConsolePrintFormat( sText,  "%s   %s 1", CHC_EXAMPLE, pCommand->m_sName );
+			ConsolePrintFormat( "%s   %s 1", CHC_EXAMPLE, pCommand->m_sName );
 			break;
 		case CMD_BREAKPOINT_ENABLE:
-			ConsoleColorizePrint( sText, " Usage: [# [,#] | *]" );
+			ConsoleColorizePrint( " Usage: [# [,#] | *]" );
 			ConsoleBufferPush( "  Re-enables breakpoint previously set, or all." );
 			Help_Examples();
-			ConsolePrintFormat( sText,  "%s   %s 1", CHC_EXAMPLE, pCommand->m_sName );
+			ConsolePrintFormat( "%s   %s 1", CHC_EXAMPLE, pCommand->m_sName );
 			break;
 		case CMD_BREAKPOINT_LIST:
 			break;
 		case CMD_BREAKPOINT_ADD_MEM:
 		case CMD_BREAKPOINT_ADD_MEMR:
 		case CMD_BREAKPOINT_ADD_MEMW:
-			ConsoleColorizePrint(sText, " Usage: <range>");
+			ConsoleColorizePrint( " Usage: <range>" );
 			Help_Range();
 			break;
 	// Config - Load / Save
 		case CMD_CONFIG_LOAD:
-			ConsoleColorizePrint( sText, " Usage: [\"filename\"]" );
-			ConsoleBufferPushFormat( sText, "  Load debugger configuration from '%s', or the specificed file.", g_sFileNameConfig.c_str() );
+			ConsoleColorizePrint( " Usage: [\"filename\"]" );
+			ConsoleBufferPushFormat( "  Load debugger configuration from '%s', or the specificed file.", g_sFileNameConfig.c_str() );
 			break;
 		case CMD_CONFIG_SAVE:
-			ConsoleColorizePrint( sText, " Usage: [\"filename\"]" );
-			ConsoleBufferPushFormat( sText, "  Save debugger configuration to '%s', or the specificed file.", g_sFileNameConfig.c_str() );
+			ConsoleColorizePrint( " Usage: [\"filename\"]" );
+			ConsoleBufferPushFormat( "  Save debugger configuration to '%s', or the specificed file.", g_sFileNameConfig.c_str() );
 			break;
 	// Config - Color
 		case CMD_CONFIG_COLOR:
-			ConsoleBufferPush( TEXT(" Usage: [<#> | <# RR GG BB>]" ) );
-			ConsoleBufferPush( TEXT("  0 params: switch to 'color' scheme" ) );
-			ConsoleBufferPush( TEXT("  1 param : dumps R G B for scheme 'color'") );
-			ConsoleBufferPush( TEXT("  4 params: sets  R G B for scheme 'color'" ) );
+			ConsoleBufferPush( " Usage: [<#> | <# RR GG BB>]" );
+			ConsoleBufferPush( "  0 params: switch to 'color' scheme" );
+			ConsoleBufferPush( "  1 param : dumps R G B for scheme 'color'" );
+			ConsoleBufferPush( "  4 params: sets  R G B for scheme 'color'" );
 			break;
 		case CMD_CONFIG_MONOCHROME:
-			ConsoleBufferPush( TEXT(" Usage: [<#> | <# RR GG BB>]" ) );
-			ConsoleBufferPush( TEXT("  0 params: switch to 'monochrome' scheme" ) );
-			ConsoleBufferPush( TEXT("  1 param : dumps R G B for scheme 'monochrome'") );
-			ConsoleBufferPush( TEXT("  4 params: sets  R G B for scheme 'monochrome'" ) );
+			ConsoleBufferPush( " Usage: [<#> | <# RR GG BB>]" );
+			ConsoleBufferPush( "  0 params: switch to 'monochrome' scheme" );
+			ConsoleBufferPush( "  1 param : dumps R G B for scheme 'monochrome'" );
+			ConsoleBufferPush( "  4 params: sets  R G B for scheme 'monochrome'" );
 			break;
 	// Config - Diasm
 		case CMD_CONFIG_DISASM:
 		{
-			ConsoleColorizePrint( sText, " Note: All arguments effect the disassembly view" );
+			ConsoleColorizePrint( " Note: All arguments effect the disassembly view" );
 
-			ConsoleColorizePrintFormat( sTemp, sText, " Usage: [%s%s | %s | %s%s | %s%s | %s%s | %s%s]"
+			ConsoleColorizePrintFormat( " Usage: [%s%s | %s | %s%s | %s%s | %s%s | %s%s]"
 				, CHC_COMMAND
 				, g_aParameters[ PARAM_CONFIG_BRANCH ].m_sName
 				, CHC_COMMAND
@@ -1116,76 +1087,76 @@ Update_t CmdHelpSpecific (int nArgs)
 			ConsoleBufferPush( "  Display current settings if no args." );
 
 			iParam = PARAM_CONFIG_BRANCH;
-			ConsoleColorizePrintFormat( sTemp, sText, " Usage: %s [#]", g_aParameters[ iParam ].m_sName );
+			ConsoleColorizePrintFormat( " Usage: %s [#]", g_aParameters[ iParam ].m_sName );
 			ConsoleBufferPush( "  Set the type of branch character:" );
-			ConsoleBufferPushFormat( sText, "  %d off, %d plain, %d fancy",
-				 DISASM_BRANCH_OFF, DISASM_BRANCH_PLAIN, DISASM_BRANCH_FANCY );
-			ConsolePrintFormat( sText, "  i.e. %s%s %s 1", CHC_EXAMPLE, pCommand->m_sName, g_aParameters[ iParam ].m_sName );
+			ConsoleBufferPushFormat( "  %d off, %d plain, %d fancy",
+				DISASM_BRANCH_OFF, DISASM_BRANCH_PLAIN, DISASM_BRANCH_FANCY );
+			ConsolePrintFormat( "  i.e. %s%s %s 1", CHC_EXAMPLE, pCommand->m_sName, g_aParameters[ iParam ].m_sName );
 
 			iParam = PARAM_CONFIG_CLICK;
-			ConsoleColorizePrintFormat( sTemp, sText, " Usage: %s [#]", g_aParameters[ iParam ].m_sName );
+			ConsoleColorizePrintFormat( " Usage: %s [#]", g_aParameters[ iParam ].m_sName );
 			ConsoleBufferPush( "  Set required key combo. (Alt, Control, or Shift) when left clicking" );
-			ConsoleBufferPushFormat( sText, "    0  Left-Click (no Alt, Ctrl, Shift)" );
-			ConsoleBufferPushFormat( sText, "    1  Alt Left-click"                   );
-			ConsoleBufferPushFormat( sText, "    2  Ctrl Left-click"                  );
-			ConsoleBufferPushFormat( sText, "    3  Alt+Ctrl Left-click"              );
-			ConsoleBufferPushFormat( sText, "    4  Shift Left-click"                 );
-			ConsoleBufferPushFormat( sText, "    5  Shift+Alt Left-click"             );
-			ConsoleBufferPushFormat( sText, "    6  Shift+Ctrl Left-click"            );
-			ConsoleBufferPushFormat( sText, "    7  Shift+Ctrl+Alt Left-click"        );
+			ConsoleBufferPush( "    0  Left-Click (no Alt, Ctrl, Shift)" );
+			ConsoleBufferPush( "    1  Alt Left-click"                   );
+			ConsoleBufferPush( "    2  Ctrl Left-click"                  );
+			ConsoleBufferPush( "    3  Alt+Ctrl Left-click"              );
+			ConsoleBufferPush( "    4  Shift Left-click"                 );
+			ConsoleBufferPush( "    5  Shift+Alt Left-click"             );
+			ConsoleBufferPush( "    6  Shift+Ctrl Left-click"            );
+			ConsoleBufferPush( "    7  Shift+Ctrl+Alt Left-click"        );
 			Help_Examples();
-			ConsolePrintFormat( sText, "    %s%s %s 0  // Plain Left-click"           , CHC_EXAMPLE, pCommand->m_sName, g_aParameters[ iParam ].m_sName );
-			ConsolePrintFormat( sText, "    %s%s %s 1  // Require Alt Left-click"     , CHC_EXAMPLE, pCommand->m_sName, g_aParameters[ iParam ].m_sName );
-			ConsolePrintFormat( sText, "    %s%s %s 2  // Require Ctrl Left-click"    , CHC_EXAMPLE, pCommand->m_sName, g_aParameters[ iParam ].m_sName );
-			ConsolePrintFormat( sText, "    %s%s %s 3  // Require Alt+Ctrl Left-click", CHC_EXAMPLE, pCommand->m_sName, g_aParameters[ iParam ].m_sName );
+			ConsolePrintFormat( "    %s%s %s 0  // Plain Left-click"           , CHC_EXAMPLE, pCommand->m_sName, g_aParameters[ iParam ].m_sName );
+			ConsolePrintFormat( "    %s%s %s 1  // Require Alt Left-click"     , CHC_EXAMPLE, pCommand->m_sName, g_aParameters[ iParam ].m_sName );
+			ConsolePrintFormat( "    %s%s %s 2  // Require Ctrl Left-click"    , CHC_EXAMPLE, pCommand->m_sName, g_aParameters[ iParam ].m_sName );
+			ConsolePrintFormat( "    %s%s %s 3  // Require Alt+Ctrl Left-click", CHC_EXAMPLE, pCommand->m_sName, g_aParameters[ iParam ].m_sName );
 
 			iParam = PARAM_CONFIG_COLON;
-			ConsoleColorizePrintFormat( sTemp, sText, " Usage: %s [0|1]", g_aParameters[ iParam ].m_sName );
+			ConsoleColorizePrintFormat( " Usage: %s [0|1]", g_aParameters[ iParam ].m_sName );
 			ConsoleBufferPush( "  Display a colon after the address" );
-			ConsolePrintFormat( sText,   "  i.e. %s%s %s 0", CHC_EXAMPLE, pCommand->m_sName, g_aParameters[ iParam ].m_sName );
+			ConsolePrintFormat( "  i.e. %s%s %s 0", CHC_EXAMPLE, pCommand->m_sName, g_aParameters[ iParam ].m_sName );
 
 			iParam = PARAM_CONFIG_OPCODE;
-			ConsoleColorizePrintFormat( sTemp, sText, " Usage: %s [0|1]", g_aParameters[ iParam ].m_sName );
+			ConsoleColorizePrintFormat( " Usage: %s [0|1]", g_aParameters[ iParam ].m_sName );
 			ConsoleBufferPush( "  Display opcode(s) after colon" );
-			ConsolePrintFormat( sText,   "  i.e. %s%s %s 1", CHC_EXAMPLE, pCommand->m_sName, g_aParameters[ iParam ].m_sName );
+			ConsolePrintFormat( "  i.e. %s%s %s 1", CHC_EXAMPLE, pCommand->m_sName, g_aParameters[ iParam ].m_sName );
 
 			iParam = PARAM_CONFIG_SPACES;
-			ConsoleColorizePrintFormat( sTemp, sText, " Usage: %s [0|1]", g_aParameters[ iParam ].m_sName );
+			ConsoleColorizePrintFormat( " Usage: %s [0|1]", g_aParameters[ iParam ].m_sName );
 			ConsoleBufferPush( "  Display spaces between opcodes" );
-			ConsolePrintFormat( sText, "  i.e. %s%s %s 0", CHC_EXAMPLE, pCommand->m_sName, g_aParameters[ iParam ].m_sName );
+			ConsolePrintFormat( "  i.e. %s%s %s 0", CHC_EXAMPLE, pCommand->m_sName, g_aParameters[ iParam ].m_sName );
 
 			iParam = PARAM_CONFIG_TARGET;
-			ConsoleColorizePrintFormat( sTemp, sText, " Usage: %s [#]", g_aParameters[ iParam ].m_sName );
+			ConsoleColorizePrintFormat( " Usage: %s [#]", g_aParameters[ iParam ].m_sName );
 			ConsoleBufferPush( "  Set the type of target address/value displayed:" );
-			ConsoleBufferPushFormat( sText, "  %d off, %d value only, %d address only, %d both",
+			ConsoleBufferPushFormat( "  %d off, %d value only, %d address only, %d both",
 				DISASM_TARGET_OFF, DISASM_TARGET_VAL, DISASM_TARGET_ADDR, DISASM_TARGET_BOTH );
-			ConsolePrintFormat( sText, "  i.e. %s%s %s %d", CHC_EXAMPLE, pCommand->m_sName, g_aParameters[ iParam ].m_sName, DISASM_TARGET_VAL );
+			ConsolePrintFormat( "  i.e. %s%s %s %d", CHC_EXAMPLE, pCommand->m_sName, g_aParameters[ iParam ].m_sName, DISASM_TARGET_VAL );
 			break;
 		}
 	// Config - Font
 		case CMD_CONFIG_FONT:
 			ConsolePrint( " No longer applicable with new debugger font" );
 /*
-			ConsoleBufferPushFormat( sText, TEXT(" Usage: [%s | %s] \"FontName\" [Height]" ),
+			ConsoleBufferPushFormat( " Usage: [%s | %s] \"FontName\" [Height]",
 				g_aParameters[ PARAM_FONT_MODE ].m_sName, g_aParameters[ PARAM_DISASM ].m_sName );
-			ConsoleBufferPush( TEXT(" i.e. FONT \"Courier\" 12" ) );
-			ConsoleBufferPush( TEXT(" i.e. FONT \"Lucida Console\" 12" ) );
-			ConsoleBufferPushFormat( sText, TEXT(" %s Controls line spacing."), g_aParameters[ PARAM_FONT_MODE ].m_sName );
-			ConsoleBufferPushFormat( sText, TEXT(" Valid values are: %d, %d, %d." ),
+			ConsoleBufferPush( " i.e. FONT \"Courier\" 12" );
+			ConsoleBufferPush( " i.e. FONT \"Lucida Console\" 12" );
+			ConsoleBufferPushFormat( " %s Controls line spacing.", g_aParameters[ PARAM_FONT_MODE ].m_sName );
+			ConsoleBufferPushFormat( " Valid values are: %d, %d, %d.",
 				FONT_SPACING_CLASSIC, FONT_SPACING_CLEAN, FONT_SPACING_COMPRESSED );
 */
 			break;
 	// Disasm
 		case CMD_DEFINE_DATA_BYTE1:
-			ConsoleColorizePrintFormat( sTemp, sText, " Usage: %s <address> | <symbol address> | <symbol range>", pCommand->m_sName );
+			ConsoleColorizePrintFormat( " Usage: %s <address> | <symbol address> | <symbol range>", pCommand->m_sName );
 
-			ConsoleBufferPush( TEXT("  Tell the diassembler to treat the BYTES as data instead of code." ) );
+			ConsoleBufferPush( "  Tell the diassembler to treat the BYTES as data instead of code." );
 
 			Help_Examples();
-			ConsolePrintFormat( sText,  "%s   %s WNDTOP 22", CHC_EXAMPLE, pCommand->m_sName );
-			ConsolePrintFormat( sText,  "%s   %s WNDBTM 23", CHC_EXAMPLE, pCommand->m_sName );
-			ConsolePrintFormat( sText,  "%s   %s WNDTOP       // treat as code again", CHC_EXAMPLE, g_aCommands[ CMD_DISASM_CODE ].m_sName );
-			ConsolePrintFormat( sText,  "%s   %s              // list all addresses viewed as data", CHC_EXAMPLE, g_aCommands[ CMD_DISASM_LIST ].m_sName  );
+			ConsolePrintFormat( "%s   %s WNDTOP 22", CHC_EXAMPLE, pCommand->m_sName );
+			ConsolePrintFormat( "%s   %s WNDBTM 23", CHC_EXAMPLE, pCommand->m_sName );
+			ConsolePrintFormat( "%s   %s WNDTOP       // treat as code again", CHC_EXAMPLE, g_aCommands[ CMD_DISASM_CODE ].m_sName );
+			ConsolePrintFormat( "%s   %s              // list all addresses viewed as data", CHC_EXAMPLE, g_aCommands[ CMD_DISASM_LIST ].m_sName  );
 			break;
 
 		case CMD_DEFINE_DATA_WORD1:
@@ -1194,119 +1165,119 @@ Update_t CmdHelpSpecific (int nArgs)
 			// DW symbol address
 			// DW symbol range:range
 			// DW address
-			ConsoleColorizePrintFormat( sTemp, sText, " Usage: %s <address> | <symbol address> | <symbol range>", pCommand->m_sName );
+			ConsoleColorizePrintFormat( " Usage: %s <address> | <symbol address> | <symbol range>", pCommand->m_sName );
 
-			ConsoleBufferPush( TEXT("  Tell the diassembler to treat the WORDS as data instead of code." ) );
+			ConsoleBufferPush( "  Tell the diassembler to treat the WORDS as data instead of code." );
 
-			ConsoleColorizePrint( sTemp, "  The data is a range of 2-byte pointer data.");
+			ConsoleColorizePrint( "  The data is a range of 2-byte pointer data.");
 
 			Help_Examples();
-			ConsolePrintFormat( sText,  "%s   %s NEXT1 801   // AppleSoft Basic Line#1 Pointer to Next line", CHC_EXAMPLE, pCommand->m_sName );
-			ConsolePrintFormat( sText,  "%s   %s LINE1 803   // Applesoft Basic Line#1 Line Number", CHC_EXAMPLE, pCommand->m_sName );
-			ConsolePrintFormat( sText,  "%s   %s NEXT1        // treat as code again", CHC_EXAMPLE, g_aCommands[ CMD_DISASM_CODE ].m_sName );
-			ConsolePrintFormat( sText,  "%s   %s              // list all addresses viewed as data", CHC_EXAMPLE, g_aCommands[ CMD_DISASM_LIST ].m_sName  );
+			ConsolePrintFormat( "%s   %s NEXT1 801   // AppleSoft Basic Line#1 Pointer to Next line", CHC_EXAMPLE, pCommand->m_sName );
+			ConsolePrintFormat( "%s   %s LINE1 803   // Applesoft Basic Line#1 Line Number", CHC_EXAMPLE, pCommand->m_sName );
+			ConsolePrintFormat( "%s   %s NEXT1        // treat as code again", CHC_EXAMPLE, g_aCommands[ CMD_DISASM_CODE ].m_sName );
+			ConsolePrintFormat( "%s   %s              // list all addresses viewed as data", CHC_EXAMPLE, g_aCommands[ CMD_DISASM_LIST ].m_sName  );
 			break;
 
 	// Memory
 		case CMD_MEMORY_ENTER_BYTE:
-			ConsoleColorizePrint( sTemp, " Usage: <address | symbol> ## [## ... ##]" );
-			ConsoleBufferPush( TEXT("  Sets memory to the specified 8-Bit Values (bytes)" ) );
+			ConsoleColorizePrint( " Usage: <address | symbol> ## [## ... ##]" );
+			ConsoleBufferPush( "  Sets memory to the specified 8-Bit Values (bytes)" );
 			Help_Examples();
-			ConsolePrintFormat( sText, "%s  %s 00 4C FF69", CHC_EXAMPLE, pCommand->m_sName );
-			ConsolePrintFormat( sText, "%s  00:4C FF69", CHC_EXAMPLE );
+			ConsolePrintFormat( "%s  %s 00 4C FF69", CHC_EXAMPLE, pCommand->m_sName );
+			ConsolePrintFormat( "%s  00:4C FF69", CHC_EXAMPLE );
 			break;
 		case CMD_MEMORY_ENTER_WORD:
-			ConsoleColorizePrint( sTemp, " Usage: <address | symbol> #### [#### ... ####]" );
-			ConsoleBufferPush( TEXT("  Sets memory to the specified 16-Bit Values (words)" ) );
+			ConsoleColorizePrint( " Usage: <address | symbol> #### [#### ... ####]" );
+			ConsoleBufferPush( "  Sets memory to the specified 16-Bit Values (words)" );
 			break;
 		case CMD_MEMORY_FILL:
-			ConsoleColorizePrint( sTemp, " Usage: <address | symbol> <address | symbol> ##" );
-			ConsoleBufferPush( TEXT("  Fills the memory range with the specified byte" ) );
-			ConsoleColorizePrintFormat( sTemp, sText, " Note: Can't fill IO addresses %s$%sC0xx", CHC_ARG_SEP, CHC_ADDRESS );
+			ConsoleColorizePrint( " Usage: <address | symbol> <address | symbol> ##" );
+			ConsoleBufferPush( "  Fills the memory range with the specified byte" );
+			ConsoleColorizePrintFormat( " Note: Can't fill IO addresses %s$%sC0xx", CHC_ARG_SEP, CHC_ADDRESS );
 			Help_Examples();
-			ConsolePrintFormat( sText, "%s  %s 2000:3FFF 00   // Clear HGR page 1", CHC_EXAMPLE, pCommand->m_sName );
-			ConsolePrintFormat( sText, "%s  %s 4000,2000 00   // Clear HGR page 2", CHC_EXAMPLE, pCommand->m_sName );
-			ConsolePrintFormat( sText, "%s  %s 2000 3FFF 00   // Clear HGR page 1", CHC_EXAMPLE, pCommand->m_sName );
+			ConsolePrintFormat( "%s  %s 2000:3FFF 00   // Clear HGR page 1", CHC_EXAMPLE, pCommand->m_sName );
+			ConsolePrintFormat( "%s  %s 4000,2000 00   // Clear HGR page 2", CHC_EXAMPLE, pCommand->m_sName );
+			ConsolePrintFormat( "%s  %s 2000 3FFF 00   // Clear HGR page 1", CHC_EXAMPLE, pCommand->m_sName );
 			break;
 		case CMD_MEMORY_MOVE:
-			ConsoleColorizePrint( sTemp, " Usage: destination range" );
-			ConsoleBufferPush( TEXT("  Copies bytes specified by the range to the destination starting address." ) );
+			ConsoleColorizePrint( " Usage: destination range" );
+			ConsoleBufferPush( "  Copies bytes specified by the range to the destination starting address." );
 			Help_Examples();
-			ConsolePrintFormat( sText, "%s  %s 4000 2000:3FFF   // move HGR page 1 to page 2", CHC_EXAMPLE, pCommand->m_sName );
-			ConsolePrintFormat( sText, "%s  %s 2001 2000:3FFF   // clear $2000-$3FFF with the byte at $2000", CHC_EXAMPLE, pCommand->m_sName );
-			ConsolePrintFormat( sText, "%s  2001<2000:3FFFM", CHC_EXAMPLE );
+			ConsolePrintFormat( "%s  %s 4000 2000:3FFF   // move HGR page 1 to page 2", CHC_EXAMPLE, pCommand->m_sName );
+			ConsolePrintFormat( "%s  %s 2001 2000:3FFF   // clear $2000-$3FFF with the byte at $2000", CHC_EXAMPLE, pCommand->m_sName );
+			ConsolePrintFormat( "%s  2001<2000:3FFFM", CHC_EXAMPLE );
 			break;
 //		case CMD_MEM_MINI_DUMP_ASC_1:
 //		case CMD_MEM_MINI_DUMP_ASC_2:
 		case CMD_MEM_MINI_DUMP_ASCII_1:
 		case CMD_MEM_MINI_DUMP_ASCII_2:
-			ConsoleColorizePrint( sTemp, " Usage: <address | symbol>" );
-			ConsoleBufferPush( TEXT("  Displays ASCII text in the Mini-Memory area") ); 
-			ConsoleBufferPush( TEXT("  ASCII control chars are hilighted") );
-			ConsoleBufferPush( TEXT("  ASCII hi-bit chars are normal") ); 
+			ConsoleColorizePrint( " Usage: <address | symbol>" );
+			ConsoleBufferPush( "  Displays ASCII text in the Mini-Memory area" ); 
+			ConsoleBufferPush( "  ASCII control chars are hilighted" );
+			ConsoleBufferPush( "  ASCII hi-bit chars are normal" ); 
 //			break;
 //		case CMD_MEM_MINI_DUMP_TXT_LO_1:
 //		case CMD_MEM_MINI_DUMP_TXT_LO_2:
 		case CMD_MEM_MINI_DUMP_APPLE_1:
 		case CMD_MEM_MINI_DUMP_APPLE_2:
-			ConsoleColorizePrint( sTemp, " Usage: <address | symbol>" );
+			ConsoleColorizePrint( " Usage: <address | symbol>" );
 			ConsoleBufferPush( "  Displays APPLE text in the Mini-Memory area" ); 
 			ConsoleBufferPush( "  APPLE control chars are inverse" );
 			ConsoleBufferPush( "  APPLE hi-bit chars are normal"   ); 
 			break;
 //		case CMD_MEM_MINI_DUMP_TXT_HI_1:
 //		case CMD_MEM_MINI_DUMP_TXT_HI_2:
-//			ConsoleBufferPush( TEXT(" Usage: <address | symbol>") ); 
-//			ConsoleBufferPush( TEXT("  Displays text in the Memory Mini-Dump area") ); 
-//			ConsoleBufferPush( TEXT("  ASCII chars with the hi-bit set, is inverse") ); 
+//			ConsoleBufferPush( " Usage: <address | symbol>" ); 
+//			ConsoleBufferPush( "  Displays text in the Memory Mini-Dump area" ); 
+//			ConsoleBufferPush( "  ASCII chars with the hi-bit set, is inverse" ); 
 			break;
 
 		case CMD_MEMORY_LOAD:
 		case CMD_MEMORY_SAVE:
 			if (iCommand == CMD_MEMORY_LOAD)
 			{
-				ConsoleColorizePrint( sTemp, " Usage: [\"Filename\"],[bank:]address[,length]" );
-				ConsoleColorizePrint( sTemp, " Usage: [\"Filename\"],[bank:]range"            );
+				ConsoleColorizePrint( " Usage: [\"Filename\"],[bank:]address[,length]" );
+				ConsoleColorizePrint( " Usage: [\"Filename\"],[bank:]range"            );
 				Help_Range();
 				ConsoleBufferPush( "  Notes: If no filename specified, defaults to the last filename (if possible)" );
 			}
 			if (iCommand == CMD_MEMORY_SAVE)
 			{			
-				ConsoleColorizePrint( sTemp, " Usage: [\"Filename\"],[bank:]address,length" );
-				ConsoleColorizePrint( sTemp, " Usage: [\"Filename\"],[bank:]range"          );
+				ConsoleColorizePrint( " Usage: [\"Filename\"],[bank:]address,length" );
+				ConsoleColorizePrint( " Usage: [\"Filename\"],[bank:]range"          );
 				Help_Range();
 				ConsoleBufferPush( "  Notes: If no filename specified, defaults to: '####.####.[bank##].bin'" );
 				ConsoleBufferPush( "    Where the form is <address>.<length>.bin"                    );
 			}
 			
-//			ConsoleBufferPush( TEXT(" Examples:" ) );
+//			ConsoleBufferPush( " Examples:" );
 			Help_Examples();
-			ConsolePrintFormat( sText, "%s   BSAVE \"test\",FF00,100"  , CHC_EXAMPLE );
-			ConsolePrintFormat( sText, "%s   BLOAD \"test\",2000:2010" , CHC_EXAMPLE );
-			ConsolePrintFormat( sText, "%s   BSAVE \"test\",F000:FFFF" , CHC_EXAMPLE );
-			ConsolePrintFormat( sText, "%s   BLOAD \"test\",4000"      , CHC_EXAMPLE );
-			ConsolePrintFormat( sText, "%s   BLOAD \"main.bin\",0:2000" , CHC_EXAMPLE );
-			ConsolePrintFormat( sText, "%s   BSAVE \"aux2.bin\",1:2000" , CHC_EXAMPLE );
-			ConsolePrintFormat( sText, "%s   BSAVE \"main.bin\",0:2000,2000" , CHC_EXAMPLE );
-			ConsolePrintFormat( sText, "%s   BSAVE \"aux2.bin\",1:2000:3FFF" , CHC_EXAMPLE );
+			ConsolePrintFormat( "%s   BSAVE \"test\",FF00,100"  , CHC_EXAMPLE );
+			ConsolePrintFormat( "%s   BLOAD \"test\",2000:2010" , CHC_EXAMPLE );
+			ConsolePrintFormat( "%s   BSAVE \"test\",F000:FFFF" , CHC_EXAMPLE );
+			ConsolePrintFormat( "%s   BLOAD \"test\",4000"      , CHC_EXAMPLE );
+			ConsolePrintFormat( "%s   BLOAD \"main.bin\",0:2000" , CHC_EXAMPLE );
+			ConsolePrintFormat( "%s   BSAVE \"aux2.bin\",1:2000" , CHC_EXAMPLE );
+			ConsolePrintFormat( "%s   BSAVE \"main.bin\",0:2000,2000" , CHC_EXAMPLE );
+			ConsolePrintFormat( "%s   BSAVE \"aux2.bin\",1:2000:3FFF" , CHC_EXAMPLE );
 			break;
 		case CMD_MEMORY_SEARCH:
-			ConsoleColorizePrint( sText, " Usage: range <\"ASCII text\" | 'apple text' | hex>" );
+			ConsoleColorizePrint( " Usage: range <\"ASCII text\" | 'apple text' | hex>" );
 			Help_Range();
 			ConsoleBufferPush( "  Where text is of the form:"            );
 			ConsoleBufferPush( "    \"...\" designate ASCII text"        );
 			ConsoleBufferPush( "    '...' designate Apple High-Bit text" );
 			Help_Examples();
-			ConsolePrintFormat( sText, "%s  %s F000,1000 'Apple'   // search High-Bit", CHC_EXAMPLE, pCommand->m_sName );
-			ConsolePrintFormat( sText, "%s  MT1 @2"                                   , CHC_EXAMPLE                    );
-			ConsolePrintFormat( sText, "%s  %s D000:FFFF \"FLAS\"    // search ASCII ", CHC_EXAMPLE, pCommand->m_sName );
-			ConsolePrintFormat( sText, "%s  MA1 @1"                                   , CHC_EXAMPLE                    );
-			ConsolePrintFormat( sText, "%s  %s D000,4000 \"EN\" 'D'  // Mixed text"   , CHC_EXAMPLE, pCommand->m_sName );
-			ConsolePrintFormat( sText, "%s  MT1 @1"                                   , CHC_EXAMPLE                    );
-			ConsolePrintFormat( sText, "%s  %s D000,4000 'Apple' ? ']'"               , CHC_EXAMPLE, pCommand->m_sName );
+			ConsolePrintFormat( "%s  %s F000,1000 'Apple'   // search High-Bit", CHC_EXAMPLE, pCommand->m_sName );
+			ConsolePrintFormat( "%s  MT1 @2"                                   , CHC_EXAMPLE                    );
+			ConsolePrintFormat( "%s  %s D000:FFFF \"FLAS\"    // search ASCII ", CHC_EXAMPLE, pCommand->m_sName );
+			ConsolePrintFormat( "%s  MA1 @1"                                   , CHC_EXAMPLE                    );
+			ConsolePrintFormat( "%s  %s D000,4000 \"EN\" 'D'  // Mixed text"   , CHC_EXAMPLE, pCommand->m_sName );
+			ConsolePrintFormat( "%s  MT1 @1"                                   , CHC_EXAMPLE                    );
+			ConsolePrintFormat( "%s  %s D000,4000 'Apple' ? ']'"               , CHC_EXAMPLE, pCommand->m_sName );
 			break;
 		case CMD_MEMORY_SEARCH_HEX:
-			ConsoleColorizePrint( sText, " Usage: range [text | byte1 [byte2 ...]]" );
+			ConsoleColorizePrint( " Usage: range [text | byte1 [byte2 ...]]" );
 			Help_Range();
 			ConsoleBufferPush( "  Where <byte> is of the form:" );
 			ConsoleBufferPush( "    ##   match specific byte"   );
@@ -1315,78 +1286,78 @@ Update_t CmdHelpSpecific (int nArgs)
 			ConsoleBufferPush( "    ?#   match any high nibble, match low nibble to specific number" );
 			ConsoleBufferPush( "    #?   match specific high nibble, match any low nibble"           );
 			Help_Examples();
-			ConsolePrintFormat( sText, "%s   %s F000,1000 AD ? C0", CHC_EXAMPLE, pCommand->m_sName );
-			ConsolePrintFormat( sText, "%s   U @1"                , CHC_EXAMPLE                    );
-			ConsolePrintFormat( sText, "%s   %s F000,1000 ?1 C0"  , CHC_EXAMPLE, pCommand->m_sName );
-			ConsolePrintFormat( sText, "%s   %s F000,1000 5? C0"  , CHC_EXAMPLE, pCommand->m_sName );
-			ConsolePrintFormat( sText, "%s   %s F000,1000 10 C?"  , CHC_EXAMPLE, pCommand->m_sName );
-			ConsolePrintFormat( sText, "%s   U @2 - 1"            , CHC_EXAMPLE                    );
-			ConsolePrintFormat( sText, "%s   %s F000:FFFF C030"   , CHC_EXAMPLE, pCommand->m_sName );
-			ConsolePrintFormat( sText, "%s   U @1 - 1"            , CHC_EXAMPLE                    );
+			ConsolePrintFormat( "%s   %s F000,1000 AD ? C0", CHC_EXAMPLE, pCommand->m_sName );
+			ConsolePrintFormat( "%s   U @1"                , CHC_EXAMPLE                    );
+			ConsolePrintFormat( "%s   %s F000,1000 ?1 C0"  , CHC_EXAMPLE, pCommand->m_sName );
+			ConsolePrintFormat( "%s   %s F000,1000 5? C0"  , CHC_EXAMPLE, pCommand->m_sName );
+			ConsolePrintFormat( "%s   %s F000,1000 10 C?"  , CHC_EXAMPLE, pCommand->m_sName );
+			ConsolePrintFormat( "%s   U @2 - 1"            , CHC_EXAMPLE                    );
+			ConsolePrintFormat( "%s   %s F000:FFFF C030"   , CHC_EXAMPLE, pCommand->m_sName );
+			ConsolePrintFormat( "%s   U @1 - 1"            , CHC_EXAMPLE                    );
 			break;
 //		case CMD_MEMORY_SEARCH_APPLE:
-//			ConsoleBufferPushFormat( sText,   TEXT("Deprecated.  Use: %s" ), g_aCommands[ CMD_MEMORY_SEARCH ].m_sName );
+//			ConsoleBufferPushFormat( "Deprecated.  Use: %s", g_aCommands[ CMD_MEMORY_SEARCH ].m_sName );
 //			break;
 //		case CMD_MEMORY_SEARCH_ASCII:
-//			ConsoleBufferPushFormat( sText,   TEXT("Deprecated.  Use: %s" ), g_aCommands[ CMD_MEMORY_SEARCH ].m_sName );
+//			ConsoleBufferPushFormat( "Deprecated.  Use: %s", g_aCommands[ CMD_MEMORY_SEARCH ].m_sName );
 //			break;
 	// Output
 		case CMD_OUTPUT_CALC:
-			ConsoleColorizePrint( sText, " Usage: <address | symbol | expression >" );
+			ConsoleColorizePrint( " Usage: <address | symbol | expression >" );
 			ConsoleBufferPush( "  Operator is one of: + - * / % ^ ~"    );
 			ConsoleBufferPush( " Output order is: Hex Bin Dec Char"     );
 			ConsoleBufferPush( "  Note: symbols take priority."         );
 			ConsoleBufferPush( "  Note: #A (if you don't want the accumulator value)" );
 			ConsoleBufferPush( "  Note: #F (if you don't want the flags value)"  );
 			Help_Examples();
-			ConsolePrintFormat( sText, "%s   CALC 5 + #A", CHC_EXAMPLE );
-			ConsolePrintFormat( sText, "%s   CALC 80 * 2", CHC_EXAMPLE );
-			ConsoleColorizePrint( sText, " See also: " CHC_COMMAND "HELP OP"          );
+			ConsolePrintFormat( "%s   CALC 5 + #A", CHC_EXAMPLE );
+			ConsolePrintFormat( "%s   CALC 80 * 2", CHC_EXAMPLE );
+			ConsoleColorizePrint( " See also: " CHC_COMMAND "HELP OP"          );
 			break;
 		case CMD_OUTPUT_ECHO:
-			ConsoleColorizePrint( sText, " Usage: string"    );
+			ConsoleColorizePrint( " Usage: string"    );
 //			ConsoleBufferPush( TEXT(" Examples:"        ) );
 			Help_Examples();
-			ConsolePrintFormat( sText,   "%s   %s Checkpoint", CHC_EXAMPLE, pCommand->m_sName );
-			ConsolePrintFormat( sText,   "%s   %s PC"        , CHC_EXAMPLE, pCommand->m_sName );
+			ConsolePrintFormat( "%s   %s Checkpoint", CHC_EXAMPLE, pCommand->m_sName );
+			ConsolePrintFormat( "%s   %s PC"        , CHC_EXAMPLE, pCommand->m_sName );
 //			ConsoleBufferPush( TEXT("  Echo the string to the console" ) );
 			break;
 		case CMD_OUTPUT_PRINT: 
-			ConsoleColorizePrint( sText, " Usage: <string | expression> [, string | expression]*"       );
-			ConsoleColorizePrint( sText, "  Note: To print Register values, they must be in upper case" );
+			ConsoleColorizePrint( " Usage: <string | expression> [, string | expression]*"       );
+			ConsoleColorizePrint( "  Note: To print Register values, they must be in upper case" );
 			Help_Examples();
-			ConsolePrintFormat( sText, "%s   %s \"A:\",A,\" X:\",X", CHC_EXAMPLE, pCommand->m_sName );
-			ConsolePrintFormat( sText, "%s   %s A,\" \",X,\" \",Y" , CHC_EXAMPLE, pCommand->m_sName );
-			ConsolePrintFormat( sText, "%s   %s PC"                , CHC_EXAMPLE, pCommand->m_sName );
+			ConsolePrintFormat( "%s   %s \"A:\",A,\" X:\",X", CHC_EXAMPLE, pCommand->m_sName );
+			ConsolePrintFormat( "%s   %s A,\" \",X,\" \",Y" , CHC_EXAMPLE, pCommand->m_sName );
+			ConsolePrintFormat( "%s   %s PC"                , CHC_EXAMPLE, pCommand->m_sName );
 			break;
 		case CMD_OUTPUT_PRINTF:
-			ConsoleColorizePrint( sText,   " Usage: <string> [, expression, ...]" );
+			ConsoleColorizePrint( " Usage: <string> [, expression, ...]" );
 			ConsoleBufferPush( "  The string may contain c-style printf formatting flags: %d %x %z %c" );
 			ConsoleBufferPush( "  Where: %d decimal, %x hex, %z binary, %c char, %% percent"           );
 			Help_Examples();
-			ConsolePrintFormat( sText, "%s   %s \"Dec: %%d  Hex: %%x  Bin: %%z  Char: %%c\",A,A,A,A", CHC_EXAMPLE, pCommand->m_sName );
-			ConsolePrintFormat( sText, "%s   %s \"%%x %%x %%x\",A,X,Y"                             , CHC_EXAMPLE, pCommand->m_sName );
+			ConsolePrintFormat( "%s   %s \"Dec: %%d  Hex: %%x  Bin: %%z  Char: %%c\",A,A,A,A", CHC_EXAMPLE, pCommand->m_sName );
+			ConsolePrintFormat( "%s   %s \"%%x %%x %%x\",A,X,Y"                             , CHC_EXAMPLE, pCommand->m_sName );
 			break;
 	// Symbols
 		case CMD_SYMBOLS_LOOKUP:
-			ConsoleColorizePrint( sText, " Usage: symbol [= <address>]" );
-			ConsolePrintFormat( sText, "       %s\"%ssymbol%s\" = %saddress"
+			ConsoleColorizePrint( " Usage: symbol [= <address>]" );
+			ConsolePrintFormat( "       %s\"%ssymbol%s\" = %saddress"
 				, CHC_ARG_MAND
 				, CHC_SYMBOL
 				, CHC_ARG_MAND
 				, CHC_ADDRESS
 			);
-			ConsoleColorizePrint( sText, " Note: Valid characters are any characters above ASCII space ($20)." );
-			ConsolePrintFormat( sText, " You %sMUST%s double-quote names containing special characters to be recognized."
+			ConsoleColorizePrint( " Note: Valid characters are any characters above ASCII space ($20)." );
+			ConsolePrintFormat( " You %sMUST%s double-quote names containing special characters to be recognized."
 				, CHC_WARNING
 				, CHC_DEFAULT
 			);
 			Help_Examples();
-			ConsolePrintFormat( sText, "%s   %s HOME"          , CHC_EXAMPLE, pCommand->m_sName );
-			ConsolePrintFormat( sText, "%s   %s LIFE = 2000"   , CHC_EXAMPLE, pCommand->m_sName );
-			ConsolePrintFormat( sText, "%s   %s LIFE"          , CHC_EXAMPLE, pCommand->m_sName );
-			ConsolePrintFormat( sText, "%s   %s \"PR#\" = FE95", CHC_EXAMPLE, pCommand->m_sName );
-			ConsolePrintFormat( sText, "%s   %s \"PR#\""       , CHC_EXAMPLE, pCommand->m_sName );
+			ConsolePrintFormat( "%s   %s HOME"          , CHC_EXAMPLE, pCommand->m_sName );
+			ConsolePrintFormat( "%s   %s LIFE = 2000"   , CHC_EXAMPLE, pCommand->m_sName );
+			ConsolePrintFormat( "%s   %s LIFE"          , CHC_EXAMPLE, pCommand->m_sName );
+			ConsolePrintFormat( "%s   %s \"PR#\" = FE95", CHC_EXAMPLE, pCommand->m_sName );
+			ConsolePrintFormat( "%s   %s \"PR#\""       , CHC_EXAMPLE, pCommand->m_sName );
 			break;
 		case CMD_SYMBOLS_ROM:
 		case CMD_SYMBOLS_APPLESOFT:
@@ -1395,29 +1366,29 @@ Update_t CmdHelpSpecific (int nArgs)
 		case CMD_SYMBOLS_USER_2:
 		case CMD_SYMBOLS_SRC_1:
 		case CMD_SYMBOLS_SRC_2:
-//			ConsoleBufferPush( TEXT(" Usage: [ ON | OFF | symbol | address ]" ) );
-//			ConsoleBufferPush( TEXT(" Usage: [ LOAD [\"filename\"] | SAVE \"filename\"]" ) ); 
-//			ConsoleBufferPush( TEXT("  ON  : Turns symbols on in the disasm window" ) );
-//			ConsoleBufferPush( TEXT("  OFF : Turns symbols off in the disasm window" ) );
-//			ConsoleBufferPush( TEXT("  LOAD: Loads symbols from last/default filename" ) );
-//			ConsoleBufferPush( TEXT("  SAVE: Saves symbol table to file" ) );
-//			ConsoleBufferPush( TEXT(" CLEAR: Clears the symbol table" ) );
-			ConsoleColorizePrint( sText, " Usage: [ <cmd> | symbol | address ]" );
+//			ConsoleBufferPush( " Usage: [ ON | OFF | symbol | address ]" );
+//			ConsoleBufferPush( " Usage: [ LOAD [\"filename\"] | SAVE \"filename\"]" ); 
+//			ConsoleBufferPush( "  ON  : Turns symbols on in the disasm window" );
+//			ConsoleBufferPush( "  OFF : Turns symbols off in the disasm window" );
+//			ConsoleBufferPush( "  LOAD: Loads symbols from last/default filename" );
+//			ConsoleBufferPush( "  SAVE: Saves symbol table to file" );
+//			ConsoleBufferPush( " CLEAR: Clears the symbol table" );
+			ConsoleColorizePrint( " Usage: [ <cmd> | symbol | address ]" );
 			ConsoleBufferPush( "  Where <cmd> is one of:" );
-			ConsolePrintFormat( sText, "%s%-5s%s: Turns symbols on in the disasm window"       , CHC_STRING, g_aParameters[ PARAM_ON    ].m_sName, CHC_DEFAULT );
-			ConsolePrintFormat( sText, "%s%-5s%s: Turns symbols off in the disasm window"      , CHC_STRING, g_aParameters[ PARAM_OFF   ].m_sName, CHC_DEFAULT );
-			ConsolePrintFormat( sText, "%s%-5s%s: Loads symbols from last/default \"filename\"", CHC_STRING, g_aParameters[ PARAM_LOAD  ].m_sName, CHC_DEFAULT ); // 2.6.2.14 Fixed: Save/Load Param help was swapped.
-			ConsolePrintFormat( sText, "%s%-5s%s: Saves symbol table to \"filename\""          , CHC_STRING, g_aParameters[ PARAM_SAVE  ].m_sName, CHC_DEFAULT ); // 2.6.2.14 Fixed: Save/Load Param help was swapped.
-			ConsolePrintFormat( sText, "%s%-5s%s: Clears the symbol table"                     , CHC_STRING, g_aParameters[ PARAM_CLEAR ].m_sName, CHC_DEFAULT );
-			ConsolePrintFormat( sText, "%s%-5s%s: Remove symbol"                               , CHC_STRING, g_aTokens[ TOKEN_EXCLAMATION ].sToken, CHC_DEFAULT );
+			ConsolePrintFormat( "%s%-5s%s: Turns symbols on in the disasm window"       , CHC_STRING, g_aParameters[ PARAM_ON    ].m_sName, CHC_DEFAULT );
+			ConsolePrintFormat( "%s%-5s%s: Turns symbols off in the disasm window"      , CHC_STRING, g_aParameters[ PARAM_OFF   ].m_sName, CHC_DEFAULT );
+			ConsolePrintFormat( "%s%-5s%s: Loads symbols from last/default \"filename\"", CHC_STRING, g_aParameters[ PARAM_LOAD  ].m_sName, CHC_DEFAULT ); // 2.6.2.14 Fixed: Save/Load Param help was swapped.
+			ConsolePrintFormat( "%s%-5s%s: Saves symbol table to \"filename\""          , CHC_STRING, g_aParameters[ PARAM_SAVE  ].m_sName, CHC_DEFAULT ); // 2.6.2.14 Fixed: Save/Load Param help was swapped.
+			ConsolePrintFormat( "%s%-5s%s: Clears the symbol table"                     , CHC_STRING, g_aParameters[ PARAM_CLEAR ].m_sName, CHC_DEFAULT );
+			ConsolePrintFormat( "%s%-5s%s: Remove symbol"                               , CHC_STRING, g_aTokens[ TOKEN_EXCLAMATION ].sToken, CHC_DEFAULT );
 			break;
 		case CMD_SYMBOLS_LIST :
-			ConsoleColorizePrint( sText, " Usage: symbol" );
+			ConsoleColorizePrint( " Usage: symbol" );
 			ConsoleBufferPush( "  Looks up symbol in all 3 symbol tables: main, user, source" );
 			break;
 // Cycles
 		case CMD_CYCLES_INFO:
-			ConsoleColorizePrint(sText, " Usage: <abs|rel|part>");
+			ConsoleColorizePrint(" Usage: <abs|rel|part>");
 			ConsoleBufferPush("  Where:");
 			ConsoleBufferPush("    abs = absolute number of cycles since power-on");
 			ConsoleBufferPush("    rel = number of cycles since last step or breakpoint");
@@ -1429,17 +1400,14 @@ Update_t CmdHelpSpecific (int nArgs)
 // Video-Scanner
 
 		case CMD_VIDEO_SCANNER_INFO:
-			ConsoleColorizePrint(sText, " Usage: <dec|hex|real|apple>");
+			ConsoleColorizePrint(" Usage: <dec|hex|real|apple>");
 			ConsoleBufferPush("  Where:");
 			ConsoleBufferPush("    <dec|hex> changes output to dec/hex");
 			ConsoleBufferPush("    <real|apple> alters horz value to hbl-l,visible,hbl-r or hbl-r+l,visible");
-			{
-				char sText2[CONSOLE_WIDTH];
-				ConsolePrintFormat(sText2, "    %sYellow%s=invisible (hbl or vbl active) / %sGreen%s=visible"
-					,CHC_INFO   , CHC_DEFAULT	// yellow
-					,CHC_COMMAND, CHC_DEFAULT	// green
-				);
-			}
+			ConsolePrintFormat("    %sYellow%s=invisible (hbl or vbl active) / %sGreen%s=visible"
+				,CHC_INFO   , CHC_DEFAULT	// yellow
+				,CHC_COMMAND, CHC_DEFAULT	// green
+			);
 			break;
 // View
 		case CMD_VIEW_TEXT4X:
@@ -1464,7 +1432,7 @@ Update_t CmdHelpSpecific (int nArgs)
 			break;
 	// Watches
 		case CMD_WATCH_ADD:
-			ConsoleColorizePrint( sText, " Usage: <address | symbol>" );
+			ConsoleColorizePrint( " Usage: <address | symbol>" );
 			ConsoleBufferPush( "  Adds the specified memory location to the watch window." );
 			break;
 	// Window
@@ -1475,20 +1443,20 @@ Update_t CmdHelpSpecific (int nArgs)
 	// Zero Page pointers
 		case CMD_ZEROPAGE_POINTER:
 		case CMD_ZEROPAGE_POINTER_ADD:
-			ConsoleColorizePrint( sText, " Usage: <address | symbol>" );
-			ConsoleColorizePrint( sText, " Usage: # <address | symbol> [address...]" );
+			ConsoleColorizePrint( " Usage: <address | symbol>" );
+			ConsoleColorizePrint( " Usage: # <address | symbol> [address...]" );
 			ConsoleBufferPush("  Adds the specified memory location to the zero page pointer window." );
 			ConsoleBufferPush("  Update the specified zero page pointer (#) with the address." );
 			ConsoleBufferPush(" Note: Displayed as symbol name (if possible) and the 16-bit target pointer" );
 			Help_Examples();
-			ConsolePrintFormat( sText, "%s   %s CH"     , CHC_EXAMPLE, pCommand->m_sName );
-			ConsolePrintFormat( sText, "%s   %s 0 CV"   , CHC_EXAMPLE, pCommand->m_sName );
-			ConsolePrintFormat( sText, "%s   %s 0 CV CH", CHC_EXAMPLE, pCommand->m_sName );
+			ConsolePrintFormat( "%s   %s CH"     , CHC_EXAMPLE, pCommand->m_sName );
+			ConsolePrintFormat( "%s   %s 0 CV"   , CHC_EXAMPLE, pCommand->m_sName );
+			ConsolePrintFormat( "%s   %s 0 CV CH", CHC_EXAMPLE, pCommand->m_sName );
 			break;
 		case CMD_ZEROPAGE_POINTER_CLEAR:
-			ConsoleColorizePrint( sText, " Usage: [# | *]" );
+			ConsoleColorizePrint( " Usage: [# | *]" );
 			ConsoleBufferPush( "  Clears specified zero page pointer, or all." );
-			ConsolePrintFormat( sText,  "  i.e. %s%s 1", CHC_EXAMPLE, pCommand->m_sName );
+			ConsolePrintFormat( "  i.e. %s%s 1", CHC_EXAMPLE, pCommand->m_sName );
 			break;
 		case CMD_ZEROPAGE_POINTER_0:
 		case CMD_ZEROPAGE_POINTER_1:
@@ -1498,13 +1466,13 @@ Update_t CmdHelpSpecific (int nArgs)
 		case CMD_ZEROPAGE_POINTER_5:
 		case CMD_ZEROPAGE_POINTER_6:
 		case CMD_ZEROPAGE_POINTER_7:
-			ConsoleColorizePrint( sText, " Usage: [<address | symbol>]" );
+			ConsoleColorizePrint( " Usage: [<address | symbol>]" );
 			ConsoleBufferPush( "  If no address specified, will remove watching the zero page pointer." );
 			break;
 
 	// Misc
 		case CMD_VERSION:
-			ConsoleColorizePrint( sText, " Usage: [*]" );
+			ConsoleColorizePrint( " Usage: [*]" );
 			ConsoleBufferPush( "  * Display extra internal stats" );
 			break;
 
@@ -1520,7 +1488,7 @@ Update_t CmdHelpSpecific (int nArgs)
 			{
 //#if DEBUG_COMMAND_HELP
 #if _DEBUG
-			ConsoleBufferPushFormat( sText, "Command help not done yet!: %s", g_aCommands[ iCommand ].m_sName );
+			ConsoleBufferPushFormat( "Command help not done yet!: %s", g_aCommands[ iCommand ].m_sName );
 #endif
 			}
 
@@ -1600,8 +1568,6 @@ Update_t CmdHelpList (int nArgs)
 //===========================================================================
 Update_t CmdVersion (int nArgs)
 {
-	TCHAR sText[ CONSOLE_WIDTH ];
-
 	unsigned int nVersion = DEBUGGER_VERSION;
 	int nMajor;
 	int nMinor;
@@ -1609,7 +1575,7 @@ Update_t CmdVersion (int nArgs)
 	int nFixMinor;
 	UnpackVersion( nVersion, nMajor, nMinor, nFixMajor, nFixMinor );
 
-	ConsolePrintFormat( sText, "  Emulator:  %s%s%s    Debugger: %s%d.%d.%d.%d%s"
+	ConsolePrintFormat( "  Emulator:  %s%s%s    Debugger: %s%d.%d.%d.%d%s"
 		, CHC_SYMBOL
 		, g_VERSIONSTRING.c_str()
 		, CHC_DEFAULT
@@ -1626,16 +1592,16 @@ Update_t CmdVersion (int nArgs)
 			if ((! _tcscmp( g_aArgs[ iArg ].sArg, g_aParameters[ PARAM_WILDSTAR        ].m_sName )) ||
 				(! _tcscmp( g_aArgs[ iArg ].sArg, g_aParameters[ PARAM_MEM_SEARCH_WILD ].m_sName )) )
 			{
-				ConsoleBufferPushFormat( sText, "  Arg: %d bytes * %d = %d bytes",
+				ConsoleBufferPushFormat( "  Arg: %d bytes * %d = %d bytes",
 					sizeof(Arg_t), MAX_ARGS, sizeof(g_aArgs) );
 
-				ConsoleBufferPushFormat( sText, "  Console: %d bytes * %d height = %d bytes",
+				ConsoleBufferPushFormat( "  Console: %d bytes * %d height = %d bytes",
 					sizeof( g_aConsoleDisplay[0] ), CONSOLE_HEIGHT, sizeof(g_aConsoleDisplay) );
 
-				ConsoleBufferPushFormat( sText, "  Commands: %d   (Aliased: %d)   Params: %d",
+				ConsoleBufferPushFormat( "  Commands: %d   (Aliased: %d)   Params: %d",
 					NUM_COMMANDS, NUM_COMMANDS_WITH_ALIASES, NUM_PARAMS );
 
-				ConsoleBufferPushFormat( sText, "  Cursor(%d)  T: %04X  C: %04X  B: %04X %c D: %02X", // Top, Cur, Bot, Delta
+				ConsoleBufferPushFormat( "  Cursor(%d)  T: %04X  C: %04X  B: %04X %c D: %02X", // Top, Cur, Bot, Delta
 					g_nDisasmCurLine, g_nDisasmTopAddress, g_nDisasmCurAddress, g_nDisasmBotAddress,
 					g_bDisasmCurBad ? TEXT('*') : TEXT(' ')
 					, g_nDisasmBotAddress - g_nDisasmTopAddress

--- a/source/Debugger/Debugger_Symbols.cpp
+++ b/source/Debugger/Debugger_Symbols.cpp
@@ -96,7 +96,7 @@ Update_t _PrintSymbolInvalidTable()
 	// TODO: display the user specified file name
 	ConsoleBufferPush( "Invalid symbol table." );
 
-	ConsolePrintFormat( sText, "Only %s%d%s symbol tables are supported:"
+	ConsolePrintFormat( "Only %s%d%s symbol tables are supported:"
 		, CHC_NUM_DEC, NUM_SYMBOL_TABLES
 		, CHC_DEFAULT
 	);
@@ -360,13 +360,11 @@ Update_t CmdSymbolsInfo (int nArgs)
 //===========================================================================
 void _CmdPrintSymbol( LPCTSTR pSymbol, WORD nAddress, int iTable )
 {
-	char   sText[ CONSOLE_WIDTH * 2 ];
-
 	// 2.6.2.19 Color for name of symbol table: _CmdPrintSymbol() "SYM HOME" _CmdSymbolsInfoHeader "SYM"
 	// CHC_STRING and CHC_NUM_DEC are both cyan, using CHC_USAGE instead of CHC_STRING
 
 	// 2.6.2.20 Changed: Output of found symbol more table friendly.  Symbol table name displayed first.
-	ConsolePrintFormat( sText, "  %s%s%s: $%s%04X %s%s"
+	ConsolePrintFormat( "  %s%s%s: $%s%04X %s%s"
 		, CHC_USAGE, g_aSymbolTableNames[ iTable ]
 		, CHC_ARG_SEP
 		, CHC_ADDRESS, nAddress
@@ -522,8 +520,7 @@ Update_t _CmdSymbolsListTables (int nArgs, int bSymbolTables )
 				// nope, ok, try as address
 				if (! _CmdSymbolList_Address2Symbol( nAddress, bSymbolTables))
 				{
-					ConsolePrintFormat( sText
-						, TEXT(" Address not found: %s$%s%04X%s" )
+					ConsolePrintFormat( " Address not found: %s$%s%04X%s"
 						, CHC_ARG_SEP
 						, CHC_ADDRESS, nAddress, CHC_DEFAULT );
 				}
@@ -537,16 +534,14 @@ Update_t _CmdSymbolsListTables (int nArgs, int bSymbolTables )
 				{
 					if (! _CmdSymbolList_Address2Symbol( nAddress, bSymbolTables ))
 					{
-						ConsolePrintFormat( sText
-							, TEXT(" %sSymbol not found: %s%s%s")
+						ConsolePrintFormat( " %sSymbol not found: %s%s%s"
 							, CHC_ERROR, CHC_SYMBOL, pSymbol, CHC_DEFAULT
 						);
 					}
 				}
 				else
 				{
-					ConsolePrintFormat( sText
-						, TEXT(" %sSymbol not found: %s%s%s")
+					ConsolePrintFormat( " %sSymbol not found: %s%s%s"
 						, CHC_ERROR, CHC_SYMBOL, pSymbol, CHC_DEFAULT
 					);
 				}
@@ -560,7 +555,6 @@ Update_t _CmdSymbolsListTables (int nArgs, int bSymbolTables )
 //===========================================================================
 int ParseSymbolTable(const std::string & pPathFileName, SymbolTable_Index_e eSymbolTableWrite, int nSymbolOffset )
 {
-	char sText[ CONSOLE_WIDTH * 3 ];
 	bool bFileDisplayed = false;
 
 	const int nMaxLen = MIN(DISASM_DISPLAY_MAX_TARGET_LEN, MAX_SYMBOLS_LEN);
@@ -654,7 +648,7 @@ int ParseSymbolTable(const std::string & pPathFileName, SymbolTable_Index_e eSym
 			int nLen = strlen( sName );
 			if (nLen > nMaxLen)
 			{
-				ConsolePrintFormat( sText, " %sWarn.: %s%s %s(%s%d %s> %s%d%s)"
+				ConsolePrintFormat( " %sWarn.: %s%s %s(%s%d %s> %s%d%s)"
 					, CHC_WARNING
 					, CHC_SYMBOL
 					, sName
@@ -678,13 +672,13 @@ int ParseSymbolTable(const std::string & pPathFileName, SymbolTable_Index_e eSym
 					bFileDisplayed = true;
 
 					// TODO: Must check for buffer overflow !
-					ConsolePrintFormat( sText, "%s%s"
+					ConsolePrintFormat( "%s%s"
 						, CHC_PATH
 						, pPathFileName.c_str()
 					);
 				}
 
-				ConsolePrintFormat( sText, " %sInfo.: %s%-16s %saliases %s$%s%04X %s%-12s%s (%s%s%s)" // MAGIC NUMBER: -MAX_SYMBOLS_LEN
+				ConsolePrintFormat( " %sInfo.: %s%-16s %saliases %s$%s%04X %s%-12s%s (%s%s%s)" // MAGIC NUMBER: -MAX_SYMBOLS_LEN
 					, CHC_INFO // 2.9.0.10 was CHC_WARNING, see #479
 					, CHC_SYMBOL
 					, sName
@@ -702,7 +696,7 @@ int ParseSymbolTable(const std::string & pPathFileName, SymbolTable_Index_e eSym
 
 				ConsoleUpdate(); // Flush buffered output so we don't ask the user to pause
 /*
-				ConsolePrintFormat( sText, " %sWarning: %sAddress already has symbol Name%s (%s%s%s): %s%s"
+				ConsolePrintFormat( " %sWarning: %sAddress already has symbol Name%s (%s%s%s): %s%s"
 					, CHC_WARNING
 					, CHC_INFO
 					, CHC_ARG_SEP
@@ -713,7 +707,7 @@ int ParseSymbolTable(const std::string & pPathFileName, SymbolTable_Index_e eSym
 					, pSymbolPrev
 				);
 
-				ConsolePrintFormat( sText, "  %s$%s%04X %s%-31s%s"
+				ConsolePrintFormat( "  %s$%s%04X %s%-31s%s"
 					, CHC_ARG_SEP
 					, CHC_ADDRESS
 					, nAddress
@@ -730,7 +724,7 @@ int ParseSymbolTable(const std::string & pPathFileName, SymbolTable_Index_e eSym
 				if( !bDupSymbolHeader )
 				{
 					bDupSymbolHeader = true;
-					ConsolePrintFormat( sText, " %sDup Symbol Name%s (%s%s%s) %s"
+					ConsolePrintFormat( " %sDup Symbol Name%s (%s%s%s) %s"
 						, CHC_ERROR
 						, CHC_DEFAULT
 						, CHC_STRING
@@ -740,7 +734,7 @@ int ParseSymbolTable(const std::string & pPathFileName, SymbolTable_Index_e eSym
 					);
 				}
 
-				ConsolePrintFormat( sText, "  %s$%s%04X %s%-31s%s"
+				ConsolePrintFormat( "  %s$%s%04X %s%-31s%s"
 					, CHC_ARG_SEP
 					, CHC_ADDRESS
 					, nAddress
@@ -868,8 +862,7 @@ void SymbolUpdate( SymbolTable_Index_e eSymbolTable, const char *pSymbolName, WO
 
 				if (bUpdateSymbol)
 				{
-					char sText[ CONSOLE_WIDTH * 2 ];
-					ConsolePrintFormat( sText, " Updating %s%s%s from %s$%s%04X%s to %s$%s%04X%s"
+					ConsolePrintFormat( " Updating %s%s%s from %s$%s%04X%s to %s$%s%04X%s"
 						, CHC_SYMBOL, pSymbolName, CHC_DEFAULT
 						, CHC_ARG_SEP					
 						, CHC_ADDRESS, nAddressPrev, CHC_DEFAULT
@@ -899,8 +892,7 @@ void SymbolUpdate( SymbolTable_Index_e eSymbolTable, const char *pSymbolName, WO
 			g_aSymbols[ eSymbolTable ][ nAddress ] = pSymbolName;
 
 			// Tell user symbol was added
-			char sText[ CONSOLE_WIDTH * 2 ];
-			ConsolePrintFormat( sText, " Added symbol: %s%s%s %s$%s%04X%s"
+			ConsolePrintFormat( " Added symbol: %s%s%s %s$%s%04X%s"
 				, CHC_SYMBOL, pSymbolName, CHC_DEFAULT
 				, CHC_ARG_SEP					
 				, CHC_ADDRESS, nAddress, CHC_DEFAULT
@@ -984,7 +976,7 @@ Update_t _CmdSymbolsCommon ( int nArgs, int bSymbolTables )
 				if (iTable != NUM_SYMBOL_TABLES)
 				{
 					Update_t iUpdate = _CmdSymbolsClear( (SymbolTable_Index_e) iTable );
-					ConsolePrintFormat( sText, TEXT(" Cleared symbol table: %s%s")
+					ConsolePrintFormat( " Cleared symbol table: %s%s"
 						, CHC_STRING, g_aSymbolTableNames[ iTable ]
 					 );
 					iUpdate |= ConsoleUpdate();

--- a/source/Debugger/Debugger_Win32.cpp
+++ b/source/Debugger/Debugger_Win32.cpp
@@ -247,9 +247,7 @@ Update_t CmdConfigGetFont(int nArgs)
 	{
 		for (int iFont = 0; iFont < NUM_FONTS; iFont++)
 		{
-			TCHAR sText[CONSOLE_WIDTH] = TEXT("");
-			ConsoleBufferPushFormat(sText, "  Font: %-20s  A:%2d  M:%2d",
-				//				g_sFontNameCustom, g_nFontWidthAvg, g_nFontWidthMax );
+			ConsoleBufferPushFormat("  Font: %-20s  A:%2d  M:%2d",
 				g_aFontConfig[iFont]._sFontName,
 				g_aFontConfig[iFont]._nFontWidthAvg,
 				g_aFontConfig[iFont]._nFontWidthMax);
@@ -276,8 +274,7 @@ Update_t CmdConfigFont(int nArgs)
 			if ((!_tcscmp(g_aArgs[iArg].sArg, g_aParameters[PARAM_WILDSTAR].m_sName)) ||
 				(!_tcscmp(g_aArgs[iArg].sArg, g_aParameters[PARAM_MEM_SEARCH_WILD].m_sName)))
 			{
-				TCHAR sText[CONSOLE_WIDTH];
-				ConsoleBufferPushFormat(sText, "Lines: %d  Font Px: %d  Line Px: %d"
+				ConsoleBufferPushFormat("Lines: %d  Font Px: %d  Line Px: %d"
 					, g_nDisasmDisplayLines
 					, g_aFontConfig[FONT_DISASM_DEFAULT]._nFontHeight
 					, g_aFontConfig[FONT_DISASM_DEFAULT]._nLineHeight);
@@ -355,9 +352,7 @@ void DebuggerMouseClick(int x, int y)
 	int cy = nOffsetInScreenY / nFontHeight;
 
 #if _DEBUG
-	char sText[CONSOLE_WIDTH];
-	sprintf(sText, "x:%d y:%d  cx:%d cy:%d", x, y, cx, cy);
-	ConsoleDisplayPush(sText);
+	ConsoleDisplayPushFormat("x:%d y:%d  cx:%d cy:%d", x, y, cx, cy);
 	DebugDisplay();
 #endif
 

--- a/source/YamlHelper.h
+++ b/source/YamlHelper.h
@@ -2,6 +2,8 @@
 
 #include "yaml.h"
 
+#include "StrFormat.h"
+
 #define SS_YAML_KEY_FILEHDR "File_hdr"
 #define SS_YAML_KEY_TAG "Tag"
 #define SS_YAML_KEY_VERSION "Version"
@@ -212,7 +214,7 @@ public:
 		delete[] m_pMbStr;
 	}
 
-	void Save(const char* format, ...);
+	void Save(const char* format, ...) ATTRIBUTE_FORMAT_PRINTF(1, 2);
 
 	void SaveInt(const char* key, int value);
 	void SaveUint(const char* key, UINT value);
@@ -233,7 +235,7 @@ public:
 	class Label
 	{
 	public:
-		Label(YamlSaveHelper& rYamlSaveHelper, const char* format, ...) :
+		Label(YamlSaveHelper& rYamlSaveHelper, const char* format, ...)  ATTRIBUTE_FORMAT_PRINTF(2, 3) :
 			yamlSaveHelper(rYamlSaveHelper)
 		{
 			fwrite(yamlSaveHelper.m_szIndent, 1, yamlSaveHelper.m_indent, yamlSaveHelper.m_hFile);

--- a/test/TestDebugger/TestDebugger.cpp
+++ b/test/TestDebugger/TestDebugger.cpp
@@ -54,14 +54,8 @@ Update_t ConsoleUpdate ()
 	return 0;
 }
 
-bool ConsoleBufferPush ( const char * pText )
+void ConsoleBufferPush ( const char * pText )
 {
-	return false;
-}
-
-bool ConsoleBufferPushVa ( char* buf, size_t bufsz, const char * pFormat, va_list va )
-{
-	return false;
 }
 
 // From Debugger_DisassemblerData.cpp

--- a/test/TestDebugger/TestDebugger.vcproj
+++ b/test/TestDebugger/TestDebugger.vcproj
@@ -41,7 +41,7 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				Optimization="0"
-				AdditionalIncludeDirectories="..\..\source\Debugger"
+				AdditionalIncludeDirectories="..\..\source\Debugger;..\..\source"
 				PreprocessorDefinitions="WIN32;_DEBUG;_CONSOLE"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="3"
@@ -116,7 +116,7 @@
 				Name="VCCLCompilerTool"
 				Optimization="2"
 				EnableIntrinsicFunctions="true"
-				AdditionalIncludeDirectories="..\..\source\Debugger"
+				AdditionalIncludeDirectories="..\..\source\Debugger;..\..\source"
 				PreprocessorDefinitions="WIN32;NDEBUG;_CONSOLE"
 				RuntimeLibrary="2"
 				EnableFunctionLevelLinking="true"
@@ -200,6 +200,10 @@
 			</File>
 			<File
 				RelativePath=".\stdafx.h"
+				>
+			</File>
+			<File
+				RelativePath="..\..\source\StrFormat.cpp"
 				>
 			</File>
 			<File


### PR DESCRIPTION
The whole bunch Console print functions in Debugger can now be much simplified with StrFormat().
No longer needs an explicit buffer to help producing the messages.