### PR TITLE
Fix printf warning.

### DIFF
--- a/source/Disk.cpp
+++ b/source/Disk.cpp
@@ -521,8 +521,8 @@ void __stdcall Disk2InterfaceCard::ControlStepper(WORD, WORD address, BYTE, BYTE
 			{
 				// take no action - can't find any titles that ever do this!
 				const std::string msg = "Disk: ControlStepper() - adjacent magnets turned on\n";
-				LogOutput(msg.c_str());
-				LogFileOutput(msg.c_str());
+				LogOutput("%s", msg.c_str());
+				LogFileOutput("%s", msg.c_str());
 			}
 		}
 


### PR DESCRIPTION
error: format not a string literal and no format arguments [-Werror=format-security]

Signed-off-by: Andrea Odetti <mariofutire@gmail.com>