### PR TITLE
Revert "Remove unnecessary static std::string variables"

### DIFF
--- a/source/Registry.cpp
+++ b/source/Registry.cpp
@@ -153,16 +153,27 @@ void RegSaveValue (LPCTSTR section, LPCTSTR key, BOOL peruser, DWORD value) {
 }
 
 //===========================================================================
-static inline std::string RegGetSlotSection(UINT slot)
+static std::string& RegGetSlotSection(UINT slot)
 {
-	return (slot == SLOT_AUX)
-		? std::string(REG_CONFIG_SLOT_AUX)
-		: (std::string(REG_CONFIG_SLOT) + (char)('0' + slot));
+	static std::string section;
+	if (slot == SLOT_AUX)
+	{
+		section = REG_CONFIG_SLOT_AUX;
+	}
+	else
+	{
+		section = REG_CONFIG_SLOT;
+		section += (char)('0' + slot);
+	}
+	return section;
 }
 
-std::string RegGetConfigSlotSection(UINT slot)
+std::string& RegGetConfigSlotSection(UINT slot)
 {
-	return std::string(REG_CONFIG "\\") + RegGetSlotSection(slot);
+	static std::string section;
+	section = REG_CONFIG "\\";
+	section += RegGetSlotSection(slot);
+	return section;
 }
 
 void RegDeleteConfigSlotSection(UINT slot)

--- a/source/Registry.h
+++ b/source/Registry.h
@@ -12,6 +12,6 @@ BOOL RegLoadValue (LPCTSTR section, LPCTSTR key, BOOL peruser, DWORD* value, DWO
 void RegSaveString (LPCTSTR section, LPCTSTR key, BOOL peruser, const std::string & buffer);
 void RegSaveValue (LPCTSTR section, LPCTSTR key, BOOL peruser, DWORD value);
 
-std::string RegGetConfigSlotSection(UINT slot);
+std::string& RegGetConfigSlotSection(UINT slot);
 void RegDeleteConfigSlotSection(UINT slot);
 void RegSetConfigSlotNewCardType(UINT slot, enum SS_CARDTYPE type);


### PR DESCRIPTION
Reverts AppleWin/AppleWin#1039