### PR TITLE
UI Improvements + dynamic toolbar in fullscreen + new scaling methods

### DIFF
--- a/resource/Applewin.rc
+++ b/resource/Applewin.rc
@@ -93,14 +93,14 @@ BEGIN
     COMBOBOX        IDC_COMPUTER,45,5,91,100,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
     CONTROL         "Confirm reboot",IDC_CHECK_CONFIRM_REBOOT,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,142,8,62,10
     GROUPBOX        "Video",IDC_STATIC,5,22,200,74
-    LTEXT           "Mo&de:",IDC_STATIC,12,33,33,8
-    COMBOBOX        IDC_VIDEOTYPE,33,30,103,100,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
-    PUSHBUTTON      "Monochrome &Color...",IDC_MONOCOLOR,12,46,80,14
-    CONTROL         "50% Scan lines",IDC_CHECK_HALF_SCAN_LINES,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,142,33,62,10
-    CONTROL         "Vertical blend",IDC_CHECK_VERTICAL_BLEND,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,142,48,62,10
-    CONTROL         "Full-Screen: Show drive/keyboard status",IDC_CHECK_FS_SHOW_SUBUNIT_STATUS,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,12,64,140,10
-    CONTROL         "VidHD in slot 3",IDC_CHECK_VIDHD_IN_SLOT3,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,12,78,140,10
+    LTEXT           "Mo&de:",IDC_STATIC,12,36,33,8
+    COMBOBOX        IDC_VIDEOTYPE,33,33,103,100,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
+    PUSHBUTTON      "Monochrome &Color...",IDC_MONOCOLOR,10,55,80,14
+    CONTROL         "50% Scan lines",IDC_CHECK_HALF_SCAN_LINES,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,142,34,62,10
+    CONTROL         "Vertical blend",IDC_CHECK_VERTICAL_BLEND,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,142,49,62,10
+    CONTROL         "Integer scale",IDC_CHECK_INTEGER_SCALE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,142,78,60,10   
+    CONTROL         "Full stretch", IDC_CHECK_STRETCHVIDEO, "Button", BS_AUTOCHECKBOX | WS_TABSTOP, 142, 64, 60, 10
+    CONTROL         "VidHD in slot 3",IDC_CHECK_VIDHD_IN_SLOT3,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,12,78,100,10
     LTEXT           "&Serial Port:",IDC_STATIC,5,108,40,8
     COMBOBOX        IDC_SERIALPORT,45,106,90,100,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
     PUSHBUTTON      "&Ethernet Settings...",IDC_ETHERNET,4,124,80,14
@@ -392,6 +392,16 @@ BEGIN
     END
 END
 
+IDR_MENU_TOOLBAR MENU
+BEGIN
+    POPUP "Toolbar Menu"
+    BEGIN
+        MENUITEM "Dock top",                    ID_TOOLBAR_TOP
+        MENUITEM "Dock left",                   ID_TOOLBAR_LEFT
+        MENUITEM "Dock bottom",                 ID_TOOLBAR_BOTTOM
+        MENUITEM "Dock right",                  ID_TOOLBAR_RIGHT
+    END
+END
 
 /////////////////////////////////////////////////////////////////////////////
 //

--- a/resource/resource.h
+++ b/resource/resource.h
@@ -112,7 +112,7 @@
 #define IDC_COMBO_HDD2                  1079
 #define IDC_COMBO_DISK1                 1080
 #define IDC_COMBO_DISK2                 1081
-#define IDC_CHECK_FS_SHOW_SUBUNIT_STATUS 1082
+#define IDC_CHECK_INTEGER_SCALE         1082
 #define IDC_CHECK_VERTICAL_BLEND        1083
 #define IDC_CHECK_50HZ_VIDEO            1084
 #define IDC_COMBO_DISK1_SLOT5           1085
@@ -123,6 +123,12 @@
 #define IDC_CHECK_TFE_VIRTUAL_DNS       1090
 #define IDC_TFE_NPCAP_INFO              1091
 #define IDC_COMBO_GAME_IO_CONNECTOR     1092
