### PR TITLE
Uthernet II: 2 fixes and minor changes

### DIFF
--- a/source/Configuration/PageDisk.cpp
+++ b/source/Configuration/PageDisk.cpp
@@ -29,7 +29,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "../Windows/AppleWin.h"
 #include "../CardManager.h"
 #include "../Disk.h"	// Drive_e, Disk_Status_e
-#include "../HardDisk.h"
+#include "../Harddisk.h"
 #include "../Registry.h"
 #include "../Interface.h"
 #include "../resource/resource.h"

--- a/source/SaveState.cpp
+++ b/source/SaveState.cpp
@@ -41,7 +41,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "Pravets.h"
 #include "Speaker.h"
 #include "Speech.h"
-#include "HardDisk.h"
+#include "Harddisk.h"
 
 #include "Configuration/Config.h"
 #include "Configuration/IPropertySheet.h"

--- a/source/Tfe/IPRaw.cpp
+++ b/source/Tfe/IPRaw.cpp
@@ -132,7 +132,7 @@ std::vector<uint8_t> createETH2Frame(const std::vector<uint8_t> &data,
 }
 
 void getIPPayload(const int lengthOfFrame, const uint8_t *frame,
-                  size_t &lengthOfPayload, const uint8_t *&payload, uint32_t &destination, uint8_t &protocol)
+                  size_t &lengthOfPayload, const uint8_t *&payload, uint32_t &source, uint8_t &protocol)
 {
     const int minimumSize = getIPMinimumSize();
     if (lengthOfFrame > minimumSize)
@@ -149,7 +149,7 @@ void getIPPayload(const int lengthOfFrame, const uint8_t *frame,
                 protocol = ip4header->proto;
                 payload = frame + sizeof(ETH2Frame) + ipv4HeaderSize;
                 lengthOfPayload = ipPacketSize - ipv4HeaderSize;
-                destination = ip4header->destinationAddress;
+                source = ip4header->sourceAddress;
                 return;
             }
         }
@@ -158,5 +158,5 @@ void getIPPayload(const int lengthOfFrame, const uint8_t *frame,
     protocol = 0xFF; // reserved protocol
     payload = nullptr;
     lengthOfPayload = 0;
-    destination = 0;
+    source = 0;
 }

--- a/source/Tfe/IPRaw.h
+++ b/source/Tfe/IPRaw.h
@@ -8,4 +8,4 @@ std::vector<uint8_t> createETH2Frame(const std::vector<uint8_t> &data,
                                      const uint32_t sourceAddress, const uint32_t destinationAddress);
 
 void getIPPayload(const int lengthOfFrame, const uint8_t *frame,
-                  size_t &lengthOfPayload, const uint8_t *&payload, uint32_t &destination, uint8_t &protocol);
+                  size_t &lengthOfPayload, const uint8_t *&payload, uint32_t &source, uint8_t &protocol);

--- a/source/Uthernet2.cpp
+++ b/source/Uthernet2.cpp
@@ -1649,7 +1649,7 @@ bool Uthernet2::GetRegistryVirtualDNS(UINT slot)
 {
     const std::string regSection = RegGetConfigSlotSection(slot);
 
-    // be default VirtualDNS is enabled
+    // The default value for VirtualDNS is enabled
     // as it is backward compatible
     // (except for the initial value of PTIMER which is anyway never used)
 

--- a/source/Uthernet2.cpp
+++ b/source/Uthernet2.cpp
@@ -1640,7 +1640,12 @@ void Uthernet2::SetRegistryVirtualDNS(UINT slot, const bool enabled)
 bool Uthernet2::GetRegistryVirtualDNS(UINT slot)
 {
     const std::string regSection = RegGetConfigSlotSection(slot);
-    DWORD enabled = 0;
-    RegLoadValue(regSection.c_str(), REGVALUE_UTHERNET_VIRTUAL_DNS, TRUE, &enabled, 0);
+
+    // be default VirtualDNS is enabled
+    // as it is backward compatible
+    // (except for the initial value of PTIMER which is anyway never used)
+
+    DWORD enabled = 1;
+    RegLoadValue(regSection.c_str(), REGVALUE_UTHERNET_VIRTUAL_DNS, TRUE, &enabled);
     return enabled != 0;
 }

--- a/source/Uthernet2.cpp
+++ b/source/Uthernet2.cpp
@@ -162,9 +162,9 @@ namespace
         writeData(socket, memory, data, len);
     }
 
