### PR TITLE
Debugger cleanup misc march 2023

### DIFF
--- a/source/Debugger/Debug.h
+++ b/source/Debugger/Debug.h
@@ -29,20 +29,20 @@
 // Breakpoints
 	enum BreakpointHit_t
 	{
-		BP_HIT_NONE = 0
-		, BP_HIT_INVALID = (1 << 0)
-		, BP_HIT_OPCODE = (1 << 1)
-		, BP_HIT_REG = (1 << 2)
-		, BP_HIT_MEM = (1 << 3)
-		, BP_HIT_MEMR = (1 << 4)
-		, BP_HIT_MEMW = (1 << 5)
-		, BP_HIT_PC_READ_FLOATING_BUS_OR_IO_MEM = (1 << 6)
-		, BP_HIT_INTERRUPT = (1 << 7)
-		, BP_DMA_TO_IO_MEM = (1 << 8)
-		, BP_DMA_FROM_IO_MEM = (1 << 9)
-		, BP_DMA_TO_MEM = (1 << 10)
-		, BP_DMA_FROM_MEM = (1 << 11)
-		, BP_HIT_VIDEO_POS = (1 << 12)
+		  BP_HIT_NONE                           = 0
+		, BP_HIT_INVALID                        = (1 <<  0)
+		, BP_HIT_OPCODE                         = (1 <<  1)
+		, BP_HIT_REG                            = (1 <<  2)
+		, BP_HIT_MEM                            = (1 <<  3)
+		, BP_HIT_MEMR                           = (1 <<  4)
+		, BP_HIT_MEMW                           = (1 <<  5)
+		, BP_HIT_PC_READ_FLOATING_BUS_OR_IO_MEM = (1 <<  6)
+		, BP_HIT_INTERRUPT                      = (1 <<  7)
+		, BP_DMA_TO_IO_MEM                      = (1 <<  8)
+		, BP_DMA_FROM_IO_MEM                    = (1 <<  9)
+		, BP_DMA_TO_MEM                         = (1 << 10)
+		, BP_DMA_FROM_MEM                       = (1 << 11)
+		, BP_HIT_VIDEO_POS                      = (1 << 12)
 	};
 
 	extern int          g_nBreakpoints;

--- a/source/Debugger/Debugger_Help.cpp
+++ b/source/Debugger/Debugger_Help.cpp
@@ -181,7 +181,7 @@ void Help_Operators()
 			sText += g_aBreakpointSymbols[ iBreakOp ];
 			sText += ' ';
 		}
-	}	
+	}
 	sText += CHC_DEFAULT;
 	ConsolePrint( sText.c_str() );
 }
@@ -379,7 +379,7 @@ bool Colorize( char * pDst, size_t /*nDstSz*/, const char* pSrc)
 		{
 			*pDst = *pSrc;
 			pDst++;
-			pSrc++;	
+			pSrc++;
 		}
 	}
 	*pDst = 0;
@@ -602,7 +602,7 @@ Update_t CmdHelpSpecific (int nArgs)
 	}
 
 	for (iArg = 1; iArg <= nArgs; iArg++ )
-	{	
+	{
 		iCommand = 0;
 		nFound = 0;
 
@@ -726,7 +726,7 @@ Update_t CmdHelpSpecific (int nArgs)
 				ConsoleBufferPushFormat( "%s  <-- Missing", pCommand->m_sName );
 	#if DEBUG_COMMAND_HELP
 				if (! bAllCommands) // Release version doesn't display message
-				{			
+				{
 					ConsoleBufferPushFormat( "Missing Summary Help: %s", g_aCommands[ iCommand ].aName );
 				}
 	#endif
@@ -735,11 +735,11 @@ Update_t CmdHelpSpecific (int nArgs)
 
 			if (bCategory)
 				continue;
-		}		
+		}
 
 		// MASTER HELP
 		switch (iCommand)
-		{	
+		{
 	// CPU / General
 		case CMD_ASSEMBLE:
 			ConsoleColorizePrint( " Usage: [address | symbol]" );
@@ -1141,7 +1141,7 @@ Update_t CmdHelpSpecific (int nArgs)
 				ConsoleBufferPush( "  Notes: If no filename specified, defaults to the last filename (if possible)" );
 			}
 			if (iCommand == CMD_MEMORY_SAVE)
-			{			
+			{
 				ConsoleColorizePrint( " Usage: [\"Filename\"],[bank:]address,length" );
 				ConsoleColorizePrint( " Usage: [\"Filename\"],[bank:]range"          );
 				Help_Range();
@@ -1447,7 +1447,7 @@ Update_t CmdHelpList (int nArgs)
 	return UPDATE_CONSOLE_DISPLAY;
 }
 
-	
+
 //===========================================================================
 Update_t CmdVersion (int nArgs)
 {

--- a/source/Debugger/Debugger_Help.cpp
+++ b/source/Debugger/Debugger_Help.cpp
@@ -1285,7 +1285,7 @@ Update_t CmdHelpSpecific (int nArgs)
 			ConsoleColorizePrint( " Usage: symbol" );
 			ConsoleBufferPush( "  Looks up symbol in all 3 symbol tables: main, user, source" );
 			break;
-// Cycles
+	// Cycles
 		case CMD_CYCLES_INFO:
 			ConsoleColorizePrint(" Usage: <abs|rel|part>");
 			ConsoleBufferPush("  Where:");
@@ -1296,8 +1296,7 @@ Update_t CmdHelpSpecific (int nArgs)
 		case CMD_CYCLES_RESET:
 			ConsoleBufferPush("  Use in conjunctioned with 'cycles part' to reset to current instruction");
 			break;
-// Video-Scanner
-
+	// Video-Scanner
 		case CMD_VIDEO_SCANNER_INFO:
 			ConsoleColorizePrint(" Usage: <dec|hex|real|apple>");
 			ConsoleBufferPush("  Where:");
@@ -1308,7 +1307,7 @@ Update_t CmdHelpSpecific (int nArgs)
 				,CHC_COMMAND, CHC_DEFAULT	// green
 			);
 			break;
-// View
+	// View
 		case CMD_VIEW_TEXT4X:
 		case CMD_VIEW_TEXT41:
 		case CMD_VIEW_TEXT42:


### PR DESCRIPTION
Minor misc. cleanup:

* BP alignment
* remove superfluous tabs
* Fix sections

Normally I would indent `case` in that honking big switch/chase in `CmdHelpSpecific()` but I believe I intentionally coded that inconsistent way to minimize horizontal scrolling decades ago.