### PR TITLE
Debugger stop reason

### DIFF
--- a/docs/Debugger_Changelog.txt
+++ b/docs/Debugger_Changelog.txt
@@ -1,4 +1,7 @@
 /*
+2.9.1.15 Added: QoL when a breakpoint register is hit display which register and breakpoint triggered it.
+    Example:
+        Stop reason: Register PC matches breakpoint #0
 2.9.1.14 Fix disassembly when in middle of data
     Example:
         ASC 7D0:7D7

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -88,7 +88,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 	int                  g_bDebugBreakpointHit = 0;       // See: BreakpointHit_t
 	static Breakpoint_t *g_pDebugBreakpointHit = nullptr; // NOTE: Only valid for BP_HIT_REG, see: CheckBreakpointsReg()
 
-	int  g_nBreakpoints          = 0;
+	int          g_nBreakpoints = 0;
 	Breakpoint_t g_aBreakpoints[ MAX_BREAKPOINTS ];
 
 	// NOTE: BreakpointSource_t and g_aBreakpointSource must match!

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -8613,7 +8613,7 @@ void DebugContinueStepping(const bool bCallerWillUpdateDisplay/*=false*/)
 					{
 						int iBreakpoint = (g_pDebugBreakpointHit - g_aBreakpoints);
 						stopReason = StrFormat( "Register %s%s%s matches breakpoint %s#%s%d",
-							CHC_CATEGORY, // TODO: CHC_REGS
+							CHC_REGS,
 							g_aBreakpointSource[ g_pDebugBreakpointHit->eSource ],
 							CHC_DEFAULT,
 							CHC_ARG_SEP,

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -8595,7 +8595,22 @@ void DebugContinueStepping(const bool bCallerWillUpdateDisplay/*=false*/)
 			else if (g_bDebugBreakpointHit & BP_HIT_OPCODE)
 				stopReason = "Opcode match";
 			else if (g_bDebugBreakpointHit & BP_HIT_REG)
-				stopReason = "Register matches value";
+			{
+					if (g_pDebugBreakpointHit)
+					{
+						int iBreakpoint = (g_pDebugBreakpointHit - g_aBreakpoints);
+						stopReason = StrFormat( "Register %s%s%s matches breakpoint %s#%s%d",
+							CHC_CATEGORY, // TODO: CHC_REGS
+							g_aBreakpointSource[ g_pDebugBreakpointHit->eSource ],
+							CHC_DEFAULT,
+							CHC_ARG_SEP,
+							CHC_NUM_HEX,
+							iBreakpoint
+						);
+					}
+					else
+						stopReason = "Register matches value";
+			}
 			else if (g_bDebugBreakpointHit & BP_HIT_MEM)
 				stopReason = StrFormat("Memory access at $%04X", g_uBreakMemoryAddress);
 			else if (g_bDebugBreakpointHit & BP_HIT_MEMW)
@@ -8617,7 +8632,7 @@ void DebugContinueStepping(const bool bCallerWillUpdateDisplay/*=false*/)
 				skipStopReason = true;
 
 			if (!skipStopReason)
-				ConsoleBufferPushFormat( "Stop reason: %s", stopReason.c_str() );
+				ConsolePrintFormat( CHC_INFO "Stop reason: " CHC_DEFAULT "%s", stopReason.c_str() );
 
 			for (int i = 0; i < NUM_BREAK_ON_DMA; i++)
 			{
@@ -8628,7 +8643,7 @@ void DebugContinueStepping(const bool bCallerWillUpdateDisplay/*=false*/)
 						stopReason = StrFormat("HDD DMA to memory $%04X-%04X (BP#%d)", g_DebugBreakOnDMA[i].memoryAddr, g_DebugBreakOnDMA[i].memoryAddrEnd, g_DebugBreakOnDMA[i].BPid);
 					else if (nDebugBreakpointHit & BP_DMA_FROM_MEM)
 						stopReason = StrFormat("HDD DMA from memory $%04X-%04X (BP#%d)", g_DebugBreakOnDMA[i].memoryAddr, g_DebugBreakOnDMA[i].memoryAddrEnd, g_DebugBreakOnDMA[i].BPid);
-					ConsoleBufferPushFormat("Stop reason: %s", stopReason.c_str());
+					ConsolePrintFormat( CHC_INFO "Stop reason: " CHC_DEFAULT "%s", stopReason.c_str() );
 				}
 			}
 

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -85,7 +85,8 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 	static DebugBreakOnDMA g_DebugBreakOnDMA[NUM_BREAK_ON_DMA];
 	static DebugBreakOnDMA g_DebugBreakOnDMAIO;
 
-	int  g_bDebugBreakpointHit = 0;	// See: BreakpointHit_t
+	int                 g_bDebugBreakpointHit = 0;       // See: BreakpointHit_t
+	static Breakpoint_t*g_pDebugBreakpointHit = nullptr; // NOTE: Only valid for BP_HIT_REG, see: CheckBreakpointsReg()
 
 	int  g_nBreakpoints          = 0;
 	Breakpoint_t g_aBreakpoints[ MAX_BREAKPOINTS ];
@@ -1311,6 +1312,8 @@ int CheckBreakpointsIO ()
 //===========================================================================
 int CheckBreakpointsReg ()
 {
+	g_pDebugBreakpointHit = nullptr;
+
 	int iAnyBreakpointHit = 0;
 
 	for (int iBreakpoint = 0; iBreakpoint < MAX_BREAKPOINTS; iBreakpoint++)
@@ -1349,6 +1352,7 @@ int CheckBreakpointsReg ()
 		if (bBreakpointHit)
 		{
 			iAnyBreakpointHit = hitBreakpoint(pBP, BP_HIT_REG);
+			g_pDebugBreakpointHit = pBP; // Save breakpoint so we can display which register triggered the breakpoint.
 		}
 	}
 

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -1327,7 +1327,7 @@ int CheckBreakpointsReg ()
 
 		switch (pBP->eSource)
 		{
-			case BP_SRC_REG_PC: 
+			case BP_SRC_REG_PC:
 				bBreakpointHit = _CheckBreakpointValue( pBP, regs.pc );
 				break;
 			case BP_SRC_REG_A:

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -85,8 +85,8 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 	static DebugBreakOnDMA g_DebugBreakOnDMA[NUM_BREAK_ON_DMA];
 	static DebugBreakOnDMA g_DebugBreakOnDMAIO;
 
-	int                 g_bDebugBreakpointHit = 0;       // See: BreakpointHit_t
-	static Breakpoint_t*g_pDebugBreakpointHit = nullptr; // NOTE: Only valid for BP_HIT_REG, see: CheckBreakpointsReg()
+	int                  g_bDebugBreakpointHit = 0;       // See: BreakpointHit_t
+	static Breakpoint_t *g_pDebugBreakpointHit = nullptr; // NOTE: Only valid for BP_HIT_REG, see: CheckBreakpointsReg()
 
 	int  g_nBreakpoints          = 0;
 	Breakpoint_t g_aBreakpoints[ MAX_BREAKPOINTS ];

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -53,7 +53,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #define MAKE_VERSION(a,b,c,d) ((a<<24) | (b<<16) | (c<<8) | (d))
 
 	// See /docs/Debugger_Changelog.txt for full details
-	const int DEBUGGER_VERSION = MAKE_VERSION(2,9,1,14);
+	const int DEBUGGER_VERSION = MAKE_VERSION(2,9,1,15);
 
 
 // Public _________________________________________________________________________________________

--- a/source/Debugger/Debugger_Console.h
+++ b/source/Debugger/Debugger_Console.h
@@ -80,6 +80,7 @@
 	#define CHC_STRING   "`6" // 
 	#define CHC_EXAMPLE  "`:"
 	#define CHC_PATH     "`:" // Light Blue
+	#define CHC_REGS     "`6" // Cyan
 #else
 	#define CHC_DEFAULT  ""
 	#define CHC_USAGE    ""


### PR DESCRIPTION
Small QoL when a breakpoint is triggered.  See bottom line in debugger.  Color code register and breakpoint number.

# Before
![debugger_stop_reason_before](https://user-images.githubusercontent.com/7876796/226508610-0f47d289-a4d8-47cd-807f-dcbb7164e5f2.png)

# After
![debugger_stop_reason_after](https://user-images.githubusercontent.com/7876796/226508616-c4738b19-39e4-49c7-96c5-f55a0d45ab40.png)
