### PR TITLE
Card: cleanup interface.

### DIFF
--- a/source/Card.h
+++ b/source/Card.h
@@ -39,7 +39,7 @@ public:
 	virtual ~Card(void) {}
 
 	virtual void InitializeIO(LPBYTE pCxRomPeripheral) = 0;
-	virtual void Init(void) = 0;
+	virtual void Destroy() = 0;
 	virtual void Reset(const bool powerCycle) = 0;
 	virtual void Update(const ULONG nExecutedCycles) = 0;
 	virtual void SaveSnapshot(YamlSaveHelper& yamlSaveHelper) = 0;
@@ -74,7 +74,7 @@ public:
 	virtual ~EmptyCard(void) {}
 
 	virtual void InitializeIO(LPBYTE pCxRomPeripheral) {}
-	virtual void Init(void) {}
+	virtual void Destroy() {}
 	virtual void Reset(const bool powerCycle) {}
 	virtual void Update(const ULONG nExecutedCycles) {}
 	virtual void SaveSnapshot(YamlSaveHelper& yamlSaveHelper) {}
@@ -90,7 +90,7 @@ public:
 	virtual ~DummyCard(void) {}
 
 	virtual void InitializeIO(LPBYTE pCxRomPeripheral);
-	virtual void Init(void) {}
+	virtual void Destroy() {}
 	virtual void Reset(const bool powerCycle) {}
 	virtual void Update(const ULONG nExecutedCycles);
 	virtual void SaveSnapshot(YamlSaveHelper& yamlSaveHelper);

--- a/source/CardManager.cpp
+++ b/source/CardManager.cpp
@@ -251,3 +251,25 @@ void CardManager::SaveSnapshot(YamlSaveHelper& yamlSaveHelper)
 		}
 	}
 }
+
+void CardManager::Reset(const bool powerCycle)
+{
+	for (UINT i = SLOT0; i < NUM_SLOTS; ++i)
+	{
+		if (m_slot[i])
+		{
+			m_slot[i]->Reset(powerCycle);
+		}
+	}
+}
+
+void CardManager::Destroy()
+{
+	for (UINT i = SLOT0; i < NUM_SLOTS; ++i)
+	{
+		if (m_slot[i])
+		{
+			m_slot[i]->Destroy();
+		}
+	}
+}

--- a/source/CardManager.h
+++ b/source/CardManager.h
@@ -58,6 +58,8 @@ public:
 	class LanguageCardUnit* GetLanguageCard(void) { return m_pLanguageCard; }
 
 	void InitializeIO(LPBYTE pCxRomPeripheral);
+	void Reset(const bool powerCycle);
+	void Destroy();
 	void Update(const ULONG nExecutedCycles);
 	void SaveSnapshot(YamlSaveHelper& yamlSaveHelper);
 

--- a/source/Disk.h
+++ b/source/Disk.h
@@ -127,13 +127,12 @@ public:
 	Disk2InterfaceCard(UINT slot);
 	virtual ~Disk2InterfaceCard(void);
 
-	virtual void Init(void) {};
 	virtual void Reset(const bool powerCycle);
 
 	virtual void InitializeIO(LPBYTE pCxRomPeripheral);
 	virtual void Update(const ULONG nExecutedCycles);
 
-	void Destroy(void);		// no, doesn't "destroy" the disk image.  DiskIIManagerShutdown()
+	virtual void Destroy(void);		// no, doesn't "destroy" the disk image.  DiskIIManagerShutdown()
 
 	void Boot(void);
 	void FlushCurrentTrack(const int drive);

--- a/source/FourPlay.h
+++ b/source/FourPlay.h
@@ -11,7 +11,7 @@ public:
 	}
 	virtual ~FourPlayCard(void) {}
 
-	virtual void Init(void) {}
+	virtual void Destroy(void) {}
 	virtual void Reset(const bool powerCycle) {}
 	virtual void Update(const ULONG nExecutedCycles) {}
 

