### PR TITLE
[WinMM] Fix joysticks not detected : first & second devices are not always at index 0 & 1

### DIFF
--- a/source/FourPlay.cpp
+++ b/source/FourPlay.cpp
@@ -52,6 +52,9 @@
 #include "Memory.h"
 #include "YamlHelper.h"
 
+extern int JOYSTICK_1; // declared in joystick.cpp
+extern int JOYSTICK_2;
+
 BYTE __stdcall FourPlayCard::IORead(WORD pc, WORD addr, BYTE bWrite, BYTE value, ULONG nExecutedCycles)
 {
 	BYTE nOutput = MemReadFloatingBus(nExecutedCycles);
@@ -67,15 +70,13 @@ BYTE __stdcall FourPlayCard::IORead(WORD pc, WORD addr, BYTE bWrite, BYTE value,
 	UINT yAxis = 0;
 
 	JOYINFOEX infoEx;
-	MMRESULT result = 0;
 	infoEx.dwSize = sizeof(infoEx);
 	infoEx.dwFlags = JOY_RETURNPOV | JOY_RETURNBUTTONS;
 
 	switch (addr & 0xF)
 	{
 	case 0: // Joystick 1
-		result = joyGetPosEx(JOYSTICKID1, &infoEx);
-		if (result == JOYERR_NOERROR)
+		if (JOYSTICK_1 >= 0 && joyGetPosEx(JOYSTICK_1, &infoEx) == JOYERR_NOERROR)
 		{
 			xAxis = (infoEx.dwXpos >> 8) & 0xFF;
 			yAxis = (infoEx.dwYpos >> 8) & 0xFF;
@@ -89,8 +90,7 @@ BYTE __stdcall FourPlayCard::IORead(WORD pc, WORD addr, BYTE bWrite, BYTE value,
 		nOutput = up | (down << 1) | (left << 2) | (right << 3) | (alwaysHigh << 5) | (trigger2 << 6) | (trigger1 << 7);
 		break;
 	case 1: // Joystick 2
-		result = joyGetPosEx(JOYSTICKID2, &infoEx);
-		if (result == JOYERR_NOERROR)
+		if (JOYSTICK_2 >= 0 && joyGetPosEx(JOYSTICK_2, &infoEx) == JOYERR_NOERROR)
 		{
 			xAxis = (infoEx.dwXpos >> 8) & 0xFF;
 			yAxis = (infoEx.dwYpos >> 8) & 0xFF;

--- a/source/Joystick.cpp
+++ b/source/Joystick.cpp
@@ -51,6 +51,9 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 enum {DEVICE_NONE=0, DEVICE_JOYSTICK, DEVICE_KEYBOARD, DEVICE_MOUSE, DEVICE_JOYSTICK_THUMBSTICK2};
 
+int JOYSTICK_1 = -1;
+int JOYSTICK_2 = -1;
+
 // Indexed by joytype[n]
 static const DWORD joyinfo[6] =	{	DEVICE_NONE,
 									DEVICE_JOYSTICK,
@@ -123,13 +126,16 @@ void JoySetHookAltKeys(bool hook)
 //===========================================================================
 void CheckJoystick0()
 {
+	if (JOYSTICK_1 < 0)
+		return;
+
   static DWORD lastcheck = 0;
   DWORD currtime = GetTickCount();
   if ((currtime-lastcheck >= 10) || joybutton[0] || joybutton[1])
   {
     lastcheck = currtime;
     JOYINFO info;
-    if (joyGetPos(JOYSTICKID1,&info) == JOYERR_NOERROR)
+    if (joyGetPos(JOYSTICK_1,&info) == JOYERR_NOERROR)
 	{
       joybutton[0] = ((info.wButtons & JOY_BUTTON1) != 0);
       if (joyinfo[joytype[1]] == DEVICE_NONE)	// Only consider 2nd button if NOT emulating a 2nd Apple joystick
@@ -160,7 +166,7 @@ void CheckJoystick1()
       JOYINFOEX infoEx;
       infoEx.dwSize = sizeof(infoEx);
       infoEx.dwFlags = JOY_RETURNBUTTONS | JOY_RETURNZ | JOY_RETURNR;
-      result = joyGetPosEx(JOYSTICKID1, &infoEx);
+      result = joyGetPosEx(JOYSTICK_1, &infoEx);
       if (result == JOYERR_NOERROR)
       {
         info.wButtons = (infoEx.dwButtons & JOY_BUTTON2) ? JOY_BUTTON1 : 0;
@@ -169,7 +175,7 @@ void CheckJoystick1()
       }
     }
     else
-      result = joyGetPos(JOYSTICKID2, &info);
+      result = joyGetPos(JOYSTICK_2, &info);
     if (result == JOYERR_NOERROR)
 	{
       joybutton[2] = ((info.wButtons & JOY_BUTTON1) != 0);
@@ -193,99 +199,128 @@ void CheckJoystick1()
 //===========================================================================
 void JoyInitialize()
 {
-  // Emulated joystick #0 can only use JOYSTICKID1 (if no joystick, then use keyboard)
-  // Emulated joystick #1 can only use JOYSTICKID2 (if no joystick, then disable)
+	//
+	// Detect First and Second connected JOYSTICK in WinMM apis. JOYSTICKID1 is 0 and is not always anymore the first connected joystick
+	//
 
-  //
-  // Init for emulated joystick #0:
-  //
+	JOYSTICK_1 = -1;
+	JOYSTICK_2 = -1;
 
-  if (joyinfo[joytype[0]] == DEVICE_JOYSTICK)
-  {
-    JOYCAPS caps;
-    if (joyGetDevCaps(JOYSTICKID1,&caps,sizeof(JOYCAPS)) == JOYERR_NOERROR)
+	bool firstFound = false;
+
+	UINT joys = joyGetNumDevs();
+	for (int i = 0; i < joys; i++)
 	{
-      joyshrx[0] = 0;
-      joyshry[0] = 0;
-      joysubx[0] = (int)caps.wXmin;
-      joysuby[0] = (int)caps.wYmin;
-      UINT xrange  = caps.wXmax-caps.wXmin;
-      UINT yrange  = caps.wYmax-caps.wYmin;
-      while (xrange > 256)
-	  {
-        xrange >>= 1;
-        ++joyshrx[0];
-      }
-      while (yrange > 256)
-	  {
-        yrange >>= 1;
-        ++joyshry[0];
-      }
-    }
-    else
-	{
-      joytype[0] = J0C_KEYBD_NUMPAD;
+		JOYCAPS caps;
+		int ret = joyGetDevCaps(i, &caps, sizeof(JOYCAPS));
+		if (ret != JOYERR_NOERROR)
+			continue;
+
+		JOYINFO info;
+		ret = joyGetPos(i, &info);
+		if (ret != JOYERR_NOERROR)
+			continue;
+
+		if (firstFound)
+		{
+			JOYSTICK_2 = i;
+			break;
+		}
+
+		JOYSTICK_1 = i;
+		firstFound = true;
 	}
-  }
 
-  //
-  // Init for emulated joystick #1:
-  //
+	//
+	// Init for emulated joystick #0:
+	//
 
-  if (joyinfo[joytype[1]] == DEVICE_JOYSTICK)
-  {
-    JOYCAPS caps;
-    if (joyGetDevCaps(JOYSTICKID2,&caps,sizeof(JOYCAPS)) == JOYERR_NOERROR)
+	if (joyinfo[joytype[0]] == DEVICE_JOYSTICK)
 	{
-      joyshrx[1] = 0;
-      joyshry[1] = 0;
-      joysubx[1] = (int)caps.wXmin;
-      joysuby[1] = (int)caps.wYmin;
-      UINT xrange  = caps.wXmax-caps.wXmin;
-      UINT yrange  = caps.wYmax-caps.wYmin;
-      while (xrange > 256)
-	  {
-        xrange >>= 1;
-        ++joyshrx[1];
-      }
-      while (yrange > 256)
-	  {
-        yrange >>= 1;
-        ++joyshry[1];
-      }
-    }
-    else
-	{
-      joytype[1] = J1C_DISABLED;
+		JOYCAPS caps;
+		if (JOYSTICK_1 >= 0 && joyGetDevCaps(JOYSTICK_1, &caps, sizeof(JOYCAPS)) == JOYERR_NOERROR)
+		{
+			joyshrx[0] = 0;
+			joyshry[0] = 0;
+			joysubx[0] = (int)caps.wXmin;
+			joysuby[0] = (int)caps.wYmin;
+			UINT xrange = caps.wXmax - caps.wXmin;
+			UINT yrange = caps.wYmax - caps.wYmin;
+			while (xrange > 256)
+			{
+				xrange >>= 1;
+				++joyshrx[0];
+			}
+			while (yrange > 256)
+			{
+				yrange >>= 1;
+				++joyshry[0];
+			}
+		}
+		else
+		{
+			joytype[0] = J0C_KEYBD_NUMPAD;
+		}
 	}
-  }
-  else if (joyinfo[joytype[1]] == DEVICE_JOYSTICK_THUMBSTICK2)
-  {
-    JOYCAPS caps;
-    if (joyGetDevCaps(JOYSTICKID1, &caps, sizeof(JOYCAPS)) == JOYERR_NOERROR)
-    {
-      joyshrx[1] = 0;
-      joyshry[1] = 0;
-      joysubx[1] = (int)caps.wZmin;
-      joysuby[1] = (int)caps.wRmin;
-      UINT xrange = caps.wZmax - caps.wZmin;
-      UINT yrange = caps.wRmax - caps.wRmin;
-      while (xrange > 256)
-      {
-        xrange >>= 1;
-        ++joyshrx[1];
-      }
-      while (yrange > 256)
-      {
-        yrange >>= 1;
-        ++joyshry[1];
-      }
-    }
-    else
-    {
-      joytype[1] = J1C_DISABLED;
-    }
-  }
+
+	//
+	// Init for emulated joystick #1:
+	//
+
+	if (JOYSTICK_2 >= 0 && joyinfo[joytype[1]] == DEVICE_JOYSTICK)
+	{
+		JOYCAPS caps;
+		if (joyGetDevCaps(JOYSTICK_2, &caps, sizeof(JOYCAPS)) == JOYERR_NOERROR)
+		{
+			joyshrx[1] = 0;
+			joyshry[1] = 0;
+			joysubx[1] = (int)caps.wXmin;
+			joysuby[1] = (int)caps.wYmin;
+			UINT xrange = caps.wXmax - caps.wXmin;
+			UINT yrange = caps.wYmax - caps.wYmin;
+			while (xrange > 256)
+			{
+				xrange >>= 1;
+				++joyshrx[1];
+			}
+			while (yrange > 256)
+			{
+				yrange >>= 1;
+				++joyshry[1];
+			}
+		}
+		else
+		{
+			joytype[1] = J1C_DISABLED;
+		}
+	}
+	else if (JOYSTICK_1 >= 0 && joyinfo[joytype[1]] == DEVICE_JOYSTICK_THUMBSTICK2)
+	{
+		JOYCAPS caps;
+		if (joyGetDevCaps(JOYSTICK_1, &caps, sizeof(JOYCAPS)) == JOYERR_NOERROR)
+		{
+			joyshrx[1] = 0;
+			joyshry[1] = 0;
+			joysubx[1] = (int)caps.wZmin;
+			joysuby[1] = (int)caps.wRmin;
+			UINT xrange = caps.wZmax - caps.wZmin;
+			UINT yrange = caps.wRmax - caps.wRmin;
+			while (xrange > 256)
+			{
+				xrange >>= 1;
+				++joyshrx[1];
+			}
+			while (yrange > 256)
+			{
+				yrange >>= 1;
+				++joyshry[1];
+			}
+		}
+		else
+		{
+			joytype[1] = J1C_DISABLED;
+		}
+	}
 }
 
 //===========================================================================
@@ -710,9 +745,9 @@ BOOL JoySetEmulationType(HWND window, DWORD newtype, int nJoystickNumber, const 
   if (joyinfo[newtype] == DEVICE_JOYSTICK || joyinfo[newtype] == DEVICE_JOYSTICK_THUMBSTICK2)
   {
     JOYCAPS caps;
-	unsigned int nJoy2ID = joyinfo[newtype] == DEVICE_JOYSTICK_THUMBSTICK2 ? JOYSTICKID1 : JOYSTICKID2;
-	unsigned int nJoyID = nJoystickNumber == JN_JOYSTICK0 ? JOYSTICKID1 : nJoy2ID;
-    if (joyGetDevCaps(nJoyID, &caps, sizeof(JOYCAPS)) != JOYERR_NOERROR)
+	unsigned int nJoy2ID = joyinfo[newtype] == DEVICE_JOYSTICK_THUMBSTICK2 ? JOYSTICK_1 : JOYSTICK_2;
+	unsigned int nJoyID = nJoystickNumber == JN_JOYSTICK0 ? JOYSTICK_1 : nJoy2ID;
+    if (nJoyID < 0 || joyGetDevCaps(nJoyID, &caps, sizeof(JOYCAPS)) != JOYERR_NOERROR)
     {
       MessageBox(window,
                  TEXT("The emulator is unable to read your PC joystick.  ")

--- a/source/SNESMAX.cpp
+++ b/source/SNESMAX.cpp
@@ -57,6 +57,9 @@
 #include "Memory.h"
 #include "YamlHelper.h"
 
+extern int JOYSTICK_1; // declared in joystick.cpp
+extern int JOYSTICK_2;
+
 // Default to Sony DS4 / DualSense:
 // b11,..,b0: St,Sl / -,-,R,L,X,A,B,Y
 //
@@ -102,8 +105,7 @@ BYTE __stdcall SNESMAXCard::IOWrite(WORD pc, WORD addr, BYTE bWrite, BYTE value,
 	UINT xAxis = 0;
 	UINT yAxis = 0;
 
-	JOYINFOEX infoEx;
-	MMRESULT result = 0;
+	JOYINFOEX infoEx;	
 	infoEx.dwSize = sizeof(infoEx);
 	infoEx.dwFlags = JOY_RETURNPOV | JOY_RETURNBUTTONS;
 
@@ -117,14 +119,14 @@ BYTE __stdcall SNESMAXCard::IOWrite(WORD pc, WORD addr, BYTE bWrite, BYTE value,
 		controller1Buttons = 0;
 		controller2Buttons = 0;
 
-		result = joyGetPosEx(JOYSTICKID1, &infoEx);
-		if (result == JOYERR_NOERROR)
+		if (JOYSTICK_1 >= 0 && joyGetPosEx(JOYSTICK_1, &infoEx) == JOYERR_NOERROR)
 			controller1Buttons = pCard->GetControllerButtons(JOYSTICKID1, infoEx, pCard->m_altControllerType[0]);
+
 		controller1Buttons = ~controller1Buttons;
 
-		result = joyGetPosEx(JOYSTICKID2, &infoEx);
-		if (result == JOYERR_NOERROR)
+		if (JOYSTICK_2 >= 0 && joyGetPosEx(JOYSTICK_2, &infoEx) == JOYERR_NOERROR)
 			controller2Buttons = pCard->GetControllerButtons(JOYSTICKID2, infoEx, pCard->m_altControllerType[1]);
+
 		controller2Buttons = ~controller2Buttons;
 
 		break;


### PR DESCRIPTION
We can't trust JOYSTICKID1 (0) & JOYSTICKID2 (1) indexes with WinMM. ( my 1st device is @ index 4 )
So it's mostly not working & not detecting joysticks.

Detect JOYSTICK_1 & JOYSTICK_2 real indexes instead.
