### PR TITLE
Fix a couple of warnings from PR#1090

### DIFF
--- a/source/Debugger/Debugger_Display.cpp
+++ b/source/Debugger/Debugger_Display.cpp
@@ -2154,28 +2154,28 @@ void DrawRegister ( int line, LPCTSTR name, const int nBytes, const WORD nValue,
 	DebuggerSetColorBG( DebuggerGetColor( iBackground ));
 	PrintText( name, rect );
 
-	unsigned int nData = nValue;
-	int nOffset = 6;
-
 	if (PARAM_REG_SP == iSource)
 	{
-		WORD nStackDepth = _6502_STACK_END - nValue;
+		BYTE nStackDepth = _6502_STACK_END - (_6502_STACK_BEGIN + (nValue & 0xFF));
 		int nFontWidth = g_aFontConfig[ FONT_INFO ]._nFontWidthAvg;
 		rect.left += (2 * nFontWidth) + (nFontWidth >> 1); // 2.5 looks a tad nicer then 2
 
 		// ## = Stack Depth (in bytes)
 		DebuggerSetColorFG( DebuggerGetColor( FG_INFO_OPERATOR )); // FG_INFO_OPCODE, FG_INFO_TITLE
-		PrintText( (nStackDepth < 256) ? ByteToHexStr( uint8_t(nStackDepth) ).c_str() : "**", rect );
+		PrintText( ByteToHexStr( nStackDepth ).c_str(), rect );
 	}
 
 	std::string sValue;
 
 	if (nBytes == 2)
 	{
-		sValue = WordToHexStr( nData );
+		sValue = WordToHexStr( nValue );
 	}
 	else
 	{
+		assert(nBytes == 1 && nValue < 256); // Ensure the following downsizing is legal.
+		const BYTE nData = BYTE(nValue);
+
 		rect.left  = DISPLAY_REGS_COLUMN + (3 * nFontWidth);
 //		rect.right = SCREENSPLIT2;
 
@@ -2190,10 +2190,11 @@ void DrawRegister ( int line, LPCTSTR name, const int nBytes, const WORD nValue,
 		DebuggerSetColorFG( DebuggerGetColor( FG_INFO_OPERATOR ));
 		PrintTextCursorX( "'", rect ); // PrintTextCursorX()
 
-		sValue = StrFormat( "  %02X", nData );
+		sValue = "  " + ByteToHexStr( nData );
 	}
 
 	// Needs to be far enough over, since 4 chars of ZeroPage symbol also calls us
+	const int nOffset = 6;
 	rect.left  = DISPLAY_REGS_COLUMN + (nOffset * nFontWidth);
 
 	if ((PARAM_REG_PC == iSource) || (PARAM_REG_SP == iSource)) // Stack Pointer is target address, but doesn't look as good.

--- a/source/Debugger/Debugger_Display.cpp
+++ b/source/Debugger/Debugger_Display.cpp
@@ -1845,7 +1845,7 @@ WORD DrawDisassemblyLine ( int iLine, const WORD nBaseAddress )
 
 
 //===========================================================================
-static void DrawFlags ( int line, WORD nRegFlags )
+static void DrawFlags ( int line, BYTE nRegFlags )
 {
 	if (! ((g_iWindowThis == WINDOW_CODE) || ((g_iWindowThis == WINDOW_DATA))))
 		return;
@@ -2165,7 +2165,7 @@ void DrawRegister ( int line, LPCTSTR name, const int nBytes, const WORD nValue,
 
 		// ## = Stack Depth (in bytes)
 		DebuggerSetColorFG( DebuggerGetColor( FG_INFO_OPERATOR )); // FG_INFO_OPCODE, FG_INFO_TITLE
-		PrintText( ByteToHexStr( nStackDepth ).c_str(), rect );
+		PrintText( (nStackDepth < 256) ? ByteToHexStr( uint8_t(nStackDepth) ).c_str() : "**", rect );
 	}
 
 	std::string sValue;


### PR DESCRIPTION
1. The only call site of DrawFlags() is taking only a BYTE. The function signature should change to prevent upsizing BYTE to WORD and hence the warning.
2. nStackDepth could in theory go over 255, in that case, some special indication should be printed. With the condition checked, casting it to BYTE is now safe.