### PR TITLE
Remove unnecessary static std::string variables

### DIFF
--- a/source/Registry.cpp
+++ b/source/Registry.cpp
@@ -153,27 +153,16 @@ void RegSaveValue (LPCTSTR section, LPCTSTR key, BOOL peruser, DWORD value) {
 }
 
 //===========================================================================
-static std::string& RegGetSlotSection(UINT slot)
+static inline std::string RegGetSlotSection(UINT slot)
 {
-	static std::string section;
-	if (slot == SLOT_AUX)
-	{
-		section = REG_CONFIG_SLOT_AUX;
-	}
-	else
-	{
-		section = REG_CONFIG_SLOT;
-		section += (char)('0' + slot);
-	}
-	return section;
+	return (slot == SLOT_AUX)
+		? std::string(REG_CONFIG_SLOT_AUX)
+		: (std::string(REG_CONFIG_SLOT) + (char)('0' + slot));
 }
 
-std::string& RegGetConfigSlotSection(UINT slot)
+std::string RegGetConfigSlotSection(UINT slot)
 {
-	static std::string section;
-	section = REG_CONFIG "\\";
-	section += RegGetSlotSection(slot);
-	return section;
+	return std::string(REG_CONFIG "\\") + RegGetSlotSection(slot);
 }
 
 void RegDeleteConfigSlotSection(UINT slot)

--- a/source/Registry.h
+++ b/source/Registry.h
@@ -12,6 +12,6 @@ BOOL RegLoadValue (LPCTSTR section, LPCTSTR key, BOOL peruser, DWORD* value, DWO
 void RegSaveString (LPCTSTR section, LPCTSTR key, BOOL peruser, const std::string & buffer);
 void RegSaveValue (LPCTSTR section, LPCTSTR key, BOOL peruser, DWORD value);
 
-std::string& RegGetConfigSlotSection(UINT slot);
+std::string RegGetConfigSlotSection(UINT slot);
 void RegDeleteConfigSlotSection(UINT slot);
 void RegSetConfigSlotNewCardType(UINT slot, enum SS_CARDTYPE type);


### PR DESCRIPTION
The static variables are kind of weird that got recomputed upon every call.
The functions can simply return the wanted string as value.