### PR TITLE
Two adjacent magnets off in quick succession

### DIFF
--- a/source/CmdLine.cpp
+++ b/source/CmdLine.cpp
@@ -549,6 +549,10 @@ bool ProcessCmdLine(LPSTR lpCmdLine)
 			lpNextArg = GetNextArg(lpNextArg);
 			g_cmdLine.wavFileMockingboard = lpCmdLine;
 		}
+		else if (strcmp(lpCmdLine, "-no-disk2-stepper-defer") == 0)	// a debug switch (likely to be removed in a future version)
+		{
+			g_cmdLine.noDisk2StepperDefer = true;
+		}
 		else	// unsupported
 		{
 			LogFileOutput("Unsupported arg: %s\n", lpCmdLine);

--- a/source/CmdLine.h
+++ b/source/CmdLine.h
@@ -22,6 +22,7 @@ struct CmdLine
 		snesMaxAltControllerType[1] = false;
 		supportDCD = false;
 		enableDumpToRealPrinter = false;
+		noDisk2StepperDefer = false;
 		szImageName_harddisk[HARDDISK_1] = NULL;
 		szImageName_harddisk[HARDDISK_2] = NULL;
 		szSnapshotName = NULL;
@@ -63,6 +64,7 @@ struct CmdLine
 	bool snesMaxAltControllerType[2];
 	bool supportDCD;
 	bool enableDumpToRealPrinter;
+	bool noDisk2StepperDefer;	// debug
 	SS_CARDTYPE slotInsert[NUM_SLOTS];
 	LPCSTR szImageName_drive[NUM_SLOTS][NUM_DRIVES];
 	bool driveConnected[NUM_SLOTS][NUM_DRIVES];

--- a/source/Disk.cpp
+++ b/source/Disk.cpp
@@ -73,6 +73,7 @@ Disk2InterfaceCard::Disk2InterfaceCard(UINT slot) :
 	m_diskLastReadLatchCycle = 0;
 	m_enhanceDisk = true;
 	m_is13SectorFirmware = false;
+	m_deferStepper = true;
 	m_deferredStepperEvent = false;
 	m_deferredStepperAddress = 0;
 	m_deferredStepperCumulativeCycles = 0;
@@ -489,6 +490,14 @@ void __stdcall Disk2InterfaceCard::ControlStepper(WORD, WORD address, BYTE, BYTE
 			m_magnetStates |= phase_bit;	// phase on
 		else
 			m_magnetStates &= ~phase_bit;	// phase off
+	}
+
+	if (!m_deferStepper)
+	{
+		m_deferredStepperAddress = address;
+		m_deferredStepperCumulativeCycles = g_nCumulativeCycles;
+		ControlStepperDeferred();
+		return;
 	}
 
 	if (m_syncEvent.m_active)

--- a/source/Disk.cpp
+++ b/source/Disk.cpp
@@ -73,7 +73,6 @@ Disk2InterfaceCard::Disk2InterfaceCard(UINT slot) :
 	m_diskLastReadLatchCycle = 0;
 	m_enhanceDisk = true;
 	m_is13SectorFirmware = false;
-	m_deferStepper = true;
 	m_deferredStepperEvent = false;
 	m_deferredStepperAddress = 0;
 	m_deferredStepperCumulativeCycles = 0;
@@ -492,7 +491,7 @@ void __stdcall Disk2InterfaceCard::ControlStepper(WORD, WORD address, BYTE, BYTE
 			m_magnetStates &= ~phase_bit;	// phase off
 	}
 
-	if (!m_deferStepper)
+	if (!GetCardMgr().GetDisk2CardMgr().IsStepperDeferred())
 	{
 		m_deferredStepperAddress = address;
 		m_deferredStepperCumulativeCycles = g_nCumulativeCycles;

--- a/source/Disk.h
+++ b/source/Disk.h
@@ -210,6 +210,7 @@ private:
 	void InsertSyncEvent(void);
 	static int SyncEventCallback(int id, int cycles, ULONG uExecutedCycles);
 	void ControlStepperDeferred(bool adjacentMagnetsOff, WORD nextAddress);
+	void ControlStepperLogging(WORD address, unsigned __int64 cumulativeCycles);
 
 	void PreJitterCheck(int phase, BYTE latch);
 	void AddJitter(int phase, FloppyDisk& floppy);
@@ -279,9 +280,9 @@ private:
 	SEQUENCER_FUNCTION m_seqFunc;
 	UINT m_dbgLatchDelayedCnt;
 
+	bool m_deferredStepperEvent;
 	WORD m_deferredStepperAddress;
 	unsigned __int64 m_deferredStepperCumulativeCycles;
-	bool m_ignoreNextStepperOff;
 	SyncEvent m_syncEvent;
 
 	// Jitter (GH#930)

--- a/source/Disk.h
+++ b/source/Disk.h
@@ -166,6 +166,7 @@ public:
 	bool UserSelectNewDiskImage(const int drive, LPCSTR pszFilename="");
 	bool DriveSwap(void);
 	bool IsDriveConnected(int drive) { return m_floppyDrive[drive].m_isConnected; }
+	void SetStepperDefer(bool defer) { m_deferStepper = defer; }
 
 	static const std::string& GetSnapshotCardName(void);
 	virtual void SaveSnapshot(YamlSaveHelper& yamlSaveHelper);
@@ -280,6 +281,7 @@ private:
 	SEQUENCER_FUNCTION m_seqFunc;
 	UINT m_dbgLatchDelayedCnt;
 
+	bool m_deferStepper;	// debug: can disable via cmd-line
 	bool m_deferredStepperEvent;
 	WORD m_deferredStepperAddress;
 	unsigned __int64 m_deferredStepperCumulativeCycles;

--- a/source/Disk.h
+++ b/source/Disk.h
@@ -166,7 +166,6 @@ public:
 	bool UserSelectNewDiskImage(const int drive, LPCSTR pszFilename="");
 	bool DriveSwap(void);
 	bool IsDriveConnected(int drive) { return m_floppyDrive[drive].m_isConnected; }
-	void SetStepperDefer(bool defer) { m_deferStepper = defer; }
 
 	static const std::string& GetSnapshotCardName(void);
 	virtual void SaveSnapshot(YamlSaveHelper& yamlSaveHelper);
@@ -281,7 +280,6 @@ private:
 	SEQUENCER_FUNCTION m_seqFunc;
 	UINT m_dbgLatchDelayedCnt;
 
-	bool m_deferStepper;	// debug: can disable via cmd-line
 	bool m_deferredStepperEvent;
 	WORD m_deferredStepperAddress;
 	unsigned __int64 m_deferredStepperCumulativeCycles;

--- a/source/Disk.h
+++ b/source/Disk.h
@@ -207,6 +207,7 @@ private:
 	bool GetFirmware(WORD lpNameId, BYTE* pDst);
 	void InitFirmware(LPBYTE pCxRomPeripheral);
 	void UpdateLatchForEmptyDrive(FloppyDrive* pDrive);
+	void InsertSyncEvent(void);
 	static int SyncEventCallback(int id, int cycles, ULONG uExecutedCycles);
 	void ControlStepperDeferred(bool adjacentMagnetsOff, WORD nextAddress);
 

--- a/source/Disk.h
+++ b/source/Disk.h
@@ -101,6 +101,7 @@ public:
 		m_isConnected = true;
 		m_phasePrecise = 0;
 		m_phase = 0;
+		m_lastStepperAccess = (BYTE)-1;	// valid: [0..7], not accessed yet: -1
 		m_lastStepperCycle = 0;
 		m_motorOnCycle = 0;
 		m_headWindow = 0;
@@ -113,6 +114,7 @@ public:
 	bool m_isConnected;
 	float m_phasePrecise;	// Phase precise to half a phase (aka quarter track)
 	int m_phase;			// Integral phase number
+	BYTE m_lastStepperAccess;
 	unsigned __int64 m_lastStepperCycle;
 	unsigned __int64 m_motorOnCycle;
 	BYTE m_headWindow;

--- a/source/Disk.h
+++ b/source/Disk.h
@@ -209,7 +209,7 @@ private:
 	void UpdateLatchForEmptyDrive(FloppyDrive* pDrive);
 	void InsertSyncEvent(void);
 	static int SyncEventCallback(int id, int cycles, ULONG uExecutedCycles);
-	void ControlStepperDeferred(bool adjacentMagnetsOff, WORD nextAddress);
+	void ControlStepperDeferred(void);
 	void ControlStepperLogging(WORD address, unsigned __int64 cumulativeCycles);
 
 	void PreJitterCheck(int phase, BYTE latch);

--- a/source/Disk2CardManager.cpp
+++ b/source/Disk2CardManager.cpp
@@ -143,3 +143,14 @@ void Disk2CardManager::GetFilenameAndPathForSaveState(std::string& filename, std
 		}
 	}
 }