-    void writeDataIPRaw(Socket &socket, std::vector<uint8_t> &memory, const uint8_t *data, const size_t len, const uint32_t destination)
+    void writeDataIPRaw(Socket &socket, std::vector<uint8_t> &memory, const uint8_t *data, const size_t len, const uint32_t source)
     {
-        writeAny(socket, memory, destination);
+        writeAny(socket, memory, source);
         write16(socket, memory, static_cast<uint16_t>(len));
         writeData(socket, memory, data, len);
     }
@@ -620,9 +620,9 @@ void Uthernet2::receiveOnePacketRaw()
     {
         const uint8_t * payload;
         size_t lengthOfPayload;
-        uint32_t destination;
+        uint32_t source;
         uint8_t packetProtocol;
-        getIPPayload(len, buffer, lengthOfPayload, payload, destination, packetProtocol);
+        getIPPayload(len, buffer, lengthOfPayload, payload, source, packetProtocol);
 
         // see if there is a IPRAW socket that should accept thi spacket
         int ipRawSocket = -1;
@@ -649,7 +649,7 @@ void Uthernet2::receiveOnePacketRaw()
         // priority to IPRAW
         if (ipRawSocket >= 0)
         {
-            receiveOnePacketIPRaw(ipRawSocket, lengthOfPayload, payload, destination, packetProtocol, len);
+            receiveOnePacketIPRaw(ipRawSocket, lengthOfPayload, payload, source, packetProtocol, len);
         }
         // fallback to MACRAW (if open)
         else if (macRawSocket >= 0)
@@ -681,13 +681,13 @@ void Uthernet2::receiveOnePacketMacRaw(const size_t i, const int size, uint8_t *
     }
 }
 
