### PR TITLE
Properly catch installation of multiple Z80 cards.

### DIFF
--- a/source/CardManager.cpp
+++ b/source/CardManager.cpp
@@ -87,7 +87,7 @@ void CardManager::InsertInternal(UINT slot, SS_CARDTYPE type)
 	case CT_Z80:
 		_ASSERT(m_pZ80Card == NULL);
 		if (m_pZ80Card) break;	// Only support one Z80 card
-		m_slot[slot] = new Z80Card(slot);
+		m_slot[slot] = m_pZ80Card = new Z80Card(slot);
 		break;
 	case CT_Phasor:
 		m_slot[slot] = new MockingboardCard(slot, type);
@@ -166,6 +166,9 @@ void CardManager::RemoveInternal(UINT slot)
 		case CT_Saturn128K:
 		case CT_LanguageCardIIe:
 			m_pLanguageCard = NULL;
+			break;
+		case CT_Z80:
+			m_pZ80Card = NULL;
 			break;
 		}
 

--- a/source/CardManager.h
+++ b/source/CardManager.h
@@ -83,5 +83,5 @@ private:
 	class CSuperSerialCard* m_pSSC;
 	class LanguageCardUnit* m_pLanguageCard;
 	class ParallelPrinterCard* m_pParallelPrinterCard;
-	class m_pZ80Card* m_pZ80Card;
+	class Z80Card* m_pZ80Card;
 };


### PR DESCRIPTION
Corrected the check if multiple Z80 cards are installed. The check was already there, but didn't work - due to incomplete copy&pasting - and a minor goof with the class name...