+
+void Disk2CardManager::SetStepperDefer(bool defer)
+{
+	for (UINT i = SLOT0; i < NUM_SLOTS; i++)
+	{
+		if (GetCardMgr().QuerySlot(i) == CT_Disk2)
+		{
+			dynamic_cast<Disk2InterfaceCard&>(GetCardMgr().GetRef(i)).SetStepperDefer(defer);
+		}
+	}
+}

--- a/source/Disk2CardManager.cpp
+++ b/source/Disk2CardManager.cpp
@@ -146,11 +146,5 @@ void Disk2CardManager::GetFilenameAndPathForSaveState(std::string& filename, std
 
 void Disk2CardManager::SetStepperDefer(bool defer)
 {
-	for (UINT i = SLOT0; i < NUM_SLOTS; i++)
-	{
-		if (GetCardMgr().QuerySlot(i) == CT_Disk2)
-		{
-			dynamic_cast<Disk2InterfaceCard&>(GetCardMgr().GetRef(i)).SetStepperDefer(defer);
-		}
-	}
+	m_stepperDeferred = defer;
 }

--- a/source/Disk2CardManager.h
+++ b/source/Disk2CardManager.h
@@ -15,4 +15,5 @@ public:
 	void Destroy(void);
 	bool IsAnyFirmware13Sector(void);
 	void GetFilenameAndPathForSaveState(std::string& filename, std::string& path);
+	void SetStepperDefer(bool defer);
 };