--- a/source/Harddisk.h
+++ b/source/Harddisk.h
@@ -85,12 +85,11 @@ public:
 	HarddiskInterfaceCard(UINT slot);
 	virtual ~HarddiskInterfaceCard(void);
 
-	virtual void Init(void) {}
 	virtual void Reset(const bool powerCycle);
 	virtual void Update(const ULONG nExecutedCycles) {}
 
 	virtual void InitializeIO(LPBYTE pCxRomPeripheral);
-	void Destroy(void);
+	virtual void Destroy(void);
 	const std::string& GetFullName(const int iDrive);
 	const std::string& HarddiskGetFullPathName(const int iDrive);
 	void GetFilenameAndPathForSaveState(std::string& filename, std::string& path);

--- a/source/LanguageCard.h
+++ b/source/LanguageCard.h
@@ -14,7 +14,7 @@ public:
 
 	virtual ~LanguageCardUnit(void);
 
-	virtual void Init(void) {}
+	virtual void Destroy(void) {}
 	virtual void Reset(const bool powerCycle) {}
 	virtual void Update(const ULONG nExecutedCycles) {}
 

--- a/source/MouseInterface.cpp
+++ b/source/MouseInterface.cpp
@@ -146,7 +146,7 @@ CMouseInterface::CMouseInterface(UINT slot) :
 
 //	Uninitialize();
 	InitializeROM();
-	Reset();
+	Reset(true);
 }
 
 CMouseInterface::~CMouseInterface()
@@ -193,7 +193,7 @@ void CMouseInterface::Uninitialize()
 }
 #endif
 
-void CMouseInterface::Reset()
+void CMouseInterface::Reset(const bool /* powerCycle */)
 {
 	m_by6821A = 0;
 	m_by6821B = 0x40;		// Set PB6

--- a/source/MouseInterface.h
+++ b/source/MouseInterface.h
@@ -11,13 +11,12 @@ public:
 	CMouseInterface(UINT slot);
 	virtual ~CMouseInterface();
 
-	virtual void Init(void) {}
-	virtual void Reset(const bool powerCycle) {}
+	virtual void Destroy() {}
+	virtual void Reset(const bool powerCycle);
 	virtual void Update(const ULONG nExecutedCycles) {}
 
 	virtual void InitializeIO(LPBYTE pCxRomPeripheral);
 //	void Uninitialize();
-	void Reset();
 	UINT GetSlot(void) { return m_slot; }
 	static BYTE __stdcall IORead(WORD PC, WORD uAddr, BYTE bWrite, BYTE uValue, ULONG nExecutedCycles);
 	static BYTE __stdcall IOWrite(WORD PC, WORD uAddr, BYTE bWrite, BYTE uValue, ULONG nExecutedCycles);

--- a/source/SAM.h
+++ b/source/SAM.h
@@ -11,7 +11,7 @@ public:
 	}
 	virtual ~SAMCard(void) {}
 
-	virtual void Init(void) {}
+	virtual void Destroy(void) {}
 	virtual void Reset(const bool powerCycle) {}
 	virtual void Update(const ULONG nExecutedCycles) {}
 

--- a/source/SNESMAX.h
+++ b/source/SNESMAX.h
@@ -18,7 +18,7 @@ public:
 	}
 	virtual ~SNESMAXCard(void) {}
 
-	virtual void Init(void) {}
+	virtual void Destroy(void) {}
 	virtual void Reset(const bool powerCycle) {}
 	virtual void Update(const ULONG nExecutedCycles) {}
 

--- a/source/SerialComms.cpp
+++ b/source/SerialComms.cpp
@@ -126,6 +126,10 @@ void CSuperSerialCard::InternalReset()
 
 CSuperSerialCard::~CSuperSerialCard()
 {
+	CloseComm();
+
+	delete [] m_pExpansionRom;
+	m_pExpansionRom = NULL;
 }
 
 //===========================================================================
