### PR TITLE
Breakpoints: some new features

### DIFF
--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -1094,7 +1094,7 @@ bool GetBreakpointInfo ( WORD nOffset, bool & bBreakpointActive_, bool & bBreakp
 	return false;
 }
 
-// returns the hit type if the breakpoints stops
+// returns the hit type if the breakpoint stops
 static BreakpointHit_t hitBreakpoint(Breakpoint_t * pBP, BreakpointHit_t eHitType)
 {
 	pBP->bHit = true;
@@ -2309,7 +2309,6 @@ Update_t CmdTrace (int nArgs)
 	g_nDebugStepUntil = -1;
 
 	DebugEnterStepping();
-	GetFrame().FrameRefreshStatus(DRAW_TITLE | DRAW_DISK_STATUS);
 	DebugContinueStepping(true);
 
 	return UPDATE_ALL; // TODO: Verify // 0
@@ -2367,7 +2366,6 @@ Update_t CmdTraceLine (int nArgs)
 	g_nDebugStepUntil = -1;
 
 	DebugEnterStepping();
-	GetFrame().FrameRefreshStatus(DRAW_TITLE | DRAW_DISK_STATUS);
 	DebugContinueStepping(true);
 
 	return UPDATE_ALL; // TODO: Verify // 0
@@ -8389,8 +8387,7 @@ void DebugBegin ()
 //===========================================================================
 void DebugExitDebugger ()
 {
-	ClearTempBreakpoints();  // make sure we remove dead breakpoints before checking
-	// should this check if breakpoints are actually enabled?
+	ClearTempBreakpoints();  // make sure we remove temp breakpoints before checking
 	if (g_nBreakpoints == 0 && g_hTraceFile == NULL)
 	{
 		DebugEnd();

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -1244,7 +1244,7 @@ int CheckBreakpointsIO ()
 		NO_6502_TARGET
 	};
 	int  nBytes;
-	int  iBreakpointHit = 0;
+	int  bBreakpointHit = 0;
 
 	int  iTarget;
 	int  nAddress;
@@ -1275,20 +1275,20 @@ int CheckBreakpointsIO ()
 
 								if (pBP->eSource == BP_SRC_MEM_RW)
 								{
-									iBreakpointHit |= hitBreakpoint(pBP, BP_HIT_MEM);
+									bBreakpointHit |= hitBreakpoint(pBP, BP_HIT_MEM);
 								}
 								else if (pBP->eSource == BP_SRC_MEM_READ_ONLY)
 								{
 									if (g_aOpcodes[opcode].nMemoryAccess & (MEM_RI|MEM_R))
 									{
-										iBreakpointHit |= hitBreakpoint(pBP, BP_HIT_MEMR);
+										bBreakpointHit |= hitBreakpoint(pBP, BP_HIT_MEMR);
 									}
 								}
 								else if (pBP->eSource == BP_SRC_MEM_WRITE_ONLY)
 								{
 									if (g_aOpcodes[opcode].nMemoryAccess & (MEM_WI|MEM_W))
 									{
-										iBreakpointHit |= hitBreakpoint(pBP, BP_HIT_MEMW);
+										bBreakpointHit |= hitBreakpoint(pBP, BP_HIT_MEMW);
 									}
 								}
 								else
@@ -1302,7 +1302,7 @@ int CheckBreakpointsIO ()
 			}
 		}
 	}
-	return iBreakpointHit;
+	return bBreakpointHit;
 }
 
 // Returns true if a register breakpoint is triggered
@@ -1909,24 +1909,24 @@ Update_t CmdBreakpointChange (int nArgs) {
 		{
 			switch (sArg[i])
 			{
-			case 'E':
-				bp.bEnabled = true;
-				break;
-			case 'e':
-				bp.bEnabled = false;
-				break;
-			case 'T':
-				bp.bTemp = true;
-				break;
-			case 't':
-				bp.bTemp = false;
-				break;
-			case 'S':
-				bp.bStop = true;
-				break;
-			case 's':
-				bp.bStop = false;
-				break;
+				case 'E':
+					bp.bEnabled = true;
+					break;
+				case 'e':
+					bp.bEnabled = false;
+					break;
+				case 'T':
+					bp.bTemp = true;
+					break;
+				case 't':
+					bp.bTemp = false;
+					break;
+				case 'S':
+					bp.bStop = true;
+					break;
+				case 's':
+					bp.bStop = false;
+					break;
 			}
 		}
 	}
