### PR TITLE
Fix to use logical "&&" for boolean variables

### DIFF
--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -5782,7 +5782,7 @@ Update_t CmdOutputCalc (int nArgs)
 	if (bParen)
 		strText += '(';
 
-	if (bHi & bLo)
+	if (bHi && bLo)
 		strText += "High Ctrl";
 	else
 	if (bHi)


### PR DESCRIPTION
Since both variables are boolean, VC detected and suggested that the intention should be using logical AND `&&` instead of bitwise AND `&`.