### PR TITLE
Debugger: Format changes only - consistent space after keywords

### DIFF
--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -793,7 +793,7 @@ Update_t CmdProfile (int nArgs)
 				int   nLine = g_nProfileLine;
 				int   iLine;
 				
-				for( iLine = 0; iLine < nLine; iLine++ )
+				for ( iLine = 0; iLine < nLine; iLine++ )
 				{
 					pText = ProfileLinePeek( iLine );
 					if (pText)
@@ -1580,7 +1580,7 @@ void _BWZ_RemoveOne( Breakpoint_t *aBreakWatchZero, const int iSlot, int & nTota
 
 void _BWZ_RemoveAll( Breakpoint_t *aBreakWatchZero, const int nMax, int & nTotal )
 {
-	for( int iSlot = 0; iSlot < nMax; iSlot++ )
+	for ( int iSlot = 0; iSlot < nMax; iSlot++ )
 	{
 		_BWZ_RemoveOne( aBreakWatchZero, iSlot, nTotal );
 	}
@@ -1625,7 +1625,7 @@ void _BWZ_EnableDisableViaArgs( int nArgs, Breakpoint_t * aBreakWatchZero, const
 
 		if (! _tcscmp(g_aArgs[nArgs].sArg, g_aParameters[ PARAM_WILDSTAR ].m_sName))
 		{
-			for( ; iSlot < nMax; iSlot++ )
+			for ( ; iSlot < nMax; iSlot++ )
 			{
 				aBreakWatchZero[ iSlot ].bEnabled = bEnabled;
 			}			
@@ -2405,7 +2405,7 @@ bool ConfigSave_BufferToDisk ( const char *pFileName, ConfigSave_t eConfigSave )
 		int   nLine = g_ConfigState.GetNumLines();
 		int   iLine;
 		
-		for( iLine = 0; iLine < nLine; iLine++ )
+		for ( iLine = 0; iLine < nLine; iLine++ )
 		{
 			pText = g_ConfigState.GetLine( iLine );
 			if ( pText )
@@ -3412,40 +3412,40 @@ bool MemoryDumpCheck (int nArgs, WORD * pAddress_ )
 
 	pArg->eDevice = DEV_MEMORY;						// Default
 
-	if(strncmp(g_aArgs[1].sArg, "SY", 2) == 0)			// SY6522
+	if (strncmp(g_aArgs[1].sArg, "SY", 2) == 0)			// SY6522
 	{
 		nAddress = (g_aArgs[1].sArg[2] - '0') & 3;
 		pArg->eDevice = DEV_SY6522;
 		bUpdate = true;
 	}
-	else if(strncmp(g_aArgs[1].sArg, "AY", 2) == 0)		// AY8910
+	else if (strncmp(g_aArgs[1].sArg, "AY", 2) == 0)		// AY8910
 	{
 		nAddress  = (g_aArgs[1].sArg[2] - '0') & 3;
 		pArg->eDevice = DEV_AY8910;
 		bUpdate = true;
 	}
 #ifdef SUPPORT_Z80_EMU
-	else if(strcmp(g_aArgs[1].sArg, "*AF") == 0)
+	else if (strcmp(g_aArgs[1].sArg, "*AF") == 0)
 	{
 		nAddress = *(WORD*)(mem + REG_AF);
 		bUpdate = true;
 	}
-	else if(strcmp(g_aArgs[1].sArg, "*BC") == 0)
+	else if (strcmp(g_aArgs[1].sArg, "*BC") == 0)
 	{
 		nAddress = *(WORD*)(mem + REG_BC);
 		bUpdate = true;
 	}
-	else if(strcmp(g_aArgs[1].sArg, "*DE") == 0)
+	else if (strcmp(g_aArgs[1].sArg, "*DE") == 0)
 	{
 		nAddress = *(WORD*)(mem + REG_DE);
 		bUpdate = true;
 	}
-	else if(strcmp(g_aArgs[1].sArg, "*HL") == 0)
+	else if (strcmp(g_aArgs[1].sArg, "*HL") == 0)
 	{
 		nAddress = *(WORD*)(mem + REG_HL);
 		bUpdate = true;
 	}
-	else if(strcmp(g_aArgs[1].sArg, "*IX") == 0)
+	else if (strcmp(g_aArgs[1].sArg, "*IX") == 0)
 	{
 		nAddress = *(WORD*)(mem + REG_IX);
 		bUpdate = true;
@@ -3503,7 +3503,7 @@ static Update_t _CmdMemoryDump (int nArgs, int iWhich, int iView )
 {
 	WORD nAddress = 0;
 
-	if( ! MemoryDumpCheck(nArgs, & nAddress ) )
+	if ( ! MemoryDumpCheck(nArgs, & nAddress ) )
 	{
 		return Help_Arg_1( g_iCommand );
 	}
@@ -3598,7 +3598,7 @@ Update_t CmdMemoryEnterByte (int nArgs)
 	while (nArgs >= 2)
 	{
 		WORD nData = g_aArgs[nArgs].nValue;
-		if( nData > 0xFF)
+		if ( nData > 0xFF)
 		{
 			*(mem + nAddress + nArgs - 2)  = (BYTE)(nData >> 0);
 			*(mem + nAddress + nArgs - 1)  = (BYTE)(nData >> 8);
@@ -3643,7 +3643,7 @@ Update_t CmdMemoryEnterWord (int nArgs)
 //===========================================================================
 void MemMarkDirty( WORD nAddressStart, WORD nAddressEnd )
 {
-	for( int iPage = (nAddressStart >> 8); iPage <= (nAddressEnd >> 8); iPage++ )
+	for ( int iPage = (nAddressStart >> 8); iPage <= (nAddressEnd >> 8); iPage++ )
 	{
 		*(memdirty+iPage) = 1;
 	}
@@ -3664,7 +3664,7 @@ Update_t CmdMemoryFill (int nArgs)
 	int  nAddressLen = 0;
 	BYTE nValue = 0;
 
-	if( nArgs == 3)
+	if ( nArgs == 3)
 	{
 		nAddressStart = g_aArgs[1].nValue;
 		nAddressEnd   = g_aArgs[2].nValue;
@@ -3687,7 +3687,7 @@ Update_t CmdMemoryFill (int nArgs)
 		MemMarkDirty( nAddressStart, nAddressEnd );
 
 		nValue = g_aArgs[nArgs].nValue & 0xFF;
-		while( nAddressLen-- ) // v2.7.0.22
+		while ( nAddressLen-- ) // v2.7.0.22
 		{
 			// TODO: Optimize - split into pre_io, and post_io
 			if ((nAddress2 < _6502_IO_BEGIN) || (nAddress2 > _6502_IO_END))
@@ -3709,7 +3709,7 @@ static std::string g_sMemoryLoadSaveFileName;
 //===========================================================================
 Update_t CmdConfigGetDebugDir (int nArgs)
 {
-	if( nArgs != 0 )
+	if ( nArgs != 0 )
 		return Help_Arg_1( CMD_CONFIG_GET_DEBUG_DIR );
 
 	// TODO: debugger dir has no ` CONSOLE_COLOR_ESCAPE_CHAR ?!?!
@@ -3924,7 +3924,7 @@ Update_t CmdMemoryLoad (int nArgs)
 			if (nRead == 1) // (size_t)nLen)
 			{
 				int iByte;
-				for( iByte = 0; iByte < nAddressLen; iByte++ )
+				for ( iByte = 0; iByte < nAddressLen; iByte++ )
 				{
 					*pDst++ = *pSrc++;
 				}
@@ -4033,13 +4033,13 @@ Update_t CmdMemoryLoad (int nArgs)
 	char *pFileName = g_aArgs[ 1 ].sArg;
 	int   nLen = strlen( pFileName );
 	char *pEnd = pFileName + nLen - 1;
-	while( pEnd > pFileName )
+	while ( pEnd > pFileName )
 	{
-		if( *pEnd == '.' )
+		if ( *pEnd == '.' )
 		{
-			for( int i = 1; i < nFileTypes; i++ )
+			for ( int i = 1; i < nFileTypes; i++ )
 			{
-				if( strcmp( pEnd, aFileTypes[i].pExtension ) == 0 )
+				if ( strcmp( pEnd, aFileTypes[i].pExtension ) == 0 )
 				{
 					pFileType = &aFileTypes[i];
 					break;
@@ -4047,13 +4047,13 @@ Update_t CmdMemoryLoad (int nArgs)
 			}
 		}
 
-		if( pFileType )
+		if ( pFileType )
 			break;
 
 		pEnd--;
 	}
 
-	if( !pFileType )
+	if ( !pFileType )
 		if (g_aArgs[ iArgComma1 ].eToken != TOKEN_COMMA)
 			return Help_Arg_1( CMD_MEMORY_LOAD );
 
@@ -4062,7 +4062,7 @@ Update_t CmdMemoryLoad (int nArgs)
 	WORD nAddressEnd   = 0;
 	int  nAddressLen   = 0;
 
-	if( pFileType )
+	if ( pFileType )
 	{
 		nAddressStart = pFileType->nAddress;
 		nAddressLen   = pFileType->nLength;
@@ -4074,7 +4074,7 @@ Update_t CmdMemoryLoad (int nArgs)
 	if (g_aArgs[ iArgComma1 ].eToken == TOKEN_COMMA)
 		eRange = Range_Get( nAddressStart, nAddress2, iArgAddress );
 
-	if( nArgs > iArgComma2 )
+	if ( nArgs > iArgComma2 )
 	{
 		if (eRange == RANGE_MISSING_ARG_2)
 		{
@@ -4185,7 +4185,7 @@ Update_t CmdMemoryMove (int nArgs)
 //			BYTE *pDst = mem + nDst;
 //			BYTE *pEnd = pSrc + nAddressLen;
 
-		while( nAddressLen-- ) // v2.7.0.23
+		while ( nAddressLen-- ) // v2.7.0.23
 		{
 			// TODO: Optimize - split into pre_io, and post_io
 			if ((nDst < _6502_IO_BEGIN) || (nDst > _6502_IO_END))
@@ -4289,7 +4289,7 @@ Update_t CmdMemorySave (int nArgs)
 				
 				// memcpy -- copy out of active memory bank
 				int iByte;
-				for( iByte = 0; iByte < nAddressLen; iByte++ )
+				for ( iByte = 0; iByte < nAddressLen; iByte++ )
 				{
 					*pDst++ = *pSrc++;
 				}
@@ -4553,12 +4553,12 @@ size_t Util_GetDebuggerText( char* &pText_ )
 	memset( g_aDebuggerVirtualTextScreen, 0, sizeof( g_aDebuggerVirtualTextScreen ) );
 	DebugDisplay();
 
-	for( int y = 0; y < DEBUG_VIRTUAL_TEXT_HEIGHT; y++ )
+	for ( int y = 0; y < DEBUG_VIRTUAL_TEXT_HEIGHT; y++ )
 	{
-		for( int x = 0; x < DEBUG_VIRTUAL_TEXT_WIDTH; x++ )
+		for ( int x = 0; x < DEBUG_VIRTUAL_TEXT_WIDTH; x++ )
 		{
 			char c = g_aDebuggerVirtualTextScreen[y][x];
-			if( (c < 0x20) || (c >= 0x7F) )
+			if ( (c < 0x20) || (c >= 0x7F) )
 				c = ' '; // convert null to spaces to keep everything non-proptional
 			*pEnd++ = c;
 		}
@@ -4589,12 +4589,12 @@ size_t Util_GetTextScreen ( char* &pText_ )
 	LPBYTE g_pTextBank1  = MemGetAuxPtr (0x400 << uBank2);
 	LPBYTE g_pTextBank0  = MemGetMainPtr(0x400 << uBank2);
 
-	for( int y = 0; y < 24; y++ )
+	for ( int y = 0; y < 24; y++ )
 	{
 		// nAddressStart = 0x400 + (y%8)*0x80 + (y/8)*0x28;
 		nAddressStart = ((y&7)<<7) | ((y&0x18)<<2) | (y&0x18); // no 0x400| since using MemGet*Ptr()
 
-		for( int x = 0; x < 40; x++ ) // always 40 columns
+		for ( int x = 0; x < 40; x++ ) // always 40 columns
 		{
 			char c; // TODO: FormatCharTxtCtrl() ?
 
@@ -4603,7 +4603,7 @@ size_t Util_GetTextScreen ( char* &pText_ )
 				c = g_pTextBank1[ nAddressStart ] & 0x7F;
 				c = RemapChar(c);
 				*pEnd++ = c;
-			} // MAIN -- NOTE: intentional indent & outside if() !
+			} // MAIN -- NOTE: intentional indent & outside if () !
 
 				c = g_pTextBank0[ nAddressStart ] & 0x7F;
 				c = RemapChar(c);
@@ -4664,13 +4664,13 @@ Update_t CmdNTSC (int nArgs)
 	const char *pFileName = (nArgs > 1) ? g_aArgs[ 2 ].sArg : "";
 	int   nLen = strlen( pFileName );
 	const char *pEnd = pFileName + nLen - 1;
-	while( pEnd > pFileName )
+	while ( pEnd > pFileName )
 	{
-		if( *pEnd == '.' )
+		if ( *pEnd == '.' )
 		{
-			for( int i = TYPE_BMP; i < NUM_FILE_TYPES; i++ )
+			for ( int i = TYPE_BMP; i < NUM_FILE_TYPES; i++ )
 			{
-				if( strcmp( pEnd, aFileTypes[i].pExtension ) == 0 )
+				if ( strcmp( pEnd, aFileTypes[i].pExtension ) == 0 )
 				{
 					pFileType = &aFileTypes[i];
 					iFileType = (KnownFileType_e) i;
@@ -4679,13 +4679,13 @@ Update_t CmdNTSC (int nArgs)
 			}
 		}
 
-		if( pFileType )
+		if ( pFileType )
 			break;
 
 		pEnd--;
 	}
 
-	if( nLen == 0 )
+	if ( nLen == 0 )
 		pFileName = "AppleWinNTSC4096x4@32.data";
 
 	static std::string sPaletteFilePath;
@@ -4790,7 +4790,7 @@ Update_t CmdNTSC (int nArgs)
 
 				// Expand y from 1 to 256 rows
 				const size_t nBytesPerScanLine = 16 * 4 * nBPP; // 16 colors * 4 phases
-				for( int y = 0; y < 256; y++ )
+				for ( int y = 0; y < 256; y++ )
 					memcpy( pDst + y*nBytesPerScanLine, pSrc, nBytesPerScanLine );
 			}
 	};
@@ -4830,14 +4830,14 @@ Update_t CmdNTSC (int nArgs)
 
 #if 1 // Loop
 				// Expand x from 16 colors (single phase) to 64 colors (16 * 4 phases)
-				for( int iPhase = 0; iPhase < 4; iPhase++ )
+				for ( int iPhase = 0; iPhase < 4; iPhase++ )
 				{
 					int phase = iPhase;
 					if (iPhase == 1) phase = 3;
 					if (iPhase == 3) phase = 1;
 					int mul = (1 << phase); // Mul: *1 *8 *4 *2
 
-					for( int iDstX = 0; iDstX < 16; iDstX++ )
+					for ( int iDstX = 0; iDstX < 16; iDstX++ )
 					{
 						int iSrcX = (iDstX * mul) % 15; // Delta: +1 +2 +4 +8
 
@@ -4943,10 +4943,10 @@ Update_t CmdNTSC (int nArgs)
 				const uint8_t *pTmp = pSrc;
 				const uint32_t nBPP = 4; // bytes per pixel
 
-				for( int x = 0; x < 16; x++ )
+				for ( int x = 0; x < 16; x++ )
 				{
 					pTmp = pSrc + (x * nBPP); // dst is 16-px column
-					for( int y = 0; y < 256; y++ )
+					for ( int y = 0; y < 256; y++ )
 					{
 							*pDst++ = pTmp[0];
 							*pDst++ = pTmp[1];
@@ -4957,7 +4957,7 @@ Update_t CmdNTSC (int nArgs)
 
 				// we duplicate phase 0 a total of 4 times
 				const size_t nBytesPerScanLine = 4096 * nBPP;
-				for( int iPhase = 1; iPhase < 4; iPhase++ )
+				for ( int iPhase = 1; iPhase < 4; iPhase++ )
 					memcpy( pDst + iPhase*nBytesPerScanLine, pDst, nBytesPerScanLine );
 			}
 */
@@ -5021,13 +5021,13 @@ Update_t CmdNTSC (int nArgs)
 				/* */ uint8_t *pTmp = pDst;
 				const uint32_t nBPP = 4; // bytes per pixel
 
-				for( int iPhase = 0; iPhase < 4; iPhase++ )
+				for ( int iPhase = 0; iPhase < 4; iPhase++ )
 				{
 					pDst = pTmp + (iPhase * 16 * nBPP); // dst is 16-px column
 
-					for( int x = 0; x < 4096/16; x++ ) // 4096px/16 px = 256 columns
+					for ( int x = 0; x < 4096/16; x++ ) // 4096px/16 px = 256 columns
 					{
-						for( int i = 0; i < 16*nBPP; i++ ) // 16 px, 32-bit
+						for ( int i = 0; i < 16*nBPP; i++ ) // 16 px, 32-bit
 							*pDst++ = *pSrc++;
 
 						pDst -= (16*nBPP);
@@ -5041,12 +5041,12 @@ Update_t CmdNTSC (int nArgs)
 				const uint8_t *pTmp = pSrc;
 				const uint32_t nBPP = 4; // bytes per pixel
 
-				for( int iPhase = 0; iPhase < 4; iPhase++ )
+				for ( int iPhase = 0; iPhase < 4; iPhase++ )
 				{
 					pSrc = pTmp + (iPhase * 16 * nBPP); // src is 16-px column
-					for( int y = 0; y < 256; y++ )
+					for ( int y = 0; y < 256; y++ )
 					{
-						for( int i = 0; i < 16*nBPP; i++ ) // 16 px, 32-bit
+						for ( int i = 0; i < 16*nBPP; i++ ) // 16 px, 32-bit
 							*pDst++ = *pSrc++;
 
 						pSrc -= (16*nBPP);
@@ -5078,12 +5078,12 @@ Update_t CmdNTSC (int nArgs)
 		if (iParam == PARAM_SAVE)
 		{
 			FILE *pFile = fopen( sPaletteFilePath.c_str(), "w+b" );
-			if( pFile )
+			if ( pFile )
 			{
 				size_t nWrote = 0;
 				uint8_t *pSwizzled = new uint8_t[ g_nChromaSize ];
 
-				if( iFileType == TYPE_BMP )
+				if ( iFileType == TYPE_BMP )
 				{
 					// need to save 32-bit bpp as 24-bit bpp
 					// VideoSaveScreenShot()
@@ -5121,7 +5121,7 @@ Update_t CmdNTSC (int nArgs)
 		if (iParam == PARAM_LOAD)
 		{
 			FILE *pFile = fopen( sPaletteFilePath.c_str(), "rb" );
-			if( pFile )
+			if ( pFile )
 			{
 				strcpy( aStatusText, "Loaded" );
 
@@ -5131,7 +5131,7 @@ Update_t CmdNTSC (int nArgs)
 				bool     bSwizzle  = true;
 
 				WinBmpHeader4_t bmp, *pBmp = &bmp;
-				if( iFileType == TYPE_BMP )
+				if ( iFileType == TYPE_BMP )
 				{
 					fread( pBmp, sizeof( WinBmpHeader4_t ), 1, pFile );
 					fseek( pFile, pBmp->nOffsetData, SEEK_SET );
@@ -5148,7 +5148,7 @@ Update_t CmdNTSC (int nArgs)
 						goto _error;
 					}
 
-					if( !
+					if ( !
 					(  ((pBmp->nWidthPixels  == 64 ) && (pBmp->nHeightPixels == 256))
 					|| ((pBmp->nWidthPixels  == 64 ) && (pBmp->nHeightPixels == 1))
 					|| ((pBmp->nWidthPixels  == 16 ) && (pBmp->nHeightPixels == 1))
@@ -5158,16 +5158,16 @@ Update_t CmdNTSC (int nArgs)
 						goto _error;
 					}
 
-					if(pBmp->nStructSize == 0x28)
+					if (pBmp->nStructSize == 0x28)
 					{
-						if( pBmp->nCompression == 0) // BI_RGB mode
+						if ( pBmp->nCompression == 0) // BI_RGB mode
 							bSwizzle = false;
 					}
 					else // 0x7C version4 bitmap
 					{
-						if( pBmp->nCompression == 3 ) // BI_BITFIELDS
+						if ( pBmp->nCompression == 3 ) // BI_BITFIELDS
 						{
-							if((pBmp->nRedMask   == 0xFF000000 ) // Gimp writes in ABGR order
+							if ((pBmp->nRedMask   == 0xFF000000 ) // Gimp writes in ABGR order
 							&& (pBmp->nGreenMask == 0x00FF0000 )
 							&& (pBmp->nBlueMask  == 0x0000FF00 ))
 								bSwizzle = true;
@@ -5175,7 +5175,7 @@ Update_t CmdNTSC (int nArgs)
 					}
 				}
 				else
-					if( nFileSize != g_nChromaSize )
+					if ( nFileSize != g_nChromaSize )
 					{
 						sprintf( aStatusText, "Raw size != %d", 64*256*4 );
 						goto _error;
@@ -5184,7 +5184,7 @@ Update_t CmdNTSC (int nArgs)
 
 				fread( pSwizzled, g_nChromaSize, 1, pFile );
 
-				if( iFileType == TYPE_BMP )
+				if ( iFileType == TYPE_BMP )
 				{
 
 					if (pBmp->nHeightPixels == 1)
@@ -5210,7 +5210,7 @@ Update_t CmdNTSC (int nArgs)
 					else
 						Transpose4096x4::transposeFrom64x256( pSwizzled, (uint8_t*) pChromaTable );
 
-					if( bSwizzle )
+					if ( bSwizzle )
 						Swizzle32::ABGRswizzleBGRA( g_nChromaSize, (uint8_t*) pChromaTable, (uint8_t*) pChromaTable );
 				}
 				else
@@ -5257,11 +5257,11 @@ int CmdTextSave (int nArgs)
 
 	std::string sLoadSaveFilePath = g_sCurrentDir; // g_sProgramDir
 
-	if( bHaveFileName )
+	if ( bHaveFileName )
 		g_sMemoryLoadSaveFileName = g_aArgs[ 1 ].sArg;
 	else
 	{
-		if( GetVideo().VideoGetSW80COL() )
+		if ( GetVideo().VideoGetSW80COL() )
 			g_sMemoryLoadSaveFileName = "AppleWin_Text80.txt";
 		else
 			g_sMemoryLoadSaveFileName = "AppleWin_Text40.txt";
@@ -5310,7 +5310,7 @@ int _SearchMemoryFind(
 	g_vMemorySearchResults.push_back( NO_6502_TARGET );
 
 	WORD nAddress;
-	for( nAddress = nAddressStart; nAddress < nAddressEnd; nAddress++ )
+	for ( nAddress = nAddressStart; nAddress < nAddressEnd; nAddress++ )
 	{
 		bool bMatchAll = true;
 
@@ -5764,7 +5764,7 @@ Update_t CmdOutputCalc (int nArgs)
 
 	int nBit = 0;
 	int iBit = 0;
-	for( iBit = 0; iBit < nBits; iBit++ )
+	for ( iBit = 0; iBit < nBits; iBit++ )
 	{
 		bool bSet = (nAddress >> iBit) & 1;
 		if (bSet)
@@ -5860,7 +5860,7 @@ Update_t CmdOutputPrint (int nArgs)
 		{
 			int iChar;
 			int nChar = _tcslen( g_aArgs[ iArg ].sArg );
-			for( iChar = 0; iChar < nChar; iChar++ )
+			for ( iChar = 0; iChar < nChar; iChar++ )
 			{
 				TCHAR c = g_aArgs[ iArg ].sArg[ iChar ];
 				sText[ nLen++ ] = c;
@@ -5947,13 +5947,13 @@ Update_t CmdOutputPrintf (int nArgs)
 		{
 			int iChar;
 			int nChar = _tcslen( g_aArgs[ iArg ].sArg );
-			for( iChar = 0; iChar < nChar; iChar++ )
+			for ( iChar = 0; iChar < nChar; iChar++ )
 			{
 				TCHAR c = g_aArgs[ iArg ].sArg[ iChar ];
 				switch ( eThis )
 				{
 					case PS_LITERAL:
-						switch( c )
+						switch ( c )
 						{
 							case '\\':
 								eThis = PS_ESCAPE;
@@ -5967,7 +5967,7 @@ Update_t CmdOutputPrintf (int nArgs)
 						}
 						break;
 					case PS_ESCAPE:
-						switch( c )
+						switch ( c )
 						{
 							case 'n':
 							case 'r':
@@ -5982,7 +5982,7 @@ Update_t CmdOutputPrintf (int nArgs)
 							ConsoleBufferPushFormat( "Error: Missing value arg: %d", iValue + 1 );
 							return ConsoleUpdate();
 						}
-						switch( c )
+						switch ( c )
 						{
 							case 'X':
 							case 'x': // PS_NEXT_ARG_HEX
@@ -6098,7 +6098,7 @@ Update_t CmdOutputRun (int nArgs)
 
 		Update_t bUpdateDisplay = UPDATE_NOTHING;	
 
-		for( int iLine = 0; iLine < nLine; iLine++ )
+		for ( int iLine = 0; iLine < nLine; iLine++ )
 		{
 			script.GetLine( iLine, g_pConsoleInput, CONSOLE_WIDTH-2 );
 			g_nConsoleInputChars = _tcslen( g_pConsoleInput );
@@ -6208,7 +6208,7 @@ bool ParseAssemblyListing( bool bBytesToMemory, bool bAddSymbols )
 	const DWORD INVALID_ADDRESS = _6502_MEM_END + 1;
 
 	int nLines = g_AssemblerSourceBuffer.GetNumLines();
-	for( int iLine = 0; iLine < nLines; iLine++ )
+	for ( int iLine = 0; iLine < nLines; iLine++ )
 	{
 		g_AssemblerSourceBuffer.GetLine( iLine, sText, MAX_LINE - 1 );
 
@@ -6330,7 +6330,7 @@ Update_t CmdSource (int nArgs)
 		g_bSourceAddMemory = false;
 		g_bSourceAddSymbols = false;
 
-		for( int iArg = 1; iArg <= nArgs; iArg++ )
+		for ( int iArg = 1; iArg <= nArgs; iArg++ )
 		{	
 			const std::string pFileName = g_aArgs[ iArg ].sArg;
 
@@ -6496,7 +6496,7 @@ enum ViewVideoPage_t
 
 Update_t _ViewOutput( ViewVideoPage_t iPage, int bVideoModeFlags )
 {
-	switch( iPage ) 
+	switch ( iPage ) 
 	{
 		case VIEW_PAGE_X:
 			bVideoModeFlags |= !GetVideo().VideoGetSWPAGE2() ? 0 : VF_PAGE2;
@@ -7302,14 +7302,14 @@ Update_t CmdZeroPagePointer (int nArgs)
 	// p[0..4]                : disable
 	// p[0..4] <ZeroPageAddr> : enable
 
-	if( (nArgs != 0) && (nArgs != 1) )
+	if ( (nArgs != 0) && (nArgs != 1) )
 		return Help_Arg_1( g_iCommand );
 //		return DisplayHelp(CmdZeroPagePointer);
 
 //	int nPtrNum = g_aArgs[0].sArg[1] - '0'; // HACK: hard-coded to command length
 	int iZP = g_iCommand - CMD_ZEROPAGE_POINTER_0;
 
-	if( (iZP < 0) || (iZP >= MAX_ZEROPAGE_POINTERS) )
+	if ( (iZP < 0) || (iZP >= MAX_ZEROPAGE_POINTERS) )
 		return Help_Arg_1( g_iCommand );
 
 	if (nArgs == 0)
@@ -7367,7 +7367,7 @@ int FindParam(LPCTSTR pLookupName, Match_e eMatch, int & iParam_, int iParamBegi
 	{	
 #if ALLOW_INPUT_LOWERCASE
 		TCHAR aLookup[ 256 ] = "";
-		for( int i = 0; i < nLen; i++ )
+		for ( int i = 0; i < nLen; i++ )
 		{
 			aLookup[ i ] = toupper( pLookupName[ i ] );
 		}
@@ -7532,7 +7532,7 @@ Update_t ExecuteCommand (int nArgs)
 			for (int iChar = 0; iChar < (nLen - 1); iChar++, pChar++ )
 			{
 				bIsHex = IsHexDigit( *pChar );
-				if( !bIsHex )
+				if ( !bIsHex )
 				{
 					break;
 				}
@@ -7616,11 +7616,11 @@ Update_t ExecuteCommand (int nArgs)
 					bool bFoundLen = false;
 
 					pChar = pSrc;
-					while( *pChar )
+					while ( *pChar )
 					{
-						if( *pChar == '.' )
+						if ( *pChar == '.' )
 						{
-							if( pEnd ) // only allowed one period
+							if ( pEnd ) // only allowed one period
 							{
 								pEnd = 0;
 								break;
@@ -7630,22 +7630,22 @@ Update_t ExecuteCommand (int nArgs)
 							pEnd = pChar + 1;
 							bFoundSrc = true;
 						} else
-						if( !IsHexDigit( *pChar ) )
+						if ( !IsHexDigit( *pChar ) )
 						{
 							break;
 						}	
 						pChar++;
 					}
-					if( pEnd ) {
-						if(	(*pChar == 'M')
+					if ( pEnd ) {
+						if (	(*pChar == 'M')
 						||	(*pChar == 'm'))
 						{
 							*pChar++ = 0;
-							if( ! *pChar )
+							if ( ! *pChar )
 								bFoundLen = true;
 						}
 
-						if( bFoundSrc && bFoundLen )
+						if ( bFoundSrc && bFoundLen )
 						{
 							//ArgsGetValue( pArg, & nAddress );
 							//ConsolePrintFormat( "Dst:%s  Src: %s  End: %s", pDst, pSrc, pEnd );
@@ -7819,7 +7819,7 @@ int ParseInput ( LPTSTR pConsoleInput, bool bCook )
 	nArg = ArgsGet( pConsoleInput ); // Get the Raw Args
 
 	int iArg;
-	for( iArg = 0; iArg <= nArg; iArg++ )
+	for ( iArg = 0; iArg <= nArg; iArg++ )
 	{
 		g_aArgs[ iArg ] = g_aArgRaw[ iArg ];
 	}
@@ -8143,7 +8143,7 @@ bool ProfileSave()
 		int   nLine = g_nProfileLine;
 		int   iLine;
 		
-		for( iLine = 0; iLine < nLine; iLine++ )
+		for ( iLine = 0; iLine < nLine; iLine++ )
 		{
 			pText = ProfileLinePeek( iLine );
 			if ( pText )
@@ -8475,7 +8475,7 @@ void DebugDestroy ()
 //	DeleteObject(g_hFontWebDings);
 
 	// TODO: Symbols_Clear()
-	for( int iTable = 0; iTable < NUM_SYMBOL_TABLES; iTable++ )
+	for ( int iTable = 0; iTable < NUM_SYMBOL_TABLES; iTable++ )
 	{
 		_CmdSymbolsClear( (SymbolTable_Index_e) iTable );
 	}
@@ -8535,7 +8535,7 @@ void DebugInitialize ()
 	memset( g_aConsoleDisplay, 0, sizeof( g_aConsoleDisplay ) ); // CONSOLE_WIDTH * CONSOLE_HEIGHT );
 	ConsoleInputReset();
 
-	for( int iWindow = 0; iWindow < NUM_WINDOWS; iWindow++ )
+	for ( int iWindow = 0; iWindow < NUM_WINDOWS; iWindow++ )
 	{
 		WindowSplit_t *pWindow = & g_aWindowConfig[ iWindow ];
 
@@ -8888,7 +8888,7 @@ void DebuggerProcessKey( int keycode )
 		if (! g_nConsoleInputChars)
 		{
 			// bugfix: 2.6.1.35 Fixed: Pressing enter on blank line while in assembler wouldn't exit it.
-			if( g_bAssemblerInput )
+			if ( g_bAssemblerInput )
 			{
 				bUpdateDisplay |= DebuggerProcessCommand( false );
 			}

--- a/source/Debugger/Debugger_Assembler.cpp
+++ b/source/Debugger/Debugger_Assembler.cpp
@@ -493,9 +493,9 @@ int  _6502_GetOpmodeOpbyte ( const int nBaseAddress, int & iOpmode_, int & nOpby
 
 	// 2.7.0.0 TODO: FIXME: Opcode length that over-lap data, should be shortened ... if (nOpbyte_ > 1) if Disassembly_IsDataAddress( nBaseAddress + 1 ) nOpbyte_ = 1;
 	DisasmData_t* pData = Disassembly_IsDataAddress( nBaseAddress );
-	if( pData )
+	if ( pData )
 	{
-		if( pData_ )
+		if ( pData_ )
 			*pData_ = pData;
 
 		nSlack = pData->nEndAddress - pData->nStartAddress + 1; // *inclusive* KEEP IN SYNC: _CmdDefineByteRange() CmdDisasmDataList() _6502_GetOpmodeOpbyte() FormatNopcodeBytes()
@@ -503,7 +503,7 @@ int  _6502_GetOpmodeOpbyte ( const int nBaseAddress, int & iOpmode_, int & nOpby
 		// Data Disassembler
 		// Smart Disassembly - Data Section
 		// Assemblyer Directives - Psuedo Mnemonics
-		switch( pData->eElementType )
+		switch ( pData->eElementType )
 		{
 			case NOP_BYTE_1: nOpbyte_ = 1; iOpmode_ = AM_M; break;
 			case NOP_BYTE_2: nOpbyte_ = 2; iOpmode_ = AM_M; break;
@@ -880,8 +880,8 @@ Hash_t AssemblerHashMnemonic ( const TCHAR * pMnemonic )
 	}
 #endif
 
-	while( *pText )
-//	for( int iChar = 0; iChar < 4; iChar++ )
+	while ( *pText )
+//	for ( int iChar = 0; iChar < 4; iChar++ )
 	{	
 		char c = tolower( *pText ); // TODO: based on ALLOW_INPUT_LOWERCASE ??
 
@@ -904,7 +904,7 @@ void AssemblerHashOpcodes ()
 	Hash_t nMnemonicHash;
 	int    iOpcode;
 
-	for( iOpcode = 0; iOpcode < NUM_OPCODES; iOpcode++ )
+	for ( iOpcode = 0; iOpcode < NUM_OPCODES; iOpcode++ )
 	{
 		const TCHAR *pMnemonic = g_aOpcodes65C02[ iOpcode ].sMnemonic;
 		nMnemonicHash = AssemblerHashMnemonic( pMnemonic );
@@ -924,7 +924,7 @@ void AssemblerHashDirectives ()
 	Hash_t nMnemonicHash;
 	int    iOpcode;
 
-	for( iOpcode = 0; iOpcode < NUM_ASM_M_DIRECTIVES; iOpcode++ )
+	for ( iOpcode = 0; iOpcode < NUM_ASM_M_DIRECTIVES; iOpcode++ )
 	{
 		int iNopcode = FIRST_M_DIRECTIVE + iOpcode;
 //.		const TCHAR *pMnemonic = g_aAssemblerDirectivesMerlin[ iOpcode ].m_pMnemonic;
@@ -949,7 +949,7 @@ void _CmdAssembleHashDump ()
 	HashOpcode_t         tHash;
 
 	int iOpcode;
-	for( iOpcode = 0; iOpcode < NUM_OPCODES; iOpcode++ )
+	for ( iOpcode = 0; iOpcode < NUM_OPCODES; iOpcode++ )
 	{
 		tHash.m_iOpcode = iOpcode;
 		tHash.m_nValue  = g_aOpcodesHash[ iOpcode ]; 
@@ -961,7 +961,7 @@ void _CmdAssembleHashDump ()
 //	Hash_t nPrevHash = vHashes.at( 0 ).m_nValue;
 	Hash_t nThisHash = 0;
 
-	for( iOpcode = 0; iOpcode < NUM_OPCODES; iOpcode++ )
+	for ( iOpcode = 0; iOpcode < NUM_OPCODES; iOpcode++ )
 	{
 		tHash = vHashes.at( iOpcode );
 
@@ -1020,7 +1020,7 @@ bool AssemblerPokeOpcodeAddress( const WORD nBaseAddress )
 	int iOpcode;
 	int nOpcodes = m_vAsmOpcodes.size();
 
-	for( iOpcode = 0; iOpcode < nOpcodes; iOpcode++ )
+	for ( iOpcode = 0; iOpcode < nOpcodes; iOpcode++ )
 	{
 		int nOpcode = m_vAsmOpcodes.at( iOpcode ); // m_iOpcode;
 		int nOpmode = g_aOpcodes[ nOpcode ].nAddressMode;
@@ -1405,7 +1405,7 @@ void AssemblerProcessDelayedSymols()
 		bModified = false;
 		
 		std::vector<DelayedTarget_t>::iterator iSymbol;
-		for( iSymbol = m_vDelayedTargets.begin(); iSymbol != m_vDelayedTargets.end(); ++iSymbol )
+		for ( iSymbol = m_vDelayedTargets.begin(); iSymbol != m_vDelayedTargets.end(); ++iSymbol )
 		{
 			DelayedTarget_t *pTarget = & (*iSymbol); // m_vDelayedTargets.at( iSymbol );
 
@@ -1485,7 +1485,7 @@ bool Assemble( int iArg, int nArgs, WORD nAddress )
 	int iOpcode;
 	
 	// Ugh! Linear search.
-	for( iOpcode = 0; iOpcode < NUM_OPCODES; iOpcode++ )
+	for ( iOpcode = 0; iOpcode < NUM_OPCODES; iOpcode++ )
 	{
 		if (nMnemonicHash == g_aOpcodesHash[ iOpcode ])
 		{

--- a/source/Debugger/Debugger_Console.cpp
+++ b/source/Debugger/Debugger_Console.cpp
@@ -578,7 +578,7 @@ Update_t ConsoleScrollPageDn ()
 //===========================================================================
 Update_t ConsoleBufferTryUnpause (int nLines)
 {
-	for( int y = 0; y < nLines; y++ )
+	for ( int y = 0; y < nLines; y++ )
 	{
 		ConsoleBufferToDisplay();
 	}

--- a/source/Debugger/Debugger_Console.h
+++ b/source/Debugger/Debugger_Console.h
@@ -196,11 +196,11 @@
 		const char *pSrc = pText;
 		/* */ int   nLen = 0;
 
-		if( pText )
+		if ( pText )
 		{
-			while( *pSrc )
+			while ( *pSrc )
 			{
-				if( ConsoleColor_IsCharMeta( *pSrc ) )
+				if ( ConsoleColor_IsCharMeta( *pSrc ) )
 					pSrc++;
 				else
 					nLen++;

--- a/source/Debugger/Debugger_DisassemblerData.cpp
+++ b/source/Debugger/Debugger_DisassemblerData.cpp
@@ -113,9 +113,9 @@ WORD _GetDataRange (int nArgs, int iArg, DisasmData_t& tData_)
 
 	// 2.7.0.35 DW address -- round the length up to even number for convenience.
 	// Example: 'DW 6062' is equivalent to: 'DW 6062:6063'
-	if( g_iCommand == CMD_DEFINE_DATA_WORD1 )
+	if ( g_iCommand == CMD_DEFINE_DATA_WORD1 )
 	{
-		if( ~nLen & 1 )
+		if ( ~nLen & 1 )
 			nLen++;
 	}
 
@@ -141,9 +141,9 @@ WORD _CmdDefineByteRange(int nArgs,int iArg,DisasmData_t & tData_)
 	SymbolTable_Index_e eSymbolTable = SYMBOLS_ASSEMBLY;
 	bool bAutoDefineName = false; // 2.7.0.34
 
-	if( nArgs > 1 )
+	if ( nArgs > 1 )
 	{
-		if( g_aArgs[ 2 ].eToken == TOKEN_COLON ) // 2.7.0.31 Bug fix: DB range, i.e. DB 174E:174F
+		if ( g_aArgs[ 2 ].eToken == TOKEN_COLON ) // 2.7.0.31 Bug fix: DB range, i.e. DB 174E:174F
 		{
 			bAutoDefineName = true;
 		}
@@ -165,22 +165,22 @@ WORD _CmdDefineByteRange(int nArgs,int iArg,DisasmData_t & tData_)
 		Nopcode_e nopcode = NOP_BYTE_1;
 
 		bool isFloat = (g_iCommand == CMD_DEFINE_DATA_FLOAT);
-		if( isFloat )
+		if ( isFloat )
 			nopcode = NOP_FAC;
 
 		bool isString = (g_iCommand == CMD_DEFINE_DATA_STR);
-		if( isString )
+		if ( isString )
 			nopcode = NOP_STRING_ASCII;
 
 		bool isWord1 = (g_iCommand == CMD_DEFINE_DATA_WORD1);
-		if( isWord1 )
+		if ( isWord1 )
 			nopcode = NOP_WORD_1;
 
 		bool isAddr = (g_iCommand == CMD_DEFINE_ADDR_WORD);
-		if( isAddr )
+		if ( isAddr )
 			nopcode = NOP_ADDRESS;
 
-	if( bAutoDefineName )
+	if ( bAutoDefineName )
 	{
 		_GetAutoSymbolName( nopcode, tData_.nStartAddress , aSymbolName );
 		pSymbolName = aSymbolName;
@@ -264,7 +264,7 @@ Update_t CmdDisasmDataDefCode (int nArgs)
 	while (nAddress <= tData.nEndAddress)
 	{
 		DisasmData_t *pData = Disassembly_IsDataAddress( nAddress );
-		if( pData )
+		if ( pData )
 		{
 			if ((      nAddress    <= pData->nStartAddress)
 			&&  (tData.nEndAddress >= pData->nEndAddress  ))
@@ -342,7 +342,7 @@ Update_t CmdDisasmDataList (int nArgs)
 	// Need to iterate through all blocks
 	DisasmData_t* pData = NULL;
 
-	while( (pData = Disassembly_Enumerate( pData )) )
+	while ( (pData = Disassembly_Enumerate( pData )) )
 	{
 		if (pData->iDirective != _NOP_REMOVED)
 		{
@@ -411,7 +411,7 @@ Update_t _CmdDisasmDataDefByteX (int nArgs)
 
 	// Already exists, so update
 	DisasmData_t *pData = Disassembly_IsDataAddress( nAddress );
-	if( pData )
+	if ( pData )
 	{
 		*pData = tData;
 	}
@@ -462,7 +462,7 @@ Update_t _CmdDisasmDataDefWordX (int nArgs)
 
 	// Already exists, so update
 	DisasmData_t *pData = Disassembly_IsDataAddress( nAddress );
-	if( pData )
+	if ( pData )
 	{
 		*pData = tData;
 	}
@@ -514,7 +514,7 @@ Update_t CmdDisasmDataDefAddress16 (int nArgs)
 
 	// Already exists, so update
 	DisasmData_t *pData = Disassembly_IsDataAddress( nAddress );
-	if( pData )
+	if ( pData )
 	{
 		*pData = tData;
 	}
@@ -629,7 +629,7 @@ Update_t CmdDisasmDataDefString ( int nArgs )
 
 	// Already exists, so update
 	DisasmData_t *pData = Disassembly_IsDataAddress( nAddress );
-	if( pData )
+	if ( pData )
 	{
 		*pData = tData;
 	}
@@ -648,12 +648,12 @@ DisasmData_t* Disassembly_Enumerate( DisasmData_t *pCurrent )
 	DisasmData_t *pData = NULL; // bIsNopcode = false
 	int nDataTargets = g_aDisassemblerData.size();
 
-	if( nDataTargets )
+	if ( nDataTargets )
 	{
 		DisasmData_t *pBegin = & g_aDisassemblerData[ 0 ];
 		DisasmData_t *pEnd   = & g_aDisassemblerData[ nDataTargets - 1 ];
 
-		if( pCurrent )
+		if ( pCurrent )
 		{
 			pCurrent++;
 			if (pCurrent <= pEnd)
@@ -672,15 +672,15 @@ DisasmData_t* Disassembly_IsDataAddress ( WORD nAddress )
 	DisasmData_t *pData = NULL; // bIsNopcode = false
 	int nDataTargets = g_aDisassemblerData.size();
 
-	if( nDataTargets )
+	if ( nDataTargets )
 	{
 		// TODO: Replace with binary search -- should store data in sorted order, via start address
 		pData = & g_aDisassemblerData[ 0 ];
-		for( int iTarget = 0; iTarget < nDataTargets; iTarget++ )
+		for ( int iTarget = 0; iTarget < nDataTargets; iTarget++ )
 		{
-			if( pData->iDirective != _NOP_REMOVED )
+			if ( pData->iDirective != _NOP_REMOVED )
 			{
-				if( (nAddress >= pData->nStartAddress) && (nAddress <= pData->nEndAddress) )
+				if ( (nAddress >= pData->nStartAddress) && (nAddress <= pData->nEndAddress) )
 				{
 					return pData;
 				}
@@ -703,7 +703,7 @@ void Disassembly_AddData( DisasmData_t tData)
 //===========================================================================
 void Disassembly_GetData ( WORD nBaseAddress, const DisasmData_t *pData, DisasmLine_t & line_ )
 {
-	if( !pData )
+	if ( !pData )
 	{
 #if _DEBUG
 		ConsoleDisplayError( "Disassembly_GetData() but we don't have a valid DisasmData_t *" );
@@ -721,11 +721,11 @@ void Disassembly_DelData( DisasmData_t tData)
 	DisasmData_t *pData = NULL; // bIsNopcode = false
 	int nDataTargets = g_aDisassemblerData.size();
 
-	if( nDataTargets )
+	if ( nDataTargets )
 	{
 		// TODO: Replace with binary search -- should store data in sorted order, via start address
 		pData = & g_aDisassemblerData[ 0 ];
-		for( int iTarget = 0; iTarget < nDataTargets; iTarget++ )
+		for ( int iTarget = 0; iTarget < nDataTargets; iTarget++ )
 		{
 			if (pData->iDirective != _NOP_REMOVED)
 			{

--- a/source/Debugger/Debugger_Display.cpp
+++ b/source/Debugger/Debugger_Display.cpp
@@ -716,7 +716,7 @@ static void PrintGlyph( const int xDst, const int yDst, const int glyph )
 	_ASSERT(ySrc < CONSOLE_FONT_BITMAP_HEIGHT);
 
 	// BUG #239 - (Debugger) Save debugger "text screen" to clipboard / file
-	//	if( g_bDebuggerVirtualTextCapture )
+	//	if ( g_bDebuggerVirtualTextCapture )
 	// 
 	{
 #if _DEBUG
@@ -726,8 +726,8 @@ static void PrintGlyph( const int xDst, const int yDst, const int glyph )
 		int col = xDst / CONSOLE_FONT_WIDTH ;
 		int row = yDst / CONSOLE_FONT_HEIGHT;
 		
-		// if( !g_bDebuggerCopyInfoPane )
-		//    if( col < 50
+		// if ( !g_bDebuggerCopyInfoPane )
+		//    if ( col < 50
 		if (xDst > DISPLAY_DISASM_RIGHT) // INFO_COL_2 // DISPLAY_CPU_INFO_LEFT_COLUMN
 			col++;
 
@@ -787,7 +787,7 @@ void DebuggerPrintColor( int x, int y, const conchar_t * pText )
 	conchar_t g;
 	const conchar_t *pSrc = pText;
 
-	if( !pText)
+	if ( !pText)
 		return;
 
 	while ((g = (*pSrc)))
@@ -1509,7 +1509,7 @@ WORD DrawDisassemblyLine ( int iLine, const WORD nBaseAddress )
 //		DebuggerSetColorFG( GetDebuggerMemDC(), DebuggerGetColor( BG_DISASM_BOOKMARK ) ); // swapped
 //	}
 
-	if( g_bConfigDisasmAddressView )
+	if ( g_bConfigDisasmAddressView )
 	{
 		PrintTextCursorX( (LPCTSTR) line.sAddress, linerect );
 	}
@@ -1571,7 +1571,7 @@ WORD DrawDisassemblyLine ( int iLine, const WORD nBaseAddress )
 
 	if (! bCursorLine)
 	{
-		if( pData ) // Assembler Data Directive / Data Disassembler
+		if ( pData ) // Assembler Data Directive / Data Disassembler
 			DebuggerSetColorFG( DebuggerGetColor( FG_DISASM_DIRECTIVE ) ); // TODO: FIXME: HACK? Is the color fine?
 		else
 			DebuggerSetColorFG( DebuggerGetColor( iForeground ) );
@@ -1759,7 +1759,7 @@ WORD DrawDisassemblyLine ( int iLine, const WORD nBaseAddress )
 	}
 
 	// BUGFIX: 2.6.2.30:  DA $target --> show right paren
-	if( pData )
+	if ( pData )
 	{
 		return nOpbyte;
 	}
@@ -1795,7 +1795,7 @@ WORD DrawDisassemblyLine ( int iLine, const WORD nBaseAddress )
 	{
 		linerect.left = (int) aTabs[ TS_IMMEDIATE ];
 
-		if( line.nImmediate )
+		if ( line.nImmediate )
 		{
 			/*
                 300:A9 80 A9 81 A9 FF A9 00 A9 01 A9 7E A9 7F
@@ -1967,7 +1967,7 @@ void DrawMemory ( int line, int iMemDump )
 #if DEBUG_FORCE_DISPLAY
 	bActive = true;
 #endif
-	if( !bActive )
+	if ( !bActive )
 		return;
 
 	USHORT       nAddr   = pMD->nAddress;
@@ -2003,7 +2003,7 @@ void DrawMemory ( int line, int iMemDump )
 //		sprintf(sData,"Mem at SY#%d", nAddr);
 		sprintf( sAddress,"SY#%d", nAddr );
 	}
-	else if(eDevice == DEV_AY8910)
+	else if (eDevice == DEV_AY8910)
 	{
 //		sprintf(sData,"Mem at AY#%d", nAddr);
 		sprintf( sAddress,"AY#%d", nAddr );
@@ -2289,7 +2289,7 @@ void _DrawSoftSwitch( RECT & rect, int nAddress, bool bSet, const char *sPrefix,
 
 	_DrawSoftSwitchAddress( temp, nAddress, bg_default );
 
-	if( sPrefix )
+	if ( sPrefix )
 	{
 		DebuggerSetColorFG( DebuggerGetColor( FG_INFO_REG )); // light blue
 		PrintTextCursorX( sPrefix, temp );
@@ -2331,7 +2331,7 @@ void _DrawTriStateSoftSwitch( RECT & rect, int nAddress, const int iBankDisplay,
 		// TODO: Q. Show which bank we are writing to in red?
 		//       A. No, since we highlight bank 2 or 1, along with R/W
 		DebuggerSetColorBG( DebuggerGetColor( bg_default    ));
-		if( bDisabled )
+		if ( bDisabled )
 			DebuggerSetColorFG( DebuggerGetColor( FG_INFO_TITLE  ) );
 		else
 			DebuggerSetColorFG( DebuggerGetColor( FG_DISASM_OPERATOR ) );
@@ -2874,7 +2874,7 @@ void DrawWatches (int line)
 			rect2 = rect;
 
 			DebuggerSetColorFG( DebuggerGetColor( FG_INFO_OPCODE ));
-			for( int iByte = 0; iByte < 8; iByte++ )
+			for ( int iByte = 0; iByte < 8; iByte++ )
 			{
 				if  ((iByte & 3) == 0) {
 					DebuggerSetColorBG( DebuggerGetColor( BG_INFO_WATCH ));
@@ -2916,7 +2916,7 @@ void DrawZeroPagePointers ( int line )
 	const int nMaxSymbolLen = 7;
 	char sText[nMaxSymbolLen+1] = "";
 
-	for(int iZP = 0; iZP < MAX_ZEROPAGE_POINTERS; iZP++)
+	for (int iZP = 0; iZP < MAX_ZEROPAGE_POINTERS; iZP++)
 	{
 		RECT rect2 = rect;
 
@@ -2951,7 +2951,7 @@ void DrawZeroPagePointers ( int line )
 
 			DebuggerSetColorFG( DebuggerGetColor( FG_DISASM_ADDRESS ));
 
-			for( int x = 0; x < nMaxSymbolLen; x++ )
+			for ( int x = 0; x < nMaxSymbolLen; x++ )
 			{
 				sText[ x ] = CHAR_SPACE;
 			}
@@ -3457,7 +3457,7 @@ void DrawSubWindow_Source2 (Update_t bUpdate)
 			iSourceLine = 0;
 	}
 
-	for( int iLine = 0; iLine < nLines; iLine++ )
+	for ( int iLine = 0; iLine < nLines; iLine++ )
 	{
 		if (iLine != iSourceCursor)
 		{
@@ -3635,7 +3635,7 @@ void UpdateDisplay (Update_t bUpdate)
 		}
 	}
 	
-	switch( g_iWindowThis )
+	switch ( g_iWindowThis )
 	{
 		case WINDOW_CODE:
 			DrawWindow_Code( bUpdate );

--- a/source/Debugger/Debugger_Help.cpp
+++ b/source/Debugger/Debugger_Help.cpp
@@ -261,7 +261,7 @@ void Help_Operators()
 	_tcscpy( sText, "    " );
 	strcat( sText, CHC_USAGE );
 	int iBreakOp = 0;
-	for( iBreakOp = 0; iBreakOp < NUM_BREAKPOINT_OPERATORS; iBreakOp++ )
+	for ( iBreakOp = 0; iBreakOp < NUM_BREAKPOINT_OPERATORS; iBreakOp++ )
 	{
 		if ((iBreakOp >= PARAM_BP_LESS_EQUAL) &&
 			(iBreakOp <= PARAM_BP_GREATER_EQUAL))
@@ -452,7 +452,7 @@ bool Colorize( char * pDst, size_t /*nDstSz*/, const char* pSrc)
 			const char *start = pSrc;
 			const char *end   = pSrc;
 
-			while( isHexDigit( *end ) )
+			while ( isHexDigit( *end ) )
 				end++;
 
 			size_t nDigits = end - start;
@@ -580,11 +580,11 @@ Update_t CmdHelpSpecific (int nArgs)
 		{
 	//		int nFoundCategory = FindParam( g_aArgs[ iArg ].sArg, MATCH_EXACT, iParam, _PARAM_HELPCATEGORIES_BEGIN, _PARAM_HELPCATEGORIES_END );
 			int nFoundCategory = FindParam( g_aArgs[ iArg ].sArg, MATCH_FUZZY, iParam, _PARAM_HELPCATEGORIES_BEGIN, _PARAM_HELPCATEGORIES_END );
-			if( nFoundCategory )
+			if ( nFoundCategory )
 				bCategory = true;
 			else
 				bCategory = false;
-			switch( iParam )
+			switch ( iParam )
 			{
 				case PARAM_CAT_BOOKMARKS  : iCmdBegin = CMD_BOOKMARK        ; iCmdEnd = CMD_BOOKMARK_SAVE        ; break;
 				case PARAM_CAT_BREAKPOINTS: iCmdBegin = CMD_BREAK_INVALID   ; iCmdEnd = CMD_BREAKPOINT_SAVE      ; break;
@@ -646,7 +646,7 @@ Update_t CmdHelpSpecific (int nArgs)
 					if (nFound) {
 						bCategory = false; 
 					} else  // 2.7.0.17: HELP <category> wasn't displaying when category was one of: FLAGS, OUTPUT, WATCHES
-						if( nFoundCategory )
+						if ( nFoundCategory )
 						{
 							iCmdBegin = CMD_WATCH_ADD       ; iCmdEnd = CMD_WATCH_LIST           ;
 						}
@@ -1513,7 +1513,7 @@ Update_t CmdHelpList (int nArgs)
 		        StringCat( sText, CHC_DEFAULT, nBuf );
 		nLen += StringCat( sText, ": " , nBuf );
 
-	for( iCommand = 0; iCommand < NUM_COMMANDS_WITH_ALIASES; iCommand++ ) // aliases are not printed
+	for ( iCommand = 0; iCommand < NUM_COMMANDS_WITH_ALIASES; iCommand++ ) // aliases are not printed
 	{
 		Command_t *pCommand = & g_vSortedCommands.at( iCommand );
 //		Command_t *pCommand = & g_aCommands[ iCommand ];

--- a/source/Debugger/Debugger_Parser.cpp
+++ b/source/Debugger/Debugger_Parser.cpp
@@ -366,7 +366,7 @@ bool ArgsGetRegisterValue ( Arg_t *pArg, WORD * pAddressValue_ )
 	if (pArg && pAddressValue_)
 	{
 		// Check if we refer to reg A X Y P S
-		for( int iReg = 0; iReg < (NUM_BREAKPOINT_SOURCES-1); iReg++ )
+		for ( int iReg = 0; iReg < (NUM_BREAKPOINT_SOURCES-1); iReg++ )
 		{
 			// Skip Opcode/Instruction/Mnemonic
 			if (iReg == BP_SRC_OPCODE)
@@ -379,7 +379,7 @@ bool ArgsGetRegisterValue ( Arg_t *pArg, WORD * pAddressValue_ )
 			// Handle one char names
 			if ((pArg->nArgLen == 1) && (pArg->sArg[0] == g_aBreakpointSource[ iReg ][0]))
 			{
-				switch( iReg )
+				switch ( iReg )
 				{
 					case BP_SRC_REG_A : *pAddressValue_ = regs.a  & 0xFF; bStatus = true; break;
 					case BP_SRC_REG_P : *pAddressValue_ = regs.ps & 0xFF; bStatus = true; break;
@@ -912,7 +912,7 @@ void TextConvertTabsToSpaces( TCHAR *pDeTabified_, LPCTSTR pText, const int nDst
 			if ((nCur + nGap) >= nDstSize)
 				break;
 
-			for( int iSpc = 0; iSpc < nGap; iSpc++ )
+			for ( int iSpc = 0; iSpc < nGap; iSpc++ )
 			{
 				*pDst++ = CHAR_SPACE;
 			}

--- a/source/Debugger/Debugger_Symbols.cpp
+++ b/source/Debugger/Debugger_Symbols.cpp
@@ -103,7 +103,7 @@ Update_t _PrintSymbolInvalidTable()
 
 	// Similar to _CmdSymbolsInfoHeader()
 	sText[0] = 0;
-	for( int iTable = 0; iTable < NUM_SYMBOL_TABLES; iTable++ )
+	for ( int iTable = 0; iTable < NUM_SYMBOL_TABLES; iTable++ )
 	{
 		sprintf( sTemp, "%s%s%s%c " // %s"
 			, CHC_USAGE, g_aSymbolTableNames[ iTable ]
@@ -160,7 +160,7 @@ std::string const* FindSymbolFromAddress (WORD nAddress, int * iTable_ )
 			continue;
 
 		std::map<WORD, std::string>::iterator iSymbols = g_aSymbols[iTable].find(nAddress);
-		if(g_aSymbols[iTable].find(nAddress) != g_aSymbols[iTable].end())
+		if (g_aSymbols[iTable].find(nAddress) != g_aSymbols[iTable].end())
 		{
 			if (iTable_)
 			{
@@ -335,16 +335,16 @@ Update_t CmdSymbolsInfo (int nArgs)
 
 	int bTable = 1;
 	int iTable = 0;
-	for( ; bTable <= bDisplaySymbolTables; iTable++, bTable <<= 1 )
+	for ( ; bTable <= bDisplaySymbolTables; iTable++, bTable <<= 1 )
 	{
-		if( bDisplaySymbolTables & bTable )
+		if ( bDisplaySymbolTables & bTable )
 		{
 			_CmdSymbolsInfoHeader( iTable, sTemp ); // 15 chars per table
 
 			// 2.8.0.4 BUGFIX: Check for buffer overflow and wrap text
 			int nLen = ConsoleColor_StringLength( sTemp );
 			int nDst = ConsoleColor_StringLength( sText );
-			if((nDst + nLen) > CONSOLE_WIDTH )
+			if ((nDst + nLen) > CONSOLE_WIDTH )
 			{
 				ConsolePrint( sText );
 				strcpy( sText, sIndent ); // Indent new line
@@ -381,7 +381,7 @@ bool _FindSymbolTable( int bSymbolTables, int iTable )
 	// iTable is enumeration
 	// bSymbolTables is bit-flags of enabled tables to search
 
-	if( bSymbolTables & (1 << iTable) )
+	if ( bSymbolTables & (1 << iTable) )
 	{
 		return true;
 	}
@@ -396,9 +396,9 @@ int _GetSymbolTableFromFlag( int bSymbolTables )
 	int iTable = 0;
 	int bTable = 1;
 
-	for( ; bTable <= bSymbolTables; iTable++, bTable <<= 1 )
+	for ( ; bTable <= bSymbolTables; iTable++, bTable <<= 1 )
 	{
-		if( bTable & bSymbolTables )
+		if ( bTable & bSymbolTables )
 			break;
 	}
 
@@ -478,22 +478,22 @@ Update_t _CmdSymbolsListTables (int nArgs, int bSymbolTables )
 		
 	TCHAR sText[ CONSOLE_WIDTH ] = "";
 
-	for( int iArgs = 1; iArgs <= nArgs; iArgs++ )
+	for ( int iArgs = 1; iArgs <= nArgs; iArgs++ )
 	{
 		WORD nAddress = g_aArgs[iArgs].nValue;
 		LPCTSTR pSymbol = g_aArgs[iArgs].sArg;
 
 		// Dump all symbols for this table
-		if( g_aArgRaw[iArgs].eToken == TOKEN_STAR)
+		if ( g_aArgRaw[iArgs].eToken == TOKEN_STAR)
 		{
 	//		int iWhichTable = (g_iCommand - CMD_SYMBOLS_MAIN);
 	//		bDisplaySymbolTables = (1 << iWhichTable);
 
 			int iTable = 0;
 			int bTable = 1;
-			for( ; bTable <= bSymbolTables; iTable++, bTable <<= 1 )
+			for ( ; bTable <= bSymbolTables; iTable++, bTable <<= 1 )
 			{
-				if( bTable & bSymbolTables )
+				if ( bTable & bSymbolTables )
 				{
 					int nSymbols = g_aSymbols[iTable].size();
 					if (nSymbols)
@@ -569,7 +569,7 @@ int ParseSymbolTable(const std::string & pPathFileName, SymbolTable_Index_e eSym
 
 	FILE *hFile = fopen( pPathFileName.c_str(), "rt" );
 
-	if( !hFile && g_bSymbolsDisplayMissingFile )
+	if ( !hFile && g_bSymbolsDisplayMissingFile )
 	{
 		// TODO: print filename! Bug #242 Help file (.chm) description for "Symbols" #242
 		ConsoleDisplayError( "Symbol File not found:" );
@@ -578,9 +578,9 @@ int ParseSymbolTable(const std::string & pPathFileName, SymbolTable_Index_e eSym
 	}
 	
 	bool bDupSymbolHeader = false;
-	if( hFile )
+	if ( hFile )
 	{
-		while( !feof(hFile) )
+		while ( !feof(hFile) )
 		{
 			// Support 2 types of symbols files:
 			// 1) AppleWin:
@@ -596,24 +596,24 @@ int ParseSymbolTable(const std::string & pPathFileName, SymbolTable_Index_e eSym
 			const int MAX_LINE = 256;
 			char  szLine[ MAX_LINE ] = "";
 
-			if( !fgets(szLine, MAX_LINE-1, hFile) )	// Get next line
+			if ( !fgets(szLine, MAX_LINE-1, hFile) )	// Get next line
 			{
 				//ConsolePrint("<<EOF");
 				break;
 			}
 
-			if(strstr(szLine, "$") == NULL)
+			if (strstr(szLine, "$") == NULL)
 			{
 				sscanf(szLine, strFormat1.c_str(), &nAddress, sName);
 			}
 			else
 			{
 				char* p = strstr(szLine, "=");	// Optional
-				if(p) *p = ' ';
+				if (p) *p = ' ';
 				p = strstr(szLine, "$");
-				if(p) *p = ' ';
+				if (p) *p = ' ';
 				p = strstr(szLine, ";");		// Optional
-				if(p) *p = 0;
+				if (p) *p = 0;
 				p = strstr(szLine, " ");		// 1st space between name & value
 				if (p)
 				{
@@ -629,7 +629,7 @@ int ParseSymbolTable(const std::string & pPathFileName, SymbolTable_Index_e eSym
 			// SymbolOffset
 			nAddress += nSymbolOffset;
 
-			if( (nAddress > _6502_MEM_END) || (sName[0] == 0) )
+			if ( (nAddress > _6502_MEM_END) || (sName[0] == 0) )
 				continue;
 
 			// 2.9.0.11 Bug #479
@@ -655,9 +655,9 @@ int ParseSymbolTable(const std::string & pPathFileName, SymbolTable_Index_e eSym
 
 			// 2.8.0.5 Bug #244 (Debugger) Duplicate symbols for identical memory addresses in APPLE2E.SYM
 			std::string const* pSymbolPrev = FindSymbolFromAddress( (WORD)nAddress, &iTable ); // don't care which table it is in
-			if( pSymbolPrev )
+			if ( pSymbolPrev )
 			{
-				if( !bFileDisplayed )
+				if ( !bFileDisplayed )
 				{
 					bFileDisplayed = true;
 
@@ -712,9 +712,9 @@ int ParseSymbolTable(const std::string & pPathFileName, SymbolTable_Index_e eSym
 			WORD nAddressPrev = 0;
 
 			bool bExists  = FindAddressFromSymbol( sName, &nAddressPrev, &iTable );
-			if( bExists )
+			if ( bExists )
 			{
-				if( !bDupSymbolHeader )
+				if ( !bDupSymbolHeader )
 				{
 					bDupSymbolHeader = true;
 					ConsolePrintFormat( " %sDup Symbol Name%s (%s%s%s) %s"
@@ -773,7 +773,7 @@ Update_t CmdSymbolsLoad (int nArgs)
 	{
 		std::string pFileName;
 		
-		if( g_aArgs[ iArg ].bType & TYPE_QUOTED_2 )
+		if ( g_aArgs[ iArg ].bType & TYPE_QUOTED_2 )
 		{
 			pFileName = g_aArgs[ iArg ].sArg;
 
@@ -788,15 +788,15 @@ Update_t CmdSymbolsLoad (int nArgs)
 		unsigned int nOffsetAddr = 0;
 
 		iArg++;
-		if( iArg <= nArgs)
+		if ( iArg <= nArgs)
 		{
 			if (g_aArgs[ iArg ].eToken == TOKEN_COMMA)
 			{
 				iArg++;
-				if( iArg <= nArgs )
+				if ( iArg <= nArgs )
 				{
 					nOffsetAddr = g_aArgs[ iArg ].nValue;
-					if( (nOffsetAddr < _6502_MEM_BEGIN) || (nOffsetAddr > _6502_MEM_END) )
+					if ( (nOffsetAddr < _6502_MEM_BEGIN) || (nOffsetAddr > _6502_MEM_END) )
 					{
 						nOffsetAddr = 0;
 					}
@@ -804,13 +804,13 @@ Update_t CmdSymbolsLoad (int nArgs)
 			}
 		}
 
-		if( !pFileName.empty() )
+		if ( !pFileName.empty() )
 		{
 			nSymbols = ParseSymbolTable( sFileName, (SymbolTable_Index_e) iSymbolTable, nOffsetAddr );
 		}
 	}
 
-	if( nSymbols > 0 )
+	if ( nSymbols > 0 )
 	{
 		g_nSymbolsLoaded = nSymbols;
 	}
@@ -992,7 +992,7 @@ Update_t _CmdSymbolsCommon ( int nArgs, int bSymbolTables )
 				int iTable = _GetSymbolTableFromFlag( bSymbolTables );
 				if (iTable != NUM_SYMBOL_TABLES)
 				{
-					if( bUpdate & UPDATE_SYMBOLS )
+					if ( bUpdate & UPDATE_SYMBOLS )
 					{
 						//sprintf( sText, "  Symbol Table: %s%s%s, %sloaded symbols: %s%d"
 						//	, CHC_STRING, g_aSymbolTableNames[ iTable ]


### PR DESCRIPTION
Consistently adding space after keywords `if`, `for`, `switch` and `while`.
I have counted, there are more statements having the space than not.
This is only for the Debugger area. Inconsistency still exists in other areas.