@@ -1937,9 +1937,9 @@ Update_t CmdBreakpointChange (int nArgs) {
 void _BWZ_List( const Breakpoint_t * aBreakWatchZero, const int iBWZ ) //, bool bZeroBased )
 {
 	static const char sEnabledFlags[] = "-E";
-	static const char sStopFlags[] = "-S";
-	static const char sTempFlags[] = "-T";
-	static const char sHitFlags[] = " *";
+	static const char sStopFlags[]    = "-S";
+	static const char sTempFlags[]    = "-T";
+	static const char sHitFlags[]     = " *";
 
 	std::string sAddressBuf;
 	std::string const& sSymbol = GetSymbol(aBreakWatchZero[iBWZ].nAddress, 2, sAddressBuf);

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -1094,6 +1094,14 @@ bool GetBreakpointInfo ( WORD nOffset, bool & bBreakpointActive_, bool & bBreakp
 	return false;
 }
 
+// returns the hit type if the breakpoints stops
+static BreakpointHit_t hitBreakpoint(Breakpoint_t * pBP, BreakpointHit_t eHitType)
+{
+	pBP->bHit = true;
+	++pBP->nHitCount;
+	return pBP->bStop ? eHitType : BP_HIT_NONE;
+}
+
 
 // Returns true if we should continue checking breakpoint details, else false
 //===========================================================================
@@ -1213,7 +1221,7 @@ int CheckBreakpointsIO ()
 		NO_6502_TARGET
 	};
 	int  nBytes;
-	bool bBreakpointHit = 0;
+	int  iBreakpointHit = 0;
 
 	int  iTarget;
 	int  nAddress;
@@ -1244,17 +1252,21 @@ int CheckBreakpointsIO ()
 
 								if (pBP->eSource == BP_SRC_MEM_RW)
 								{
-									return BP_HIT_MEM;
+									iBreakpointHit |= hitBreakpoint(pBP, BP_HIT_MEM);
 								}
 								else if (pBP->eSource == BP_SRC_MEM_READ_ONLY)
 								{
 									if (g_aOpcodes[opcode].nMemoryAccess & (MEM_RI|MEM_R))
-										return BP_HIT_MEMR;
+									{
+										iBreakpointHit |= hitBreakpoint(pBP, BP_HIT_MEMR);
+									}
 								}
 								else if (pBP->eSource == BP_SRC_MEM_WRITE_ONLY)
 								{
 									if (g_aOpcodes[opcode].nMemoryAccess & (MEM_WI|MEM_W))
-										return BP_HIT_MEMW;
+									{
+										iBreakpointHit |= hitBreakpoint(pBP, BP_HIT_MEMW);
+									}
 								}
 								else
 								{
@@ -1267,14 +1279,14 @@ int CheckBreakpointsIO ()
 			}
 		}
 	}
