### PR TITLE
Debugger: Remove unnecessary alias pointer

### DIFF
--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -5129,46 +5129,47 @@ Update_t CmdNTSC (int nArgs)
 				uint8_t *pSwizzled = new uint8_t[ g_nChromaSize ];
 				bool     bSwizzle  = true;
 
-				WinBmpHeader4_t bmp, *pBmp = &bmp;
+				WinBmpHeader4_t bmp = { 0 };
+
 				if ( iFileType == TYPE_BMP )
 				{
-					fread( pBmp, sizeof( WinBmpHeader4_t ), 1, pFile );
-					fseek( pFile, pBmp->nOffsetData, SEEK_SET );
+					fread( &bmp, sizeof( WinBmpHeader4_t ), 1, pFile );
+					fseek( pFile, bmp.nOffsetData, SEEK_SET );
 
-					if (pBmp->nBitsPerPixel != 32)
+					if (bmp.nBitsPerPixel != 32)
 					{
 						strcpy( aStatusText, "Bitmap not 32-bit RGBA" );
 						goto _error;
 					}
 
-					if (pBmp->nOffsetData > nFileSize)
+					if (bmp.nOffsetData > nFileSize)
 					{
 						strcpy( aStatusText, "Bad BITMAP: Data > file size !?" );
 						goto _error;
 					}
 
 					if ( !
-					(  ((pBmp->nWidthPixels  == 64 ) && (pBmp->nHeightPixels == 256))
-					|| ((pBmp->nWidthPixels  == 64 ) && (pBmp->nHeightPixels == 1))
-					|| ((pBmp->nWidthPixels  == 16 ) && (pBmp->nHeightPixels == 1))
+					(  ((bmp.nWidthPixels  == 64 ) && (bmp.nHeightPixels == 256))
+					|| ((bmp.nWidthPixels  == 64 ) && (bmp.nHeightPixels == 1))
+					|| ((bmp.nWidthPixels  == 16 ) && (bmp.nHeightPixels == 1))
 					))
 					{
 						strcpy( aStatusText, "Bitmap not 64x256, 64x1, or 16x1" );
 						goto _error;
 					}
 
-					if (pBmp->nStructSize == 0x28)
+					if (bmp.nStructSize == 0x28)
 					{
-						if ( pBmp->nCompression == 0) // BI_RGB mode
+						if ( bmp.nCompression == 0) // BI_RGB mode
 							bSwizzle = false;
 					}
 					else // 0x7C version4 bitmap
 					{
-						if ( pBmp->nCompression == 3 ) // BI_BITFIELDS
+						if ( bmp.nCompression == 3 ) // BI_BITFIELDS
 						{
-							if ((pBmp->nRedMask   == 0xFF000000 ) // Gimp writes in ABGR order
-							&&  (pBmp->nGreenMask == 0x00FF0000 )
-							&&  (pBmp->nBlueMask  == 0x0000FF00 ))
+							if ((bmp.nRedMask   == 0xFF000000 ) // Gimp writes in ABGR order
+							&&  (bmp.nGreenMask == 0x00FF0000 )
+							&&  (bmp.nBlueMask  == 0x0000FF00 ))
 								bSwizzle = true;
 						}
 					}
@@ -5186,20 +5187,20 @@ Update_t CmdNTSC (int nArgs)
 				if ( iFileType == TYPE_BMP )
 				{
 
-					if (pBmp->nHeightPixels == 1)
+					if (bmp.nHeightPixels == 1)
 					{
 						uint8_t *pTemp64x256 = new uint8_t[ 64 * 256 * 4 ];
 						memset( pTemp64x256, 0, g_nChromaSize );
 
 						//Transpose16x1::transposeFrom16x1( pSwizzled, (uint8_t*) pChromaTable );
 
-						if (pBmp->nWidthPixels == 16)
+						if (bmp.nWidthPixels == 16)
 						{
 							Transpose16x1::transposeTo64x1( pSwizzled, pTemp64x256 );
 							Transpose64x1::transposeTo64x256( pTemp64x256, pTemp64x256 );
 						}
 						else
-						if (pBmp->nWidthPixels == 64)
+						if (bmp.nWidthPixels == 64)
 							Transpose64x1::transposeTo64x256( pSwizzled, pTemp64x256 );
 
 						Transpose4096x4::transposeFrom64x256( pTemp64x256, (uint8_t*) pChromaTable );


### PR DESCRIPTION
pBmp is never changed and always points to bmp.
I think the code can simple use bmp directly.
Also initialize the bmp structure properly.