@@ -959,33 +963,19 @@ void CSuperSerialCard::InitializeIO(LPBYTE pCxRomPeripheral)
 	if (m_pExpansionRom == NULL)
 	{
 		m_pExpansionRom = new BYTE [SSC_FW_SIZE];
-
-		if (m_pExpansionRom)
-			memcpy(m_pExpansionRom, pData, SSC_FW_SIZE);
+		memcpy(m_pExpansionRom, pData, SSC_FW_SIZE);
 	}
-
-	//
 
 	RegisterIoHandler(m_slot, &CSuperSerialCard::SSC_IORead, &CSuperSerialCard::SSC_IOWrite, NULL, NULL, this, m_pExpansionRom);
 }
 
 //===========================================================================
 
-void CSuperSerialCard::CommReset()
+void CSuperSerialCard::Reset(const bool /* powerCycle */)
 {
 	CloseComm();
 
 	InternalReset();
-}
-
-//===========================================================================
-
-void CSuperSerialCard::CommDestroy()
-{
-	CommReset();
-
-	delete [] m_pExpansionRom;
-	m_pExpansionRom = NULL;
 }
 
 //===========================================================================

--- a/source/SerialComms.h
+++ b/source/SerialComms.h
@@ -27,18 +27,15 @@ class CSuperSerialCard : public Card
 public:
 	CSuperSerialCard(UINT slot);
 	virtual ~CSuperSerialCard();
-
-	virtual void Init(void) {}
-	virtual void Reset(const bool powerCycle) {}
 	virtual void Update(const ULONG nExecutedCycles) {}
-
-	void	InitializeIO(LPBYTE pCxRomPeripheral);
-	void    CommReset();
-	void    CommDestroy();
-	void    CommSetSerialPort(DWORD dwNewSerialPortItem);
+	virtual void InitializeIO(LPBYTE pCxRomPeripheral);
+	virtual void Reset(const bool powerCycle);
+	virtual void Destroy() {}
 	static const std::string& GetSnapshotCardName(void);
 	virtual void	SaveSnapshot(YamlSaveHelper& yamlSaveHelper);
 	virtual bool	LoadSnapshot(YamlLoadHelper& yamlLoadHelper, UINT version);
+
+	void    CommSetSerialPort(DWORD dwNewSerialPortItem);
 
 	std::string const& GetSerialPortChoices();
 	DWORD	GetSerialPort() { return m_dwSerialPortItem; }	// Drop-down list item

--- a/source/Uthernet1.cpp
+++ b/source/Uthernet1.cpp
@@ -188,12 +188,6 @@ Uthernet1::Uthernet1(UINT slot) : Card(CT_Uthernet, slot)
     Init();
 }
 