+#define IDR_MENU_TOOLBAR				1093
+#define ID_TOOLBAR_TOP					1094
+#define ID_TOOLBAR_LEFT					1095
+#define ID_TOOLBAR_BOTTOM				1096
+#define ID_TOOLBAR_RIGHT				1097
+#define IDC_CHECK_STRETCHVIDEO			1098
 #define IDM_EXIT                        40001
 #define IDM_HELP                        40002
 #define IDM_ABOUT                       40003
@@ -138,7 +144,7 @@
 #define _APS_NO_MFC                     1
 #define _APS_NEXT_RESOURCE_VALUE        149
 #define _APS_NEXT_COMMAND_VALUE         40012
-#define _APS_NEXT_CONTROL_VALUE         1083
+#define _APS_NEXT_CONTROL_VALUE         1099
 #define _APS_NEXT_SYMED_VALUE           101
 #endif
 #endif

--- a/source/Common.h
+++ b/source/Common.h
@@ -36,14 +36,17 @@ enum AppMode_e
 #define  DRAW_BUTTON_DRIVES (1 << 3)
 #define  DRAW_DISK_STATUS   (1 << 4)
 
-#define  BTN_HELP          0
-#define  BTN_RUN           1
-#define  BTN_DRIVE1        2
-#define  BTN_DRIVE2        3
-#define  BTN_DRIVESWAP     4
-#define  BTN_FULLSCR       5
-#define  BTN_DEBUG         6
-#define  BTN_SETUP         7
+#define  BTN_HELP          7
+#define  BTN_RUN           0
+#define  BTN_DRIVE1        1
+#define  BTN_DRIVE2        2
+#define  BTN_DRIVESWAP     3
+#define  BTN_FULLSCR       4
+#define  BTN_DEBUG         5
+#define  BTN_SETUP         6
+
+#define  TTID_SLOT6_TRK_SEC_INFO 8
+#define  TTID_SLOT5_TRK_SEC_INFO 9
 
 // TODO: Move to StringTable.h
 #define	TITLE_APPLE_2			TEXT("Apple ][ Emulator")
@@ -67,7 +70,8 @@ enum AppMode_e
 #define  REGVALUE_CPU_TYPE           "CPU Type"
 #define  REGVALUE_OLD_APPLE2_TYPE    "Computer Emulation"	// Deprecated
 #define  REGVALUE_CONFIRM_REBOOT     "Confirm Reboot" // Added at 1.24.1 PageConfig
-#define  REGVALUE_FS_SHOW_SUBUNIT_STATUS "Full-screen show subunit status"
+#define  REGVALUE_INTEGERSCALE		 "Integer scale"
+#define  REGVALUE_STRETCHVIDEO		 "Stretch"
 #define  REGVALUE_SHOW_DISKII_STATUS "Show Disk II Status"
 #define  REGVALUE_SOUND_EMULATION    "Sound Emulation"
 #define  REGVALUE_SPKR_VOLUME        "Speaker Volume"
@@ -130,6 +134,7 @@ enum AppMode_e
 #define REGVALUE_PREF_WINDOW_X_POS   "Window X-Position"
 #define REGVALUE_PREF_WINDOW_Y_POS   "Window Y-Position"
 #define REGVALUE_PREF_HDV_START_DIR  "HDV Starting Directory"
+#define REGVALUE_PREF_TOOLBAR		 "Toolbar"
 
 #define WM_USER_BENCHMARK	WM_USER+1
 #define WM_USER_SAVESTATE	WM_USER+2