-void Uthernet2::receiveOnePacketIPRaw(const size_t i, const size_t lengthOfPayload, const uint8_t * payload, const uint32_t destination, const uint8_t protocol, const int len)
+void Uthernet2::receiveOnePacketIPRaw(const size_t i, const size_t lengthOfPayload, const uint8_t * payload, const uint32_t source, const uint8_t protocol, const int len)
 {
     Socket &socket = mySockets[i];
 
     if (socket.isThereRoomFor(lengthOfPayload))
     {
-        writeDataIPRaw(socket, myMemory, payload, lengthOfPayload, destination);
+        writeDataIPRaw(socket, myMemory, payload, lengthOfPayload, source);
 #ifdef U2_LOG_TRAFFIC
         LogFileOutput("U2: Read IPRAW[%" SIZE_T_FMT "]: +%d+%" SIZE_T_FMT " (%d) -> %d bytes\n", i, socket.getHeaderSize(),
             lengthOfPayload, len, socket.sn_rx_rsr);

--- a/source/Uthernet2.cpp
+++ b/source/Uthernet2.cpp
@@ -760,7 +760,10 @@ void Uthernet2::receiveOnePacket(const size_t i)
         receiveOnePacketFromSocket(i);
         break;
     case W5100_SN_SR_CLOSED:
-        break; // nothing to do
+#ifdef U2_LOG_STATE
+        LogFileOutput("U2: Read[%" SIZE_T_FMT "]: reading from a closed socket\n", i);
+#endif
+        break;
 #ifdef U2_LOG_UNKNOWN
     default:
         LogFileOutput("U2: Read[%" SIZE_T_FMT "]: unknown mode: %02x\n", i, socket.getStatus());
@@ -880,6 +883,11 @@ void Uthernet2::sendData(const size_t i)
     case W5100_SN_SR_ESTABLISHED:
     case W5100_SN_SR_SOCK_UDP:
         sendDataToSocket(i, data);
+        break;
+    case W5100_SN_SR_CLOSED:
+#ifdef U2_LOG_STATE
+        LogFileOutput("U2: Send[%" SIZE_T_FMT "]: sending to a closed socket\n", i);
+#endif
         break;
 #ifdef U2_LOG_UNKNOWN
     default:

--- a/source/Uthernet2.cpp
+++ b/source/Uthernet2.cpp
@@ -235,7 +235,7 @@ bool Socket::isOpen() const
 
 void Socket::process()
 {
-    if (myFD != INVALID_SOCKET && sn_sr == W5100_SN_SR_SOCK_INIT && (myErrno == SOCK_EINPROGRESS || myErrno == SOCK_EWOULDBLOCK))
+    if (myFD != INVALID_SOCKET && sn_sr == W5100_SN_SR_SOCK_SYNSENT && (myErrno == SOCK_EINPROGRESS || myErrno == SOCK_EWOULDBLOCK))
     {
 #ifdef _MSC_VER
         FD_SET writefds, exceptfds;
@@ -1005,6 +1005,7 @@ void Uthernet2::connectSocket(const size_t i)
         const int error = sock_error();
         if (error == SOCK_EINPROGRESS || error == SOCK_EWOULDBLOCK)
         {
+            socket.sn_sr = W5100_SN_SR_SOCK_SYNSENT;
             socket.myErrno = error;
         }
         else

--- a/source/Uthernet2.h
+++ b/source/Uthernet2.h
@@ -33,8 +33,10 @@ struct Socket
 
     socket_t getFD() const;
     uint8_t getStatus() const;
+    uint8_t getHeaderSize() const;
 
-    bool isThereRoomFor(const size_t len, const size_t header) const;
+    // both functions work in "data" space, the header size is added internally
+    bool isThereRoomFor(const size_t len) const;
     uint16_t getFreeRoom() const;
 
     void SaveSnapshot(YamlSaveHelper &yamlSaveHelper);
@@ -47,6 +49,7 @@ struct Socket
 private:
     socket_t myFD;
     uint8_t mySocketStatus;  // sn_sr
+    uint8_t myHeaderSize;
 };
 
 /*

--- a/source/Uthernet2.h
+++ b/source/Uthernet2.h
@@ -25,14 +25,14 @@ struct Socket
     uint16_t sn_rx_wr;
     uint16_t sn_rx_rsr;
 
-    uint8_t sn_sr;
-
-    socket_t myFD;
-
     bool isOpen() const;
     void clearFD();
-    void setFD(const socket_t fd, const int status);
+    void setStatus(const uint8_t status);
+    void setFD(const socket_t fd, const uint8_t status);
     void process();
+
+    socket_t getFD() const;
+    uint8_t getStatus() const;
 
     bool isThereRoomFor(const size_t len, const size_t header) const;
     uint16_t getFreeRoom() const;
@@ -43,6 +43,10 @@ struct Socket
     Socket();
 
     ~Socket();
+
+private:
+    socket_t myFD;
+    uint8_t mySocketStatus;  // sn_sr
 };
 
 /*

--- a/source/Uthernet2.h
+++ b/source/Uthernet2.h
@@ -48,7 +48,7 @@ struct Socket
 
 private:
     socket_t myFD;
-    uint8_t mySocketStatus;  // sn_sr
+    uint8_t mySocketStatus;  // aka W5100_SN_SR
     uint8_t myHeaderSize;
 };
 

--- a/source/Uthernet2.h
+++ b/source/Uthernet2.h
@@ -28,7 +28,6 @@ struct Socket
     uint8_t sn_sr;
 
     socket_t myFD;
-    int myErrno;
 
     bool isOpen() const;
     void clearFD();

--- a/source/Uthernet2.h
+++ b/source/Uthernet2.h
@@ -112,7 +112,7 @@ private:
     uint8_t getRXDataSizeRegister(const size_t i, const size_t shift) const;
 
     void receiveOnePacketRaw();
-    void receiveOnePacketIPRaw(const size_t i, const size_t lengthOfPayload, const uint8_t * payload, const uint32_t destination, const uint8_t protocol, const int len);
+    void receiveOnePacketIPRaw(const size_t i, const size_t lengthOfPayload, const uint8_t * payload, const uint32_t source, const uint8_t protocol, const int len);
     void receiveOnePacketMacRaw(const size_t i, const int size, uint8_t * data);
     void receiveOnePacketFromSocket(const size_t i);
     void receiveOnePacket(const size_t i);

--- a/source/W5100.h
+++ b/source/W5100.h
@@ -99,6 +99,7 @@
 
 #define W5100_SN_SR_CLOSED        0x00
 #define W5100_SN_SR_SOCK_INIT     0x13
+#define W5100_SN_SR_SOCK_SYNSENT  0x15
 #define W5100_SN_SR_ESTABLISHED   0x17
 #define W5100_SN_SR_SOCK_UDP      0x22
 #define W5100_SN_SR_SOCK_IPRAW    0x32


### PR DESCRIPTION
Bug fix:

1. UDP: it would not take into account the size of the header (6 bytes) when computing the amount of data that can be read from the peer (so potentially reading 6 bytes too many, which would not fit)
2. IPRAW: The header should contain the `source` of the packet rather than the `destination` (which is useless as it is our IP address). Doc is not very clear, but for UDP (which they refer to) they use the peer IP (so the `source` of the packet), or destination of the socket.

Changes:

1. Make Virtual DNS enabled by default