-void Uthernet1::InitialiseBackend()
-{
-    Destroy();
-    networkBackend = GetFrame().CreateNetworkBackend();
-}
-
 void Uthernet1::Init(void)
 {
     // Initialise all state member variables
@@ -1015,16 +1009,11 @@ static BYTE __stdcall TfeIo (WORD programcounter, WORD address, BYTE write, BYTE
 
 void Uthernet1::InitializeIO(LPBYTE pCxRomPeripheral)
 {
-    InitialiseBackend();
+    networkBackend = GetFrame().CreateNetworkBackend();
     if (networkBackend->isValid())
     {
         RegisterIoHandler(m_slot, TfeIo, TfeIo, TfeIoCxxx, TfeIoCxxx, this, NULL);
     }
-}
-
-void Uthernet1::Destroy()
-{
-    networkBackend.reset();
 }
 
 void Uthernet1::Reset(const bool powerCycle)

--- a/source/Uthernet1.h
+++ b/source/Uthernet1.h
@@ -123,14 +123,12 @@ class Uthernet1 : public Card
 public:
 	Uthernet1(UINT slot);
 
+	virtual void Destroy(void) {}
 	virtual void InitializeIO(LPBYTE pCxRomPeripheral);
-	virtual void Init(void);
 	virtual void Reset(const bool powerCycle);
 	virtual void Update(const ULONG nExecutedCycles);
 	virtual void SaveSnapshot(YamlSaveHelper& yamlSaveHelper);
 	virtual bool LoadSnapshot(YamlLoadHelper& yamlLoadHelper, UINT version);
-
-	void Destroy();
 
 	BYTE tfe_read(WORD ioaddress);
 	void tfe_store(WORD ioaddress, BYTE byte);
@@ -139,7 +137,7 @@ public:
 
 private:
 
-	void InitialiseBackend();
+	void Init();
 
 	void tfe_sideeffects_write_pp_on_txframe(WORD ppaddress);
 	void tfe_sideeffects_write_pp(WORD ppaddress, int oddaddress);

--- a/source/Uthernet2.cpp
+++ b/source/Uthernet2.cpp
@@ -288,11 +288,6 @@ Uthernet2::Uthernet2(UINT slot) : Card(CT_Uthernet2, slot)
     Reset(true);
 }
 
-void Uthernet2::Destroy()
-{
-    myNetworkBackend.reset();
-}
-
 void Uthernet2::setSocketModeRegister(const size_t i, const uint16_t address, const uint8_t value)
 {
     myMemory[address] = value;
@@ -1077,7 +1072,6 @@ void Uthernet2::Reset(const bool powerCycle)
     {
         // dataAddress is NOT reset, see page 10 of Uthernet II
         myDataAddress = 0;
-        myNetworkBackend.reset();
         myNetworkBackend = GetFrame().CreateNetworkBackend();
     }
 
@@ -1166,10 +1160,6 @@ BYTE __stdcall u2_C0(WORD programcounter, WORD address, BYTE write, BYTE value, 
 void Uthernet2::InitializeIO(LPBYTE pCxRomPeripheral)
 {
     RegisterIoHandler(m_slot, u2_C0, u2_C0, nullptr, nullptr, this, nullptr);
-}
-
-void Uthernet2::Init()
-{
 }
 
 void Uthernet2::Update(const ULONG nExecutedCycles)

--- a/source/Uthernet2.h
+++ b/source/Uthernet2.h
@@ -56,10 +56,8 @@ public:
 
     Uthernet2(UINT slot);
 
-    void Destroy();
-
+	virtual void Destroy(void) {}
     virtual void InitializeIO(LPBYTE pCxRomPeripheral);
-    virtual void Init();
     virtual void Reset(const bool powerCycle);
     virtual void Update(const ULONG nExecutedCycles);
     virtual void SaveSnapshot(YamlSaveHelper &yamlSaveHelper);

--- a/source/Utilities.cpp
+++ b/source/Utilities.cpp
@@ -532,15 +532,7 @@ void GetAppleWindowTitle()
 // todo: consolidate CtrlReset() and ResetMachineState()
 void ResetMachineState()
 {
-	GetCardMgr().GetDisk2CardMgr().Reset(true);
-	if (GetCardMgr().QuerySlot(SLOT7) == CT_GenericHDD)
-		GetCardMgr().GetRef(SLOT7).Reset(true);
-	if (GetCardMgr().QuerySlot(SLOT3) == CT_VidHD)
-		GetCardMgr().GetRef(SLOT3).Reset(true);
-	if (GetCardMgr().QuerySlot(SLOT3) == CT_Uthernet)
-		GetCardMgr().GetRef(SLOT3).Reset(true);
-	if (GetCardMgr().QuerySlot(SLOT3) == CT_Uthernet2)
-		GetCardMgr().GetRef(SLOT3).Reset(true);
+	GetCardMgr().Reset(true);
 	g_bFullSpeed = 0;	// Might've hit reset in middle of InternalCpuExecute() - so beep may get (partially) muted
 
 	MemReset();	// calls CpuInitialize(), CNoSlotClock.Reset()
@@ -549,14 +541,10 @@ void ResetMachineState()
 		dynamic_cast<Disk2InterfaceCard&>(GetCardMgr().GetRef(SLOT6)).Boot();
 	GetVideo().VideoResetState();
 	KeybReset();
-	if (GetCardMgr().IsSSCInstalled())
-		GetCardMgr().GetSSC()->CommReset();
 	PrintReset();
 	JoyReset();
 	MB_Reset(true);
 	SpkrReset();
-	if (GetCardMgr().IsMouseCardInstalled())
-		GetCardMgr().GetMouseCard()->Reset();
 	SetActiveCpu(GetMainCpu());
 #ifdef USE_SPEECH_API
 	g_Speech.Reset();
@@ -593,21 +581,9 @@ void CtrlReset()
 	}
 
 	GetPravets().Reset();
-	GetCardMgr().GetDisk2CardMgr().Reset();
-	if (GetCardMgr().QuerySlot(SLOT7) == CT_GenericHDD)
-		GetCardMgr().GetRef(SLOT7).Reset(false);
-	if (GetCardMgr().QuerySlot(SLOT3) == CT_VidHD)
-		GetCardMgr().GetRef(SLOT3).Reset(false);
-	if (GetCardMgr().QuerySlot(SLOT3) == CT_Uthernet)
-		GetCardMgr().GetRef(SLOT3).Reset(false);
-	if (GetCardMgr().QuerySlot(SLOT3) == CT_Uthernet2)
-		GetCardMgr().GetRef(SLOT3).Reset(false);
+	GetCardMgr().Reset(false);
 	KeybReset();
-	if (GetCardMgr().IsSSCInstalled())
-		GetCardMgr().GetSSC()->CommReset();
 	MB_Reset(false);
-	if (GetCardMgr().IsMouseCardInstalled())
-		GetCardMgr().GetMouseCard()->Reset();		// Deassert any pending IRQs - GH#514
 #ifdef USE_SPEECH_API
 	g_Speech.Reset();
 #endif

--- a/source/VidHD.h
+++ b/source/VidHD.h
@@ -19,7 +19,7 @@ public:
 	}
 	virtual ~VidHDCard(void) {}
 
-	virtual void Init(void) {}
+	virtual void Destroy(void) {}
 	virtual void Reset(const bool powerCycle);
 	virtual void Update(const ULONG nExecutedCycles) {}
 	virtual void InitializeIO(LPBYTE pCxRomPeripheral);

--- a/source/Windows/WinFrame.cpp
+++ b/source/Windows/WinFrame.cpp
@@ -965,17 +965,9 @@ LRESULT Win32Frame::WndProc(
 		Snapshot_Shutdown();
       DebugDestroy();
       if (!g_bRestart) {
-		GetCardMgr().GetDisk2CardMgr().Destroy();
-		if (GetCardMgr().QuerySlot(SLOT7) == CT_GenericHDD)
-			dynamic_cast<HarddiskInterfaceCard&>(GetCardMgr().GetRef(SLOT7)).Destroy();
-		if (GetCardMgr().QuerySlot(SLOT3) == CT_Uthernet)
-			dynamic_cast<Uthernet1&>(GetCardMgr().GetRef(SLOT3)).Destroy();
-		if (GetCardMgr().QuerySlot(SLOT3) == CT_Uthernet2)
-			dynamic_cast<Uthernet2&>(GetCardMgr().GetRef(SLOT3)).Destroy();
+		GetCardMgr().Destroy();
       }
       PrintDestroy();
-      if (GetCardMgr().IsSSCInstalled())
-		GetCardMgr().GetSSC()->CommDestroy();
       CpuDestroy();
       MemDestroy();
       SpkrDestroy();


### PR DESCRIPTION
1) Remove Init()
2) Call Reset() via CardManager
3) Destroy() (only used in disks) via CardManager.

The only "real" changes are in CSuperSerialCard: ensure destructor cleans up and remove Destroy().

Signed-off-by: Andrea Odetti <mariofutire@gmail.com>