### PR TITLE
Add ByteToHexStr() and WordToHexStr()

### DIFF
--- a/source/LanguageCard.cpp
+++ b/source/LanguageCard.cpp
@@ -443,7 +443,7 @@ bool Saturn128K::LoadSnapshot(YamlLoadHelper& yamlLoadHelper, UINT version)
 		}
 
 		// "Memory Bankxx"
-		std::string memName = GetSnapshotMemStructName() + StrFormat("%02X", uBank);
+		std::string memName = GetSnapshotMemStructName() + ByteToHexStr(uBank);
 
 		if (!yamlLoadHelper.GetSubMap(memName))
 			throw std::runtime_error("Memory: Missing map name: " + memName);

--- a/source/Memory.cpp
+++ b/source/Memory.cpp
@@ -2443,7 +2443,7 @@ static void MemLoadSnapshotAuxCommon(YamlLoadHelper& yamlLoadHelper, const std::
 		}
 
 		// "Auxiliary Memory Bankxx"
-		std::string auxMemName = MemGetSnapshotAuxMemStructName() + StrFormat("%02X", uBank-1);
+		std::string auxMemName = MemGetSnapshotAuxMemStructName() + ByteToHexStr(uBank-1);
 
 		if (!yamlLoadHelper.GetSubMap(auxMemName))
 			throw std::runtime_error("Memory: Missing map name: " + auxMemName);

--- a/source/SSI263.cpp
+++ b/source/SSI263.cpp
@@ -86,7 +86,7 @@ void SSI_Output(void)
 	LogOutput("SSI: ");
 	for (int i = 0; i <= 4; i++)
 	{
-		std::string r = (ssiRegs[i] >= 0) ? StrFormat("%02X", ssiRegs[i]) : "--";
+		std::string r = (ssiRegs[i] >= 0) ? ByteToHexStr(ssiRegs[i]) : "--";
 		LogOutput("%s ", r.c_str());
 		ssiRegs[i] = -1;
 	}

--- a/source/StrFormat.h
+++ b/source/StrFormat.h
@@ -6,6 +6,7 @@
 #if defined(_MSC_VER) && _MSC_VER < 1600
 #include <basetsd.h>
 typedef UINT8 uint8_t;
+typedef UINT16 uint16_t;
 #else
 #include <cstdint>
 #endif
@@ -19,10 +20,59 @@ typedef UINT8 uint8_t;
 std::string StrFormat(const char* format, ...) ATTRIBUTE_FORMAT_PRINTF(1, 2);
 std::string StrFormatV(const char* format, va_list va);
 
+namespace {
+
+const char g_aHexDigits[16] = {
+	'0', '1', '2', '3', '4', '5', '6', '7',
+	'8', '9', 'A', 'B', 'C', 'D', 'E', 'F',
+};
+
+// No buffer overflow check or null termination. Use with caution.
+inline char* StrBufferAppendByteAsHex(char* cp, uint8_t n)
+{
+	*cp++ = g_aHexDigits[(n >> 4) & 0x0f];
+	*cp++ = g_aHexDigits[(n >> 0) & 0x0f];
+	return cp;
+}
+
+// No buffer overflow check or null termination. Use with caution.
+inline char* StrBufferAppendWordAsHex(char* cp, uint16_t n)
+{
+	*cp++ = g_aHexDigits[(n >> 12) & 0x0f];
+	*cp++ = g_aHexDigits[(n >>  8) & 0x0f];
+	*cp++ = g_aHexDigits[(n >>  4) & 0x0f];
+	*cp++ = g_aHexDigits[(n >>  0) & 0x0f];
+	return cp;
+}
+
 inline std::string& StrAppendByteAsHex(std::string& s, uint8_t n)
 {
-	const char szHex[] = "0123456789ABCDEF";
-	s += szHex[(n >> 4) & 0x0f];
-	s += szHex[n & 0x0f];
+	const char hex[2] = { g_aHexDigits[(n >> 4) & 0x0f],
+						  g_aHexDigits[(n >> 0) & 0x0f] };
+	return s.append(hex, 2);
+}
+
+inline std::string& StrAppendWordAsHex(std::string& s, uint16_t n)
+{
+	const char hex[4] = { g_aHexDigits[(n >> 12) & 0x0f],
+						  g_aHexDigits[(n >>  8) & 0x0f],
+						  g_aHexDigits[(n >>  4) & 0x0f],
+						  g_aHexDigits[(n >>  0) & 0x0f] };
+	return s.append(hex, 4);
+}
+
+inline std::string ByteToHexStr(uint8_t n)
+{
+	std::string s;
+	StrAppendByteAsHex(s, n);
 	return s;
 }
+
+inline std::string WordToHexStr(uint16_t n)
+{
+	std::string s;
+	StrAppendWordAsHex(s, n);
+	return s;
+}
+
+} // namespace


### PR DESCRIPTION
- Simplify common StrFormat(), especially in Debugger (changes upcoming)
- Add helpers StrAppendByteAsHex() and StrAppendWordAsHex()
- Add helpers StrBufferAppendByteAsHex() and StrBufferAppendWordAsHex() for plain string buffer