--- a/source/Disk2CardManager.h
+++ b/source/Disk2CardManager.h
@@ -3,7 +3,7 @@
 class Disk2CardManager
 {
 public:
-	Disk2CardManager(void) {}
+	Disk2CardManager(void) : m_stepperDeferred(true) {}
 	~Disk2CardManager(void) {}
 
 	bool IsConditionForFullSpeed(void);
@@ -16,4 +16,8 @@ public:
 	bool IsAnyFirmware13Sector(void);
 	void GetFilenameAndPathForSaveState(std::string& filename, std::string& path);
 	void SetStepperDefer(bool defer);
+	bool IsStepperDeferred(void) { return m_stepperDeferred; }
+
+private:
+	bool m_stepperDeferred;	// debug: can disable via cmd-line
 };

--- a/source/Windows/AppleWin.cpp
+++ b/source/Windows/AppleWin.cpp
@@ -833,6 +833,9 @@ static void RepeatInitialization(void)
 		if (g_cmdLine.bRemoveNoSlotClock)
 			MemRemoveNoSlotClock();
 
+		if (g_cmdLine.noDisk2StepperDefer)
+			GetCardMgr().GetDisk2CardMgr().SetStepperDefer(false);
+
 		// Call DebugInitialize() after SetCurrentImageDir()
 		DebugInitialize();
 		LogFileOutput("Main: DebugInitialize()\n");


### PR DESCRIPTION
PR for #1110.

If 2 _adjacent_ stepper control OFF accesses occur within 10 cycles, then update the magnet states, but don't move the cog. So the track/phase doesn't change.

Developer info: all Control Stepper access are now deferred by 10 cycles, which allows detecting of the above condition. The SyncEvent functionality is used to allow this very fine level of detection, without impacting performance - ie. it's the same functionality used for precise interrupts from Mockingboard(6522) & Mouse(VBl) cards.