-	return bBreakpointHit;
+	return iBreakpointHit;
 }
 
 // Returns true if a register breakpoint is triggered
 //===========================================================================
 int CheckBreakpointsReg ()
 {
-	int bBreakpointHit = 0;
+	int iAnyBreakpointHit = 0;
 
 	for (int iBreakpoint = 0; iBreakpoint < MAX_BREAKPOINTS; iBreakpoint++)
 	{
@@ -1282,6 +1294,8 @@ int CheckBreakpointsReg ()
 
 		if (! _BreakpointValid( pBP ))
 			continue;
+
+		bool bBreakpointHit = 0;
 
 		switch (pBP->eSource)
 		{
@@ -1309,15 +1323,13 @@ int CheckBreakpointsReg ()
 
 		if (bBreakpointHit)
 		{
-			bBreakpointHit = BP_HIT_REG;
+			iAnyBreakpointHit = hitBreakpoint(pBP, BP_HIT_REG);
 			if (pBP->bTemp)
 				_BWZ_Clear(pBP, iBreakpoint);
-
-			break;
 		}
 	}
 
-	return bBreakpointHit;
+	return iAnyBreakpointHit;
 }
 
 void ClearTempBreakpoints ()
@@ -1338,7 +1350,7 @@ void ClearTempBreakpoints ()
 //===========================================================================
 int CheckBreakpointsVideo()
 {
-	int bBreakpointHit = 0;
+	int iBreakpointHit = 0;
 
 	for (int iBreakpoint = 0; iBreakpoint < MAX_BREAKPOINTS; iBreakpoint++)
 	{
@@ -1353,13 +1365,12 @@ int CheckBreakpointsVideo()
 		uint16_t vert = NTSC_GetVideoVertForDebugger();	// update video scanner's vert/horz position - needed for when in fullspeed (GH#1164)
 		if (_CheckBreakpointValue(pBP, vert))
 		{
-			bBreakpointHit = BP_HIT_VIDEO_POS;
+			iBreakpointHit = hitBreakpoint(pBP, BP_HIT_VIDEO_POS);
 			pBP->bEnabled = false;	// Disable, otherwise it'll trigger many times on this scan-line
-			break;
 		}
 	}
 
-	return bBreakpointHit;
+	return iBreakpointHit;
 }
 
 //===========================================================================
@@ -1545,6 +1556,9 @@ bool _CmdBreakpointAddReg( Breakpoint_t *pBP, BreakpointSource_t iSrc, Breakpoin
 		pBP->bSet      = true;
 		pBP->bEnabled  = true;
 		pBP->bTemp     = bIsTempBreakpoint;
+		pBP->bStop     = true;
+		pBP->bHit      = false;
+		pBP->nHitCount = 0;
 		bStatus = true;
 	}
 
@@ -1875,9 +1889,55 @@ Update_t CmdBreakpointEnable (int nArgs) {
 }
 
 
+Update_t CmdBreakpointChange (int nArgs) {
+
+	if (! g_nBreakpoints)
+		return ConsoleDisplayError("There are no (PC) Breakpoints defined.");
+
+	if (nArgs != 2)
+		return Help_Arg_1( CMD_BREAKPOINT_CHANGE );
+
+	const int iSlot = g_aArgs[1].nValue;
+	if (iSlot >= 0 && iSlot < MAX_BREAKPOINTS && g_aBreakpoints[iSlot].bSet)
+	{
+		Breakpoint_t & bp = g_aBreakpoints[iSlot];
+		const char * sArg = g_aArgs[2].sArg;
+		const int nArgLen = g_aArgs[2].nArgLen;
+		for (int i = 0; i < nArgLen; ++i)
+		{
+			switch (sArg[i])
+			{
+			case 'E':
+				bp.bEnabled = true;
+				break;
+			case 'e':
+				bp.bEnabled = false;
+				break;
+			case 'T':
+				bp.bTemp = true;
+				break;
+			case 't':
+				bp.bTemp = false;
+				break;
+			case 'S':
+				bp.bStop = true;
+				break;
+			case 's':
+				bp.bStop = false;
+				break;
+			}
+		}
+	}
+
+	return UPDATE_BREAKPOINTS;
+}
+
 void _BWZ_List( const Breakpoint_t * aBreakWatchZero, const int iBWZ ) //, bool bZeroBased )
 {
-	static const char sFlags[] = "-*";
+	static const char sEnabledFlags[] = "-E";
+	static const char sStopFlags[] = "-S";
+	static const char sTempFlags[] = "-T";
+	static const char sHitFlags[] = " *";
 
 	std::string sAddressBuf;
 	std::string const& sSymbol = GetSymbol(aBreakWatchZero[iBWZ].nAddress, 2, sAddressBuf);
@@ -1886,10 +1946,14 @@ void _BWZ_List( const Breakpoint_t * aBreakWatchZero, const int iBWZ ) //, bool 
 				: aBreakWatchZero[iBWZ].eSource == BP_SRC_MEM_WRITE_ONLY ? 'W'
 				: ' ';
 
-	ConsoleBufferPushFormat( "  #%d %c %04X %c %s",
+	ConsoleBufferPushFormat( "  #%d %c %c %c %c %08X %04X %c %s",
 //		(bZeroBased ? iBWZ + 1 : iBWZ),
 		iBWZ,
-		sFlags[ aBreakWatchZero[ iBWZ ].bEnabled ? 1 : 0 ],
+		sEnabledFlags[ aBreakWatchZero[ iBWZ ].bEnabled ? 1 : 0 ],
+		sStopFlags[ aBreakWatchZero[ iBWZ ].bStop ? 1 : 0 ],
+		sTempFlags[ aBreakWatchZero[ iBWZ ].bTemp ? 1 : 0 ],
+		sHitFlags[ aBreakWatchZero[ iBWZ ].bHit ? 1 : 0 ],
+		aBreakWatchZero[ iBWZ ].nHitCount,
 		aBreakWatchZero[ iBWZ ].nAddress,
 		cBPM,
 		sSymbol.c_str()

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -83,7 +83,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 	static DebugBreakOnDMA g_DebugBreakOnDMA[NUM_BREAK_ON_DMA];
 	static DebugBreakOnDMA g_DebugBreakOnDMAIO;
 
-	static int  g_bDebugBreakpointHit = 0;	// See: BreakpointHit_t
+	int  g_bDebugBreakpointHit = 0;	// See: BreakpointHit_t
 
 	int  g_nBreakpoints          = 0;
 	Breakpoint_t g_aBreakpoints[ MAX_BREAKPOINTS ];
@@ -1764,18 +1764,13 @@ Update_t CmdBreakpointAddVideo(int nArgs)
 }
 
 //===========================================================================
-void _BWZ_Clear( Breakpoint_t * aBreakWatchZero, int iSlot )
-{
-	aBreakWatchZero[ iSlot ].bSet     = false;
-	aBreakWatchZero[ iSlot ].bEnabled = false;
-	aBreakWatchZero[ iSlot ].nLength  = 0;
-}
-
 void _BWZ_RemoveOne( Breakpoint_t *aBreakWatchZero, const int iSlot, int & nTotal )
 {
 	if (aBreakWatchZero[iSlot].bSet)
 	{
-		_BWZ_Clear( aBreakWatchZero, iSlot );
+		aBreakWatchZero[ iSlot ].bSet     = false;
+		aBreakWatchZero[ iSlot ].bEnabled = false;
+		aBreakWatchZero[ iSlot ].nLength  = 0;
 		nTotal--;
 	}
 }
@@ -8395,7 +8390,7 @@ void DebugBegin ()
 void DebugExitDebugger ()
 {
 	ClearTempBreakpoints();  // make sure we remove dead breakpoints before checking
-	// should this check if breakpoints are enabled?
+	// should this check if breakpoints are actually enabled?
 	if (g_nBreakpoints == 0 && g_hTraceFile == NULL)
 	{
 		DebugEnd();

--- a/source/Debugger/Debug.h
+++ b/source/Debugger/Debug.h
@@ -46,6 +46,8 @@
 		, BP_HIT_VIDEO_POS = (1 << 12)
 	};
 
+	extern int          g_bDebugBreakpointHit;
+
 	extern int          g_nBreakpoints;
 	extern Breakpoint_t g_aBreakpoints[ MAX_BREAKPOINTS ];
 

--- a/source/Debugger/Debug.h
+++ b/source/Debugger/Debug.h
@@ -188,3 +188,5 @@
 	bool	IsDebugSteppingAtFullSpeed(void);
 	void	DebuggerBreakOnDmaToOrFromIoMemory(WORD nAddress, bool isDmaToMemory);
 	bool	DebuggerCheckMemBreakpoints(WORD nAddress, WORD nSize, bool isDmaToMemory);
+
+	void	ClearTempBreakpoints();

--- a/source/Debugger/Debugger_Commands.cpp
+++ b/source/Debugger/Debugger_Commands.cpp
@@ -99,6 +99,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 		{TEXT("BPL")         , CmdBreakpointList    , CMD_BREAKPOINT_LIST      , "List all breakpoints"                  }, // SoftICE
 //		{TEXT("BPLOAD")      , CmdBreakpointLoad    , CMD_BREAKPOINT_LOAD      , "Loads breakpoints" },
 		{TEXT("BPSAVE")      , CmdBreakpointSave    , CMD_BREAKPOINT_SAVE      , "Saves breakpoints" },
+		{TEXT("BPCHANGE")    , CmdBreakpointChange  , CMD_BREAKPOINT_CHANGE    , "Change breakpoint" },
 	// Config
 		{TEXT("BENCHMARK")   , CmdBenchmark         , CMD_BENCHMARK            , "Benchmark the emulator" },
 		{TEXT("BW")          , CmdConfigColorMono   , CMD_CONFIG_BW            , "Sets/Shows RGB for Black & White scheme" },

--- a/source/Debugger/Debugger_Help.cpp
+++ b/source/Debugger/Debugger_Help.cpp
@@ -499,7 +499,7 @@ Update_t CmdHelpSpecific (int nArgs)
 			switch ( iParam )
 			{
 				case PARAM_CAT_BOOKMARKS  : iCmdBegin = CMD_BOOKMARK        ; iCmdEnd = CMD_BOOKMARK_SAVE        ; break;
-				case PARAM_CAT_BREAKPOINTS: iCmdBegin = CMD_BREAK_INVALID   ; iCmdEnd = CMD_BREAKPOINT_SAVE      ; break;
+				case PARAM_CAT_BREAKPOINTS: iCmdBegin = CMD_BREAK_INVALID   ; iCmdEnd = CMD_BREAKPOINT_CHANGE    ; break;
 				case PARAM_CAT_CONFIG     : iCmdBegin = CMD_BENCHMARK       ; iCmdEnd = CMD_CONFIG_SET_DEBUG_DIR; break;
 				case PARAM_CAT_CPU        : iCmdBegin = CMD_ASSEMBLE        ; iCmdEnd = CMD_UNASSEMBLE           ; break;
 				case PARAM_CAT_FLAGS      :

--- a/source/Debugger/Debugger_Types.h
+++ b/source/Debugger/Debugger_Types.h
@@ -215,6 +215,9 @@
 		bool                 bSet    ; // used to be called enabled pre 2.0
 		bool                 bEnabled;
 		bool                 bTemp;    // If true then remove BP when hit or stepping cancelled (eg. G xxxx)
+		bool                 bHit;     // true when the breakpoint has just been hit
+		bool                 bStop;    // true if the debugger stops when it is hit
+		DWORD                nHitCount;  // number of times the breakpoint was hit
 	};
 
 	typedef Breakpoint_t Bookmark_t;
@@ -345,6 +348,7 @@
 		, CMD_BREAKPOINT_LIST
 //		, CMD_BREAKPOINT_LOAD
 		, CMD_BREAKPOINT_SAVE
+		, CMD_BREAKPOINT_CHANGE
 // Benchmark / Timing
 //		, CMD_BENCHMARK_START
 //		, CMD_BENCHMARK_STOP
@@ -648,6 +652,7 @@
 	Update_t CmdBreakpointDisable  (int nArgs);
 	Update_t CmdBreakpointEdit     (int nArgs);
 	Update_t CmdBreakpointEnable   (int nArgs);
+	Update_t CmdBreakpointChange   (int nArgs);
 	Update_t CmdBreakpointList     (int nArgs);
 //	Update_t CmdBreakpointLoad     (int nArgs);
 	Update_t CmdBreakpointSave     (int nArgs);

--- a/source/Debugger/Debugger_Types.h
+++ b/source/Debugger/Debugger_Types.h
@@ -208,16 +208,16 @@
 
 	struct Breakpoint_t
 	{
-		WORD                 nAddress; // for registers, functions as nValue
-		UINT                 nLength ;
+		WORD                 nAddress ; // for registers, functions as nValue
+		UINT                 nLength  ;
 		BreakpointSource_t   eSource;
 		BreakpointOperator_t eOperator;
-		bool                 bSet    ; // used to be called enabled pre 2.0
+		bool                 bSet     ; // used to be called enabled pre 2.0
 		bool                 bEnabled;
-		bool                 bTemp;    // If true then remove BP when hit or stepping cancelled (eg. G xxxx)
-		bool                 bHit;     // true when the breakpoint has just been hit
-		bool                 bStop;    // true if the debugger stops when it is hit
-		DWORD                nHitCount;  // number of times the breakpoint was hit
+		bool                 bTemp    ; // If true then remove BP when hit or stepping cancelled (eg. G xxxx)
+		bool                 bHit     ; // true when the breakpoint has just been hit
+		bool                 bStop    ; // true if the debugger stops when it is hit
+		DWORD                nHitCount; // number of times the breakpoint was hit
 	};
 
 	typedef Breakpoint_t Bookmark_t;


### PR DESCRIPTION
I would like to propose this PR with a few new features for breakpoints.

First, a little disclosure: I am trying to integrate AppleWin (linux only) into this debugger for CC65 https://github.com/empathicqubit/vscode-cc65-debugger. To achieve this, I need to implement the VICE binary monitor protocol https://vice-emu.sourceforge.io/vice_13.html which requires these (little) extensions to breakpoints.

But, you can simply ignore all the above and look at these features, which I think have a value on their own.

1. add a hit count
2. add a `bStop` flag. if `false` only the hit count is incremented
3. add a `bHit` flag, so it is possible to query which breakpoint(s) have caused the debugger to stop
4. keep temporary breakpoints alive a bit longer, so they can be inspected

In order to ease the debugging I have added a new command `BPCHANGE` to individually change the flags.
`BPL` has been changed to display all the new information.

What do people think of the idea? And, second question, what about the implementation?