--- a/source/Configuration/PageConfig.cpp
+++ b/source/Configuration/PageConfig.cpp
@@ -129,9 +129,13 @@ INT_PTR CPageConfig::DlgProcInternal(HWND hWnd, UINT message, WPARAM wparam, LPA
 		case IDC_CHECK_CONFIRM_REBOOT:
 		case IDC_CHECK_HALF_SCAN_LINES:
 		case IDC_CHECK_VERTICAL_BLEND:
-		case IDC_CHECK_FS_SHOW_SUBUNIT_STATUS:
+		case IDC_CHECK_INTEGER_SCALE:		
 		case IDC_CHECK_50HZ_VIDEO:
 			// Checked in DlgOK()
+			break;
+
+		case IDC_CHECK_STRETCHVIDEO:
+			EnableWindow(GetDlgItem(hWnd, IDC_CHECK_INTEGER_SCALE), !IsDlgButtonChecked(hWnd, IDC_CHECK_STRETCHVIDEO));
 			break;
 
 		case IDC_CHECK_VIDHD_IN_SLOT3:
@@ -218,8 +222,10 @@ INT_PTR CPageConfig::DlgProcInternal(HWND hWnd, UINT message, WPARAM wparam, LPA
 			m_PropertySheetHelper.FillComboBox(hWnd,IDC_VIDEOTYPE, GetVideo().GetVideoChoices(), GetVideo().GetVideoType());
 			CheckDlgButton(hWnd, IDC_CHECK_HALF_SCAN_LINES, GetVideo().IsVideoStyle(VS_HALF_SCANLINES) ? BST_CHECKED : BST_UNCHECKED);
 			Win32Frame& win32Frame = Win32Frame::GetWin32Frame();
-			CheckDlgButton(hWnd, IDC_CHECK_FS_SHOW_SUBUNIT_STATUS, win32Frame.GetFullScreenShowSubunitStatus() ? BST_CHECKED : BST_UNCHECKED);
-
+			CheckDlgButton(hWnd, IDC_CHECK_STRETCHVIDEO, win32Frame.GetStretchVideo() ? BST_CHECKED : BST_UNCHECKED);
+			CheckDlgButton(hWnd, IDC_CHECK_INTEGER_SCALE, win32Frame.GetIntegerScale() ? BST_CHECKED : BST_UNCHECKED);
+			EnableWindow(GetDlgItem(hWnd, IDC_CHECK_INTEGER_SCALE), !win32Frame.GetStretchVideo());
+						
 			CheckDlgButton(hWnd, IDC_CHECK_VERTICAL_BLEND, GetVideo().IsVideoStyle(VS_COLOR_VERTICAL_BLEND) ? BST_CHECKED : BST_UNCHECKED);
 			EnableWindow(GetDlgItem(hWnd, IDC_CHECK_VERTICAL_BLEND), (GetVideo().GetVideoType() == VT_COLOR_IDEALIZED) ? TRUE : FALSE);
 
@@ -350,12 +356,23 @@ void CPageConfig::DlgOK(HWND hWnd)
 
 	//
 
-	const bool bNewFSSubunitStatus = IsDlgButtonChecked(hWnd, IDC_CHECK_FS_SHOW_SUBUNIT_STATUS) ? true : false;
+	const bool bNewFSSubunitStatus = IsDlgButtonChecked(hWnd, IDC_CHECK_INTEGER_SCALE) ? true : false;
 
-	if (win32Frame.GetFullScreenShowSubunitStatus() != bNewFSSubunitStatus)
+	if (win32Frame.GetIntegerScale() != bNewFSSubunitStatus)
 	{
-		REGSAVE(TEXT(REGVALUE_FS_SHOW_SUBUNIT_STATUS), bNewFSSubunitStatus ? 1 : 0);
-		win32Frame.SetFullScreenShowSubunitStatus(bNewFSSubunitStatus);
+		REGSAVE(TEXT(REGVALUE_INTEGERSCALE), bNewFSSubunitStatus ? 1 : 0);
+		win32Frame.SetIntegerScale(bNewFSSubunitStatus);
+
+		if (win32Frame.IsFullScreen())
+			win32Frame.FrameRefreshStatus(DRAW_BACKGROUND | DRAW_LEDS | DRAW_DISK_STATUS);
+	}
+
+	const bool bNewStretchVideoStatus = IsDlgButtonChecked(hWnd, IDC_CHECK_STRETCHVIDEO) ? true : false;
+
+	if (win32Frame.GetStretchVideo() != bNewStretchVideoStatus)
+	{
+		REGSAVE(TEXT(REGVALUE_STRETCHVIDEO), bNewStretchVideoStatus ? 1 : 0);
+		win32Frame.SetStretchVideo(bNewStretchVideoStatus);
 
 		if (win32Frame.IsFullScreen())
 			win32Frame.FrameRefreshStatus(DRAW_BACKGROUND | DRAW_LEDS | DRAW_DISK_STATUS);

--- a/source/Debugger/Debugger_Display.cpp
+++ b/source/Debugger/Debugger_Display.cpp
@@ -632,21 +632,21 @@ void StretchBltMemToFrameDC(void)
 {
 	Win32Frame& win32Frame = Win32Frame::GetWin32Frame();
 
-	int nViewportCX, nViewportCY;
-	win32Frame.GetViewportCXCY(nViewportCX, nViewportCY);
+	RECT rc = win32Frame.GetVideoRect();
 
-	int xdest = win32Frame.IsFullScreen() ? win32Frame.GetFullScreenOffsetX() : GetVideo().GetFrameBufferCentringOffsetX() * win32Frame.GetViewportScale();
-	int ydest = win32Frame.IsFullScreen() ? win32Frame.GetFullScreenOffsetY() : GetVideo().GetFrameBufferCentringOffsetY() * win32Frame.GetViewportScale();
-	int wdest = nViewportCX;
-	int hdest = nViewportCY;
+#if RENDER_BORDERMARGIN
+	int border = GetVideo().GetFrameBufferBorderWidth();	
+	::InflateRect(&rc, -border, -border);
+#endif
 
 	BOOL bRes = StretchBlt(
 		win32Frame.FrameGetDC(),			                // HDC hdcDest,
-		xdest, ydest,									    // int nXOriginDest, int nYOriginDest,
-		wdest, hdest,										// int nWidthDest,   int nHeightDest,
+		rc.left, rc.top,									// int nXOriginDest, int nYOriginDest,
+		rc.right - rc.left, rc.bottom - rc.top,				// int nWidthDest,   int nHeightDest,
 		GetDebuggerMemDC(),									// HDC hdcSrc,
 		0, 0,												// int nXOriginSrc,  int nYOriginSrc,
-		GetVideo().GetFrameBufferBorderlessWidth(), GetVideo().GetFrameBufferBorderlessHeight(),	// int nWidthSrc,    int nHeightSrc,
+		GetVideo().GetFrameBufferBorderlessWidth(),         // int nWidthSrc,    
+		GetVideo().GetFrameBufferBorderlessHeight(),	    // int nHeightSrc,
 		SRCCOPY                                             // DWORD dwRop
 	);
 }

--- a/source/Debugger/Debugger_Win32.cpp
+++ b/source/Debugger/Debugger_Win32.cpp
@@ -340,8 +340,9 @@ void DebuggerMouseClick(int x, int y)
 	// do picking
 
 	// NB. Full-screen + VidHD isn't centred yet
-	const int nOffsetX = win32Frame.IsFullScreen() ? win32Frame.GetFullScreenOffsetX() : win32Frame.Get3DBorderWidth() + GetVideo().GetFrameBufferCentringOffsetX() * win32Frame.GetViewportScale();
-	const int nOffsetY = win32Frame.IsFullScreen() ? win32Frame.GetFullScreenOffsetY() : win32Frame.Get3DBorderHeight();
+	RECT rc = win32Frame.GetVideoRect();
+	const int nOffsetX = rc.left;
+	const int nOffsetY = rc.top;
 
 	const int nOffsetInScreenX = x - nOffsetX;
 	const int nOffsetInScreenY = y - nOffsetY;

--- a/source/FrameBase.h
+++ b/source/FrameBase.h
@@ -27,10 +27,10 @@ public:
 	virtual void FrameUpdateApple2Type() = 0;
 	virtual void FrameSetCursorPosByMousePos() = 0;
 
-	virtual void SetFullScreenShowSubunitStatus(bool bShow) = 0;
+	virtual void SetIntegerScale(bool bShow) = 0;
+	virtual void SetStretchVideo(bool bShow) = 0;	
 	virtual void SetWindowedModeShowDiskiiStatus(bool bShow) = 0;
-	virtual bool GetBestDisplayResolutionForFullScreen(UINT& bestWidth, UINT& bestHeight, UINT userSpecifiedWidth=0, UINT userSpecifiedHeight=0) = 0;
-	virtual int SetViewportScale(int nNewScale, bool bForce = false) = 0;
+	virtual bool GetBestDisplayResolutionForFullScreen(UINT& bestWidth, UINT& bestHeight, UINT userSpecifiedWidth=0, UINT userSpecifiedHeight=0) = 0;	
 	virtual void SetAltEnterToggleFullScreen(bool mode) = 0;
 
 	virtual void SetLoadedSaveStateFlag(const bool bFlag) = 0;

--- a/source/Utilities.cpp
+++ b/source/Utilities.cpp
@@ -198,8 +198,11 @@ void LoadConfiguration(bool loadImages)
 
 	DWORD dwTmp = 0;
 
-	if(REGLOAD(TEXT(REGVALUE_FS_SHOW_SUBUNIT_STATUS), &dwTmp))
-		GetFrame().SetFullScreenShowSubunitStatus(dwTmp ? true : false);
+	if(REGLOAD(TEXT(REGVALUE_INTEGERSCALE), &dwTmp))
+		GetFrame().SetIntegerScale(dwTmp ? true : false);
+
+	if (REGLOAD(TEXT(REGVALUE_STRETCHVIDEO), &dwTmp))
+		GetFrame().SetStretchVideo(dwTmp ? true : false);
 
 	if (REGLOAD(TEXT(REGVALUE_SHOW_DISKII_STATUS), &dwTmp))
 		GetFrame().SetWindowedModeShowDiskiiStatus(dwTmp ? true : false);
@@ -313,11 +316,6 @@ void LoadConfiguration(bool loadImages)
 
 	if (GetCardMgr().IsParallelPrinterCardInstalled())
 		GetCardMgr().GetParallelPrinterCard()->GetRegistryConfig();
-
-	//
-
-	if (REGLOAD(TEXT(REGVALUE_WINDOW_SCALE), &dwTmp))
-		GetFrame().SetViewportScale(dwTmp);
 
 	if (REGLOAD(TEXT(REGVALUE_CONFIRM_REBOOT), &dwTmp))
 		GetFrame().g_bConfirmReboot = dwTmp;

--- a/source/Windows/AppleWin.cpp
+++ b/source/Windows/AppleWin.cpp
@@ -804,8 +804,6 @@ static void RepeatInitialization(void)
 
 		// Create window after inserting/removing VidHD card (as it affects width & height)
 		{
-			Win32Frame::GetWin32Frame().SetViewportScale(Win32Frame::GetWin32Frame().GetViewportScale(), true);
-
 			GetFrame().Initialize(true); // g_pFramebufferinfo been created now & COM init'ed
 			LogFileOutput("Main: VideoInitialize()\n");
 


### PR DESCRIPTION
This PR has many UI improvements :

- Windows is resizable ( min size is x1 scale ).
- Vertical toolbar docked on top. ( dock right can be restored commenting #define HORIZONTAL_TOOLBAR in win32frame )
- Flat look for toolbar buttons.
- Screen is now stretched when window is resized or in fullscreen. ( except when 50% scanlines, then it's an integer scale ). 
- Render black borders around the video screen ( can be removed by commenting #define RENDER_BORDERMARGIN in win32frame )
- Disc indicators are now docked on right & have better layouting ( or bottom if toolbar docked right )
- Toolbar is shown in fullscreen when the mouse move over its area.
- Moved help at end of buttons ( kept original F1...F8 order )
- Many other small improvements ( flickerings, icon transparency, version label when showing logo... )

I hope I did not forget & break anything, and I hope you'll like it.

You can test this PR with this executable : [AppleWin.zip](https://github.com/AppleWin/AppleWin/files/10355367/AppleWin.zip)

![image](https://user-images.githubusercontent.com/51082152/210870451-990e5e6e-e547-47ee-b8f6-4640add11b82.png)

