### PR TITLE
Various *Name() functions can simply return const std::string&

### DIFF
--- a/source/CPU.cpp
+++ b/source/CPU.cpp
@@ -797,7 +797,7 @@ void CpuNmiDeassert(eIRQSRC Device)
 #define SS_YAML_VALUE_6502 "6502"
 #define SS_YAML_VALUE_65C02 "65C02"
 
-static std::string CpuGetSnapshotStructName(void)
+static const std::string& CpuGetSnapshotStructName(void)
 {
 	static const std::string name("CPU");
 	return name;

--- a/source/Disk.cpp
+++ b/source/Disk.cpp
@@ -1965,7 +1965,7 @@ static const UINT kUNIT_VERSION = 6;
 #define SS_YAML_KEY_TRACK_IMAGE_DIRTY "Track Image Dirty"
 #define SS_YAML_KEY_TRACK_IMAGE "Track Image"
 
-std::string Disk2InterfaceCard::GetSnapshotCardName(void)
+const std::string& Disk2InterfaceCard::GetSnapshotCardName(void)
 {
 	static const std::string name(SS_YAML_VALUE_CARD_DISK2);
 	return name;

--- a/source/Disk.h
+++ b/source/Disk.h
@@ -166,7 +166,7 @@ public:
 	bool DriveSwap(void);
 	bool IsDriveConnected(int drive) { return m_floppyDrive[drive].m_isConnected; }
 
-	static std::string GetSnapshotCardName(void);
+	static const std::string& GetSnapshotCardName(void);
 	virtual void SaveSnapshot(YamlSaveHelper& yamlSaveHelper);
 	virtual bool LoadSnapshot(YamlLoadHelper& yamlLoadHelper, UINT version);
 

--- a/source/FourPlay.cpp
+++ b/source/FourPlay.cpp
@@ -132,7 +132,7 @@ void FourPlayCard::InitializeIO(LPBYTE pCxRomPeripheral)
 
 static const UINT kUNIT_VERSION = 1;
 
-std::string FourPlayCard::GetSnapshotCardName(void)
+const std::string& FourPlayCard::GetSnapshotCardName(void)
 {
 	static const std::string name("4Play");
 	return name;

--- a/source/FourPlay.h
+++ b/source/FourPlay.h
@@ -19,7 +19,7 @@ public:
 
 	static BYTE __stdcall IORead(WORD pc, WORD addr, BYTE bWrite, BYTE value, ULONG nExecutedCycles);
 
-	static std::string GetSnapshotCardName(void);
+	static const std::string& GetSnapshotCardName(void);
 	virtual void SaveSnapshot(YamlSaveHelper& yamlSaveHelper);
 	virtual bool LoadSnapshot(YamlLoadHelper& yamlLoadHelper, UINT version);
 

--- a/source/Harddisk.cpp
+++ b/source/Harddisk.cpp
@@ -774,7 +774,7 @@ static const UINT kUNIT_VERSION = 3;
 #define SS_YAML_KEY_BUF "Buffer"
 #define SS_YAML_KEY_NOT_BUSY_CYCLE "Not Busy Cycle"
 
-std::string HarddiskInterfaceCard::GetSnapshotCardName(void)
+const std::string& HarddiskInterfaceCard::GetSnapshotCardName(void)
 {
 	static const std::string name(SS_YAML_VALUE_CARD_HDD);
 	return name;

--- a/source/Harddisk.h
+++ b/source/Harddisk.h
@@ -103,7 +103,7 @@ public:
 	void GetLightStatus(Disk_Status_e* pDisk1Status);
 	bool ImageSwap(void);
 
-	static std::string GetSnapshotCardName(void);
+	static const std::string& GetSnapshotCardName(void);
 	virtual void SaveSnapshot(YamlSaveHelper& yamlSaveHelper);
 	virtual bool LoadSnapshot(YamlLoadHelper& yamlLoadHelper, UINT version);
 

--- a/source/Joystick.cpp
+++ b/source/Joystick.cpp
@@ -936,7 +936,7 @@ void JoyportControl(const UINT uControl)
 #define SS_YAML_KEY_JOY1TRIMY "Joystick1 TrimY"
 #define SS_YAML_KEY_PDL_INACTIVE_CYCLE "Paddle%1d Inactive Cycle"
 
-static std::string JoyGetSnapshotStructName(void)
+static const std::string& JoyGetSnapshotStructName(void)
 {
 	static const std::string name("Joystick");
 	return name;

--- a/source/Keyboard.cpp
+++ b/source/Keyboard.cpp
@@ -457,7 +457,7 @@ void KeybToggleCapsLock ()
 #define SS_YAML_KEY_LASTKEY "Last Key"
 #define SS_YAML_KEY_KEYWAITING "Key Waiting"
 
-static std::string KeybGetSnapshotStructName(void)
+static const std::string& KeybGetSnapshotStructName(void)
 {
 	static const std::string name("Keyboard");
 	return name;

--- a/source/LanguageCard.cpp
+++ b/source/LanguageCard.cpp
@@ -172,13 +172,13 @@ static const UINT kUNIT_LANGUAGECARD_VER = 1;
 #define SS_YAML_KEY_MEMORYMODE "Memory Mode"
 #define SS_YAML_KEY_LASTRAMWRITE "Last RAM Write"
 
-std::string LanguageCardSlot0::GetSnapshotMemStructName(void)
+const std::string& LanguageCardSlot0::GetSnapshotMemStructName(void)
 {
 	static const std::string name("Memory Bank");
 	return name;
 }
 
-std::string LanguageCardSlot0::GetSnapshotCardName(void)
+const std::string& LanguageCardSlot0::GetSnapshotCardName(void)
 {
 	static const std::string name(SS_YAML_VALUE_CARD_LANGUAGECARD);
 	return name;
@@ -379,13 +379,13 @@ static const UINT kUNIT_SATURN_VER = 1;
 #define SS_YAML_KEY_NUM_SATURN_BANKS "Num Saturn Banks"
 #define SS_YAML_KEY_ACTIVE_SATURN_BANK "Active Saturn Bank"
 
-std::string Saturn128K::GetSnapshotMemStructName(void)
+const std::string& Saturn128K::GetSnapshotMemStructName(void)
 {
 	static const std::string name("Memory Bank");
 	return name;
 }
 
-std::string Saturn128K::GetSnapshotCardName(void)
+const std::string& Saturn128K::GetSnapshotCardName(void)
 {
 	static const std::string name(SS_YAML_VALUE_CARD_SATURN128);
 	return name;

--- a/source/LanguageCard.h
+++ b/source/LanguageCard.h
@@ -57,7 +57,7 @@ public:
 	virtual bool LoadSnapshot(YamlLoadHelper& yamlLoadHelper, UINT version);
 
 	static const UINT kMemBankSize = 16*1024;
-	static std::string GetSnapshotCardName(void);
+	static const std::string& GetSnapshotCardName(void);
 
 protected:
 	LanguageCardSlot0(SS_CARDTYPE type, UINT slot);
@@ -67,7 +67,7 @@ protected:
 	LPBYTE m_pMemory;
 
 private:
-	std::string GetSnapshotMemStructName(void);
+	const std::string& GetSnapshotMemStructName(void);
 };
 
 //
@@ -92,10 +92,10 @@ public:
 
 	// "The boards consist of 16K banks of memory (4 banks for the 64K board, 8 banks for the 128K), accessed one at a time" - Ref: "64K/128K RAM BOARD", Saturn Systems, Ch.1 Introduction(pg-5)
 	static const UINT kMaxSaturnBanks = 8;		// 8 * 16K = 128K
-	static std::string GetSnapshotCardName(void);
+	static const std::string& GetSnapshotCardName(void);
 
 private:
-	std::string GetSnapshotMemStructName(void);
+	const std::string& GetSnapshotMemStructName(void);
 
 	static UINT g_uSaturnBanksFromCmdLine;
 

--- a/source/Memory.cpp
+++ b/source/Memory.cpp
@@ -2196,25 +2196,25 @@ static const UINT kUNIT_CARD_VER = 3;
 #define SS_YAML_KEY_NUMAUXBANKS "Num Aux Banks"
 #define SS_YAML_KEY_ACTIVEAUXBANK "Active Aux Bank"
 
-static std::string MemGetSnapshotStructName(void)
+static const std::string& MemGetSnapshotStructName(void)
 {
 	static const std::string name("Memory");
 	return name;
 }
 
-std::string MemGetSnapshotUnitAuxSlotName(void)
+const std::string& MemGetSnapshotUnitAuxSlotName(void)
 {
 	static const std::string name("Auxiliary Slot");
 	return name;
 }
 
-static std::string MemGetSnapshotMainMemStructName(void)
+static const std::string& MemGetSnapshotMainMemStructName(void)
 {
 	static const std::string name("Main Memory");
 	return name;
 }
 
-static std::string MemGetSnapshotAuxMemStructName(void)
+static const std::string& MemGetSnapshotAuxMemStructName(void)
 {
 	static const std::string name("Auxiliary Memory Bank");
 	return name;

--- a/source/Memory.h
+++ b/source/Memory.h
@@ -96,7 +96,7 @@ bool    MemGetAnnunciator(UINT annunciator);
 bool    MemHasNoSlotClock(void);
 void    MemInsertNoSlotClock(void);
 void    MemRemoveNoSlotClock(void);
-std::string MemGetSnapshotUnitAuxSlotName(void);
+const std::string& MemGetSnapshotUnitAuxSlotName(void);
 void    MemSaveSnapshot(class YamlSaveHelper& yamlSaveHelper);
 bool    MemLoadSnapshot(class YamlLoadHelper& yamlLoadHelper, UINT unitVersion);
 void    MemSaveSnapshotAux(class YamlSaveHelper& yamlSaveHelper);

--- a/source/Mockingboard.cpp
+++ b/source/Mockingboard.cpp
@@ -1355,13 +1355,13 @@ const UINT NUM_PHASOR_UNITS = 2;
 
 #define SS_YAML_KEY_VOTRAX_PHONEME "Votrax Phoneme"
 
-std::string MB_GetSnapshotCardName(void)
+const std::string& MB_GetSnapshotCardName(void)
 {
 	static const std::string name("Mockingboard C");
 	return name;
 }
 
-std::string Phasor_GetSnapshotCardName(void)
+const std::string& Phasor_GetSnapshotCardName(void)
 {
 	static const std::string name("Phasor");
 	return name;

--- a/source/Mockingboard.h
+++ b/source/Mockingboard.h
@@ -31,10 +31,10 @@ void MB_UpdateIFR(BYTE nDevice, BYTE clr_mask, BYTE set_mask);
 BYTE MB_GetPCR(BYTE nDevice);
 
 void    MB_GetSnapshot_v1(struct SS_CARD_MOCKINGBOARD_v1* const pSS, const DWORD dwSlot);	// For debugger
-std::string MB_GetSnapshotCardName(void);
+const std::string& MB_GetSnapshotCardName(void);
 void    MB_SaveSnapshot(class YamlSaveHelper& yamlSaveHelper, const UINT uSlot);
 bool    MB_LoadSnapshot(class YamlLoadHelper& yamlLoadHelper, UINT slot, UINT version);
 
-std::string Phasor_GetSnapshotCardName(void);
+const std::string& Phasor_GetSnapshotCardName(void);
 void Phasor_SaveSnapshot(class YamlSaveHelper& yamlSaveHelper, const UINT uSlot);
 bool Phasor_LoadSnapshot(class YamlLoadHelper& yamlLoadHelper, UINT slot, UINT version);

--- a/source/MouseInterface.cpp
+++ b/source/MouseInterface.cpp
@@ -628,7 +628,7 @@ void CMouseInterface::SetButton(eBUTTON Button, eBUTTONSTATE State)
 #define SS_YAML_KEY_BUTTON1 "Button1"
 #define SS_YAML_KEY_ENABLED "Enabled"
 
-std::string CMouseInterface::GetSnapshotCardName(void)
+const std::string& CMouseInterface::GetSnapshotCardName(void)
 {
 	static const std::string name(SS_YAML_VALUE_CARD_MOUSE);
 	return name;

--- a/source/MouseInterface.h
+++ b/source/MouseInterface.h
@@ -43,7 +43,7 @@ public:
 		m_iY = iY;
 	}
 
-	static std::string GetSnapshotCardName(void);
+	static const std::string& GetSnapshotCardName(void);
 	virtual void SaveSnapshot(YamlSaveHelper& yamlSaveHelper);
 	virtual bool LoadSnapshot(YamlLoadHelper& yamlLoadHelper, UINT version);
 

--- a/source/NoSlotClock.cpp
+++ b/source/NoSlotClock.cpp
@@ -187,7 +187,7 @@ void CNoSlotClock::PopulateClockRegister()
 #define SS_YAML_KEY_COMPARISON_REGISTER_MASK "Comparison Register Mask"
 #define SS_YAML_KEY_COMPARISON_REGISTER "Comparison Register"
 
-std::string CNoSlotClock::GetSnapshotStructName(void)
+const std::string& CNoSlotClock::GetSnapshotStructName(void)
 {
 	static const std::string name("No Slot Clock");
 	return name;

--- a/source/NoSlotClock.h
+++ b/source/NoSlotClock.h
@@ -68,7 +68,7 @@ private:
 	bool Read(int address, BYTE& data);
 	void Write(int address);
 	void PopulateClockRegister();
-	std::string GetSnapshotStructName(void);
+	const std::string& GetSnapshotStructName(void);
 
 	static const UINT64 kClockInitSequence = 0x5CA33AC55CA33AC5;
 };

--- a/source/ParallelPrinter.cpp
+++ b/source/ParallelPrinter.cpp
@@ -209,7 +209,7 @@ void Printer_SetIdleLimit(unsigned int Duration)
 #define SS_YAML_KEY_APPEND "Printer Append"
 #define SS_YAML_KEY_DUMPTOREALPRINTER "Enable Dump To Real Printer"
 
-std::string Printer_GetSnapshotCardName(void)
+const std::string& Printer_GetSnapshotCardName(void)
 {
 	static const std::string name(SS_YAML_VALUE_CARD_PRINTER);
 	return name;

--- a/source/ParallelPrinter.h
+++ b/source/ParallelPrinter.h
@@ -9,7 +9,7 @@ const std::string &	Printer_GetFilename();
 void			Printer_SetIdleLimit(unsigned int Duration);
 unsigned int	Printer_GetIdleLimit();
 
-std::string Printer_GetSnapshotCardName(void);
+const std::string& Printer_GetSnapshotCardName(void);
 void Printer_SaveSnapshot(class YamlSaveHelper& yamlSaveHelper, const UINT uSlot);
 bool Printer_LoadSnapshot(class YamlLoadHelper& yamlLoadHelper, UINT slot, UINT version);
 

--- a/source/SAM.cpp
+++ b/source/SAM.cpp
@@ -96,7 +96,7 @@ void SAMCard::InitializeIO(LPBYTE pCxRomPeripheral)
 
 static const UINT kUNIT_VERSION = 1;
 
-std::string SAMCard::GetSnapshotCardName(void)
+const std::string& SAMCard::GetSnapshotCardName(void)
 {
 	static const std::string name("SAM");
 	return name;

--- a/source/SAM.h
+++ b/source/SAM.h
@@ -19,7 +19,7 @@ public:
 
 	static BYTE __stdcall IOWrite(WORD pc, WORD addr, BYTE bWrite, BYTE value, ULONG nExecutedCycles);
 
-	static std::string GetSnapshotCardName(void);
+	static const std::string& GetSnapshotCardName(void);
 	virtual void SaveSnapshot(YamlSaveHelper& yamlSaveHelper);
 	virtual bool LoadSnapshot(YamlLoadHelper& yamlLoadHelper, UINT version);
 

--- a/source/SNESMAX.cpp
+++ b/source/SNESMAX.cpp
@@ -213,7 +213,7 @@ static const UINT kUNIT_VERSION = 1;
 
 #define SS_YAML_KEY_BUTTON_INDEX "Button Index"
 
-std::string SNESMAXCard::GetSnapshotCardName(void)
+const std::string& SNESMAXCard::GetSnapshotCardName(void)
 {
 	static const std::string name("SNES MAX");
 	return name;

--- a/source/SNESMAX.h
+++ b/source/SNESMAX.h
@@ -27,7 +27,7 @@ public:
 	static BYTE __stdcall IORead(WORD pc, WORD addr, BYTE bWrite, BYTE value, ULONG nExecutedCycles);
 	static BYTE __stdcall IOWrite(WORD pc, WORD addr, BYTE bWrite, BYTE value, ULONG nExecutedCycles);
 
-	static std::string GetSnapshotCardName(void);
+	static const std::string& GetSnapshotCardName(void);
 	virtual void SaveSnapshot(YamlSaveHelper& yamlSaveHelper);
 	virtual bool LoadSnapshot(YamlLoadHelper& yamlLoadHelper, UINT version);
 

--- a/source/SaveState.cpp
+++ b/source/SaveState.cpp
@@ -165,19 +165,19 @@ void Snapshot_UpdatePath(void)
 
 //-----------------------------------------------------------------------------
 
-static std::string GetSnapshotUnitApple2Name(void)
+static const std::string& GetSnapshotUnitApple2Name(void)
 {
 	static const std::string name("Apple2");
 	return name;
 }
 
-static std::string GetSnapshotUnitSlotsName(void)
+static const std::string& GetSnapshotUnitSlotsName(void)
 {
 	static const std::string name("Slots");
 	return name;
 }
 
-static std::string GetSnapshotUnitMiscName(void)
+static const std::string& GetSnapshotUnitMiscName(void)
 {
 	static const std::string name("Miscellaneous");
 	return name;

--- a/source/SerialComms.cpp
+++ b/source/SerialComms.cpp
@@ -1417,7 +1417,7 @@ static const UINT kUNIT_VERSION = 2;
 #define SS_YAML_KEY_SERIALPORTNAME "Serial Port Name"
 #define SS_YAML_KEY_SUPPORT_DCD "Support DCD"
 
-std::string CSuperSerialCard::GetSnapshotCardName(void)
+const std::string& CSuperSerialCard::GetSnapshotCardName(void)
 {
 	static const std::string name(SS_YAML_VALUE_CARD_SSC);
 	return name;

--- a/source/SerialComms.h
+++ b/source/SerialComms.h
@@ -36,7 +36,7 @@ public:
 	void    CommReset();
 	void    CommDestroy();
 	void    CommSetSerialPort(DWORD dwNewSerialPortItem);
-	static std::string GetSnapshotCardName(void);
+	static const std::string& GetSnapshotCardName(void);
 	virtual void	SaveSnapshot(YamlSaveHelper& yamlSaveHelper);
 	virtual bool	LoadSnapshot(YamlLoadHelper& yamlLoadHelper, UINT version);
 

--- a/source/Speaker.cpp
+++ b/source/Speaker.cpp
@@ -952,7 +952,7 @@ static void Spkr_DSUninit()
 
 #define SS_YAML_KEY_LASTCYCLE "Last Cycle"
 
-static std::string SpkrGetSnapshotStructName(void)
+static const std::string& SpkrGetSnapshotStructName(void)
 {
 	static const std::string name("Speaker");
 	return name;

--- a/source/Uthernet1.cpp
+++ b/source/Uthernet1.cpp
@@ -1078,7 +1078,7 @@ void Uthernet1::Update(const ULONG nExecutedCycles)
 
 static const UINT kUNIT_VERSION = 1;
 
-std::string Uthernet1::GetSnapshotCardName(void)
+const std::string& Uthernet1::GetSnapshotCardName(void)
 {
     static const std::string name("Uthernet");
     return name;

--- a/source/Uthernet1.h
+++ b/source/Uthernet1.h
@@ -135,7 +135,7 @@ public:
 	BYTE tfe_read(WORD ioaddress);
 	void tfe_store(WORD ioaddress, BYTE byte);
 
-	static std::string GetSnapshotCardName(void);
+	static const std::string& GetSnapshotCardName(void);
 
 private:
 

--- a/source/Uthernet2.cpp
+++ b/source/Uthernet2.cpp
@@ -239,7 +239,7 @@ uint16_t Socket::getFreeRoom() const
     return size - rsr;
 }
 
-std::string Uthernet2::GetSnapshotCardName()
+const std::string& Uthernet2::GetSnapshotCardName()
 {
     static const std::string name("Uthernet2");
     return name;

--- a/source/Uthernet2.h
+++ b/source/Uthernet2.h
@@ -49,7 +49,7 @@ struct Socket
 class Uthernet2 : public Card
 {
 public:
-    static std::string GetSnapshotCardName();
+    static const std::string& GetSnapshotCardName();
 
     Uthernet2(UINT slot);
 

--- a/source/VidHD.cpp
+++ b/source/VidHD.cpp
@@ -183,13 +183,13 @@ static const UINT kUNIT_VERSION = 1;
 #define SS_YAML_KEY_BORDER_COLOR "Border Color"
 #define SS_YAML_KEY_SHADOW "Shadow"
 
-std::string VidHDCard::GetSnapshotCardName(void)
+const std::string& VidHDCard::GetSnapshotCardName(void)
 {
 	static const std::string name("VidHD");
 	return name;
 }
 
-static std::string MemGetSnapshotAuxMemStructName(void)
+static const std::string& MemGetSnapshotAuxMemStructName(void)
 {
 	static const std::string name("Auxiliary Memory Bank");
 	return name;

--- a/source/VidHD.h
+++ b/source/VidHD.h
@@ -34,7 +34,7 @@ public:
 
 	static void UpdateSHRCell(bool is640Mode, bool isColorFillMode, uint16_t addrPalette, bgra_t* pVideoAddress, uint32_t a);
 
-	static std::string GetSnapshotCardName(void);
+	static const std::string& GetSnapshotCardName(void);
 	virtual void SaveSnapshot(YamlSaveHelper& yamlSaveHelper);
 	virtual bool LoadSnapshot(YamlLoadHelper& yamlLoadHelper, UINT version);
 

--- a/source/Video.cpp
+++ b/source/Video.cpp
@@ -275,7 +275,7 @@ bool Video::VideoGetSWAltCharSet(void)
 #define SS_YAML_KEY_CYCLES_THIS_FRAME "Cycles This Frame"
 #define SS_YAML_KEY_VIDEO_REFRESH_RATE "Video Refresh Rate"
 
-std::string Video::VideoGetSnapshotStructName(void)
+const std::string& Video::VideoGetSnapshotStructName(void)
 {
 	static const std::string name("Video");
 	return name;

--- a/source/Video.h
+++ b/source/Video.h
@@ -285,7 +285,7 @@ protected:
 
 private:
 	void SetFrameBuffer(uint8_t* frameBuffer) { g_pFramebufferbits = frameBuffer; }
-	std::string VideoGetSnapshotStructName(void);
+	const std::string& VideoGetSnapshotStructName(void);
 
 	int g_nAltCharSetOffset;
 	uint32_t g_uVideoMode;		// Current Video Mode (this is the last set one as it may change mid-scan line!)

--- a/source/Z80VICE/z80.cpp
+++ b/source/Z80VICE/z80.cpp
@@ -6465,7 +6465,7 @@ void z80_WRMEM(WORD Addr, BYTE Value)
 #define SS_YAML_KEY_REGL2 "L'"
 #define SS_YAML_KEY_ACTIVE "Active"
 
-std::string Z80_GetSnapshotCardName(void)
+const std::string& Z80_GetSnapshotCardName(void)
 {
 	static const std::string name(SS_YAML_VALUE_CARD_Z80);
 	return name;

--- a/source/z80emu.h
+++ b/source/z80emu.h
@@ -18,6 +18,6 @@
 void Z80_InitializeIO(LPBYTE pCxRomPeripheral, UINT uSlot);
 
 // NB. These are in z80.cpp:
-std::string Z80_GetSnapshotCardName(void);
+const std::string& Z80_GetSnapshotCardName(void);
 void Z80_SaveSnapshot(class YamlSaveHelper& yamlSaveHelper, const UINT uSlot);
 bool Z80_LoadSnapshot(class YamlLoadHelper& yamlLoadHelper, UINT uSlot, UINT version);


### PR DESCRIPTION
This saves a bunch of unnecessary string copying.