### PR TITLE
Debugger step over

### DIFF
--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -2356,7 +2356,7 @@ Update_t CmdStepOut (int nArgs)
 	// TODO: "RET" should probably pop the Call stack
 	// Also see: CmdCursorJumpRetAddr
 	WORD nAddress;
-	if (_6502_GetStackReturnAddress( nAddress ))
+	if (_6502_GetStackReturnAddress( nAddress, true ))
 	{
 		nArgs = _Arg_1( nAddress );
 		g_aArgs[1].sArg[0] = 0;

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -2351,8 +2351,8 @@ Update_t CmdStepOver (int nArgs)
 				            RTS
 				*/
 				// MSVC:
-				//   int nMaxSteps = 0xFFFFF; // GH #1194
-				//   Set BP on line above: (regs.pc != nExpectedAddr)
+				// 1.  Revert line to repro: int nMaxSteps = 0xFFFF;
+				// 2.  Set BP on line above: (regs.pc != nExpectedAddr)
 				// AppleWin:
 				//   F7
 				//   300:A0 FF 20 09 03 88 D0 FA 60 A9 FF 20 A8 FC 60

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -2362,10 +2362,10 @@ Update_t CmdStepOver (int nArgs)
 				//   <Ctrl>-<Space>
 				// MSVC:
 				// Change regs.sp to one of 3 cases:
-				//   Case   Addr On Stack   Top of Stack   Diagnostic                      R SP
-				//   0      No              No             ERROR        nStackOffset = 0   regs.sp = 0x1F3
-				//   1      Yes             Yes            INFO         nStackOffset = 1   regs.sp = 0x1F2
-				//   2      Yes             No             WARN         nStackOffset > 1   regs.sp = 0x1F1
+				//   Case   Addr On Stack   Top of Stack   Diagnostic   nStackOffset   R SP              Continue in emulator
+				//   0      No              No             ERROR        -1             regs.sp = 0x1F3
+				//   1      Yes             Yes            INFO          O             regs.sp = 0x1F2   R PC FCB3
+				//   2      Yes             No             WARN         +1             regs.sp = 0x1F1   R S  F1
 				/**/ if (nStackOffset <  0) ConsolePrintFormat( CHC_ERROR   "ERROR" CHC_ARG_SEP ":" CHC_ERROR   " Didn't step over JSR! " CHC_ARG_SEP "(" CHC_DEFAULT "RTS address not found!"                                                                          CHC_ARG_SEP ")"                      ); // Case 0
 				else if (nStackOffset == 0) ConsolePrintFormat( CHC_INFO    "INFO"  CHC_ARG_SEP ":" CHC_INFO    " Didn't step over JSR! " CHC_ARG_SEP "(" CHC_DEFAULT "RTS on top of stack."                                                                            CHC_ARG_SEP ")"                      ); // Case 1
 				else /*                  */ ConsolePrintFormat( CHC_WARNING "WARN"  CHC_ARG_SEP ":" CHC_WARNING " Didn't step over JSR! " CHC_ARG_SEP "(" CHC_DEFAULT "Stack has RTS address but needs fixup: " CHC_ARG_SEP "$" CHC_NUM_HEX "%02X" CHC_DEFAULT " bytes" CHC_ARG_SEP ")", nStackOffset & 0xFF ); // Case 2

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -2369,9 +2369,9 @@ Update_t CmdStepOver (int nArgs)
 				   1      Yes             Yes            INFO          O             regs.sp = 0x1F2   R PC FCB3
 				   2      Yes             No             WARN         +1             regs.sp = 0x1F1   R S  F1
 				*/
-				/**/ if (nStackOffset <  0) ConsolePrintFormat( CHC_ERROR   "ERROR" CHC_ARG_SEP ":" CHC_ERROR   " Didn't step over JSR! " CHC_ARG_SEP "(" CHC_DEFAULT "RTS address not found!"                                                                          CHC_ARG_SEP ")"                      ); // Case 0
-				else if (nStackOffset == 0) ConsolePrintFormat( CHC_INFO    "INFO"  CHC_ARG_SEP ":" CHC_INFO    " Didn't step over JSR! " CHC_ARG_SEP "(" CHC_DEFAULT "RTS on top of stack."                                                                            CHC_ARG_SEP ")"                      ); // Case 1
-				else /*                  */ ConsolePrintFormat( CHC_WARNING "WARN"  CHC_ARG_SEP ":" CHC_WARNING " Didn't step over JSR! " CHC_ARG_SEP "(" CHC_DEFAULT "Stack has RTS address but needs fixup: " CHC_ARG_SEP "$" CHC_NUM_HEX "%02X" CHC_DEFAULT " bytes" CHC_ARG_SEP ")", nStackOffset & 0xFF ); // Case 2
+				/**/ if (nStackOffset <  0) ConsolePrintFormat( CHC_ERROR   "ERROR" CHC_ARG_SEP ":" CHC_ERROR   " Didn't step over JSR! " CHC_ARG_SEP "(" CHC_DEFAULT "RTS "           CHC_ARG_SEP "$" CHC_ADDRESS "%04X" CHC_DEFAULT " not found!"                                                                CHC_ARG_SEP ")", nExpectedAddr                      ); // Case 0
+				else if (nStackOffset == 0) ConsolePrintFormat( CHC_INFO    "INFO"  CHC_ARG_SEP ":" CHC_INFO    " Didn't step over JSR! " CHC_ARG_SEP "(" CHC_DEFAULT "RTS "           CHC_ARG_SEP "$" CHC_ADDRESS "%04X" CHC_DEFAULT " on top of stack."                                                          CHC_ARG_SEP ")", nExpectedAddr                      ); // Case 1
+				else /*                  */ ConsolePrintFormat( CHC_WARNING "WARN"  CHC_ARG_SEP ":" CHC_WARNING " Didn't step over JSR! " CHC_ARG_SEP "(" CHC_DEFAULT "Stack has RTS " CHC_ARG_SEP "$" CHC_ADDRESS "%04X" CHC_DEFAULT " but needs fixup: " CHC_ARG_SEP "$" CHC_NUM_HEX "%02X" CHC_DEFAULT " bytes" CHC_ARG_SEP ")", nExpectedAddr, nStackOffset & 0xFF ); // Case 2
 
 				ConsolePrintFormat( CHC_DEFAULT "  Please report '" CHC_SYMBOL "nMaxSteps" CHC_ARG_SEP " = " CHC_DEFAULT "0x" CHC_NUM_HEX "%04X" CHC_DEFAULT "' to:", nMaxSteps );
 				ConsolePrintFormat( CHC_PATH    "  https://github.com/AppleWin/AppleWin/issues/1194"               );

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -2336,8 +2336,8 @@ Update_t CmdStepOver (int nArgs)
 			// If the PC isn't at the expected address after the JSR print a diagnostic so the user knows the stack may be buggered up
 			if (regs.pc != nExpectedAddr)
 			{
-				WORD nActualAddr;
-				bool bValidAddr   = _6502_GetStackReturnAddress( nActualAddr ) && (nActualAddr == nExpectedAddr);
+				WORD nActualAddr  = _6502_GetStackReturnAddress();
+				bool bValidAddr   = (nActualAddr == nExpectedAddr);
 				int  nStackOffset = _6502_FindStackReturnAddress( nExpectedAddr ); // Trace stack to seee if our expected address is on it
 
 				/*
@@ -2388,13 +2388,11 @@ Update_t CmdStepOut (int nArgs)
 {
 	// TODO: "RET" should probably pop the Call stack
 	// Also see: CmdCursorJumpRetAddr
-	WORD nAddress;
-	if (_6502_GetStackReturnAddress( nAddress, true ))
-	{
-		nArgs = _Arg_1( nAddress );
-		g_aArgs[1].sArg[0] = 0;
-		CmdGo( 1, true );
-	}
+	WORD nAddress = _6502_GetStackReturnAddress();
+
+	nArgs = _Arg_1( nAddress );
+	g_aArgs[1].sArg[0] = 0;
+	CmdGo( 1, true );
 
 	return UPDATE_ALL;
 }
@@ -3367,22 +3365,19 @@ Update_t CmdCursorJumpPC (int nArgs)
 //===========================================================================
 Update_t CmdCursorJumpRetAddr (int nArgs)
 {
-	WORD nAddress = 0;
-	if (_6502_GetStackReturnAddress( nAddress ))
-	{	
-		g_nDisasmCurAddress = nAddress;
+	WORD nAddress = _6502_GetStackReturnAddress();
+	g_nDisasmCurAddress = nAddress;
 
-		if (CURSOR_ALIGN_CENTER == nArgs)
-		{
-			WindowUpdateDisasmSize();
-		}
-		else
-		if (CURSOR_ALIGN_TOP == nArgs)
-		{
-			g_nDisasmCurLine = 0;
-		}
-		DisasmCalcTopBotAddress();
+	if (CURSOR_ALIGN_CENTER == nArgs)
+	{
+		WindowUpdateDisasmSize();
 	}
+	else
+	if (CURSOR_ALIGN_TOP == nArgs)
+	{
+		g_nDisasmCurLine = 0;
+	}
+	DisasmCalcTopBotAddress();
 
 	return UPDATE_ALL;
 }

--- a/source/Debugger/Debugger_Assembler.cpp
+++ b/source/Debugger/Debugger_Assembler.cpp
@@ -468,7 +468,11 @@ WORD _6502_GetStackReturnAddress ()
 	return nAddress;
 }
 
-// NOTE: nStack is both an input and output
+// NOTES: nStack is both an input and output;
+//        If nStack is 0x1FF it WILL return overflow 0x200.  Current callers are:
+//          _6502_FindStackReturnAddress(), and
+//          _6502_GetStackReturnAddress()
+//       which DON'T return this overflow stack value to previous callers.
 //===========================================================================
 WORD _6502_PeekStackReturnAddress (WORD & nStack)
 {

--- a/source/Debugger/Debugger_Assembler.cpp
+++ b/source/Debugger/Debugger_Assembler.cpp
@@ -464,11 +464,12 @@ bool _6502_CalcRelativeOffset ( int nOpcode, int nBaseAddress, int nTargetAddres
 	return false;
 }
 
-// Return stack offset if the address is on stack, else 0 if not found
+// Return stack offset if the address is on stack, else -1 if not found
 //===========================================================================
 int _6502_FindStackReturnAddress (const WORD & nAddress)
 {
 	WORD nStack = regs.sp;
+	int  nDepth = -1; // not found
 	nStack++;
 
 	while (nStack <= (_6502_STACK_END - 1))
@@ -480,10 +481,13 @@ int _6502_FindStackReturnAddress (const WORD & nAddress)
 		nReturnAddress++;
 
 		if (nReturnAddress == nAddress)
-			return (nStack-1 - regs.sp);
+		{
+			nDepth = (nStack - 2 - regs.sp);
+			return nDepth;
+		}
 	}
 
-	return 0; // not found
+	return nDepth;
 }
 
 //===========================================================================

--- a/source/Debugger/Debugger_Assembler.cpp
+++ b/source/Debugger/Debugger_Assembler.cpp
@@ -464,6 +464,27 @@ bool _6502_CalcRelativeOffset ( int nOpcode, int nBaseAddress, int nTargetAddres
 	return false;
 }
 
+// Return stack offset if the address is on stack, else 0 if not found
+//===========================================================================
+int _6502_FindStackReturnAddress (const WORD & nAddress)
+{
+	unsigned nStack = regs.sp;
+	nStack++;
+
+	while (nStack <= (_6502_STACK_END - 1))
+	{
+		WORD nReturnAddress = (unsigned)*(LPBYTE)(mem + nStack);
+		nStack++;
+
+		nReturnAddress += ((unsigned)*(LPBYTE)(mem + nStack)) << 8;
+		nReturnAddress++;
+
+		if (nReturnAddress ==nAddress)
+			return (nStack-1 - regs.sp);
+	}
+
+	return 0; // not found
+}
 
 //===========================================================================
 int  _6502_GetOpmodeOpbyte ( const int nBaseAddress, int & iOpmode_, int & nOpbyte_, const DisasmData_t** pData_ )

--- a/source/Debugger/Debugger_Assembler.cpp
+++ b/source/Debugger/Debugger_Assembler.cpp
@@ -468,7 +468,7 @@ bool _6502_CalcRelativeOffset ( int nOpcode, int nBaseAddress, int nTargetAddres
 //===========================================================================
 int _6502_FindStackReturnAddress (const WORD & nAddress)
 {
-	unsigned nStack = regs.sp;
+	WORD nStack = regs.sp;
 	nStack++;
 
 	while (nStack <= (_6502_STACK_END - 1))

--- a/source/Debugger/Debugger_Assembler.cpp
+++ b/source/Debugger/Debugger_Assembler.cpp
@@ -479,7 +479,7 @@ int _6502_FindStackReturnAddress (const WORD & nAddress)
 		nReturnAddress += ((unsigned)*(LPBYTE)(mem + nStack)) << 8;
 		nReturnAddress++;
 
-		if (nReturnAddress ==nAddress)
+		if (nReturnAddress == nAddress)
 			return (nStack-1 - regs.sp);
 	}
 

--- a/source/Debugger/Debugger_Assembler.cpp
+++ b/source/Debugger/Debugger_Assembler.cpp
@@ -426,8 +426,60 @@ Fx	BEQ r  SBC (d),Y  sbc (z)  ---  ---      SBC d,X  INC z,X  ---  SED  SBC a,Y 
 	void AssemblerHashOpcodes ();
 	void AssemblerHashDirectives ();
 
-// Implementation ___________________________________________________________
+// Utility __________________________________________________________________
 
+// === Stack ===
+
+// Return stack offset if the address is on the stack, else -1 if not found
+//===========================================================================
+int _6502_FindStackReturnAddress (const WORD nAddress)
+{
+	WORD nReturnAddress;
+	WORD nStack = regs.sp + 1;
+	int  nDepth = -1; // not found
+
+	// Normally would <= _6502_STACK_END-1 since JSR always pushes 2 bytes
+	// but the SP could be $00 before JSR forcing RTS address to be split $100/$1FF
+	// or  the SP could be $01 before JSR forcing RTS address to be at    $100/$101
+	//    R PC 300
+	//    R S 0
+	//    300:20 04 03 60 60
+	//    <Ctrl-Space>
+	while (nStack <= (_6502_STACK_END + 1))
+	{
+		nReturnAddress = _6502_PeekStackReturnAddress(nStack);
+
+		if (nReturnAddress == nAddress)
+		{
+			nDepth = (nStack - 2 - regs.sp);
+			return nDepth;
+		}
+	}
+
+	return nDepth;
+}
+
+// NOTE: If the stack pointer is <= 01 before a JSR the stack will wrap around.
+//===========================================================================
+WORD _6502_GetStackReturnAddress ()
+{
+	WORD nStack = regs.sp + 1;
+	WORD nAddress = _6502_PeekStackReturnAddress(nStack);
+	return nAddress;
+}
+
+// NOTE: nStack is both an input and output
+//===========================================================================
+WORD _6502_PeekStackReturnAddress (WORD & nStack)
+{
+	WORD   nAddress;
+	       nAddress  = ((unsigned) *(LPBYTE)(mem + 0x100 + (nStack & 0xFF))     ); nStack++;
+	       nAddress += ((unsigned) *(LPBYTE)(mem + 0x100 + (nStack & 0xFF)) << 8);
+	       nAddress++;
+	return nAddress;
+}
+
+// == Opcodes ===
 
 //===========================================================================
 bool _6502_CalcRelativeOffset ( int nOpcode, int nBaseAddress, int nTargetAddress, WORD * pTargetOffset_ )
@@ -462,32 +514,6 @@ bool _6502_CalcRelativeOffset ( int nOpcode, int nBaseAddress, int nTargetAddres
 	}
 
 	return false;
-}
-
-// Return stack offset if the address is on stack, else -1 if not found
-//===========================================================================
-int _6502_FindStackReturnAddress (const WORD & nAddress)
-{
-	WORD nStack = regs.sp;
-	int  nDepth = -1; // not found
-	nStack++;
-
-	while (nStack <= (_6502_STACK_END - 1))
-	{
-		WORD nReturnAddress = (unsigned)*(LPBYTE)(mem + nStack);
-		nStack++;
-
-		nReturnAddress += ((unsigned)*(LPBYTE)(mem + nStack)) << 8;
-		nReturnAddress++;
-
-		if (nReturnAddress == nAddress)
-		{
-			nDepth = (nStack - 2 - regs.sp);
-			return nDepth;
-		}
-	}
-
-	return nDepth;
 }
 
 //===========================================================================
@@ -590,27 +616,6 @@ void _6502_GetOpcodeOpmodeOpbyte (int & iOpcode_, int & iOpmode_, int & nOpbyte_
 {
 	iOpcode_ = _6502_GetOpmodeOpbyte( regs.pc, iOpmode_, nOpbyte_ );
 }
-
-// NOTE: If the stack pointer is <= 01 before a JSR the stack will wrap around.
-// Use bWrapAround to access stack memory in this case.
-//===========================================================================
-bool _6502_GetStackReturnAddress (WORD & nAddress_, bool bWrapAround /* = false */)
-{
-	unsigned nStack = regs.sp;
-	nStack++;
-
-	if (bWrapAround || nStack <= (_6502_STACK_END - 1)) // JSR always pushes 2 bytes.  If no wrap around then the stack pointer must be <= 0x1FE
-	{
-		nAddress_ = (unsigned)*(LPBYTE)(mem + 0x100 + (nStack & 0xFF));
-		nStack++;
-		
-		nAddress_ += ((unsigned)*(LPBYTE)(mem + 0x100 + (nStack & 0xFF))) << 8;
-		nAddress_++;
-		return true;
-	}
-	return false;
-}
-
 
 //===========================================================================
 bool _6502_GetTargets (WORD nAddress, int *pTargetPartial_, int *pTargetPartial2_, int *pTargetPointer_, int * pTargetBytes_,

--- a/source/Debugger/Debugger_Assembler.h
+++ b/source/Debugger/Debugger_Assembler.h
@@ -194,7 +194,7 @@ extern	int g_aAssemblerFirstDirective[ NUM_ASSEMBLERS ];
 	int  _6502_FindStackReturnAddress (const WORD & nAddress);
 	int  _6502_GetOpmodeOpbyte( const int iAddress, int & iOpmode_, int & nOpbytes_, const DisasmData_t** pData = NULL );
 	void _6502_GetOpcodeOpmodeOpbyte( int & iOpcode_, int & iOpmode_, int & nOpbytes_ );
-	bool _6502_GetStackReturnAddress( WORD & nAddress_ );
+	bool _6502_GetStackReturnAddress (WORD & nAddress_, bool bWrapAround = false);
 	bool _6502_GetTargets( WORD nAddress, int *pTargetPartial_, int *pTargetPartial2_, int *pTargetPointer_, int * pBytes_,
 						   bool bIgnoreBranch = true, bool bIncludeNextOpcodeAddress = true );
 	bool _6502_GetTargetAddress( const WORD & nAddress, WORD & nTarget_ );

--- a/source/Debugger/Debugger_Assembler.h
+++ b/source/Debugger/Debugger_Assembler.h
@@ -191,16 +191,21 @@ extern	int g_aAssemblerFirstDirective[ NUM_ASSEMBLERS ];
 
 // Prototypes _______________________________________________________________
 
-	int  _6502_FindStackReturnAddress (const WORD & nAddress);
+	// Stack
+	int  _6502_FindStackReturnAddress (const WORD nAddress);
+	WORD _6502_GetStackReturnAddress ();
+	WORD _6502_PeekStackReturnAddress (WORD & nStack);
+
+	// Opcodes
 	int  _6502_GetOpmodeOpbyte( const int iAddress, int & iOpmode_, int & nOpbytes_, const DisasmData_t** pData = NULL );
 	void _6502_GetOpcodeOpmodeOpbyte( int & iOpcode_, int & iOpmode_, int & nOpbytes_ );
-	bool _6502_GetStackReturnAddress (WORD & nAddress_, bool bWrapAround = false);
 	bool _6502_GetTargets( WORD nAddress, int *pTargetPartial_, int *pTargetPartial2_, int *pTargetPointer_, int * pBytes_,
 						   bool bIgnoreBranch = true, bool bIncludeNextOpcodeAddress = true );
 	bool _6502_GetTargetAddress( const WORD & nAddress, WORD & nTarget_ );
 	bool _6502_IsOpcodeBranch( int nOpcode );
 	bool _6502_IsOpcodeValid( int nOpcode );
 
+	// Assembler
 	Hash_t  AssemblerHashMnemonic ( const TCHAR * pMnemonic );
 //	bool AssemblerGetAddressingMode ( int iArg, int nArgs, WORD nAddress, std::vector<int> & vOpcodes );
 	void _CmdAssembleHashDump ();

--- a/source/Debugger/Debugger_Assembler.h
+++ b/source/Debugger/Debugger_Assembler.h
@@ -191,6 +191,7 @@ extern	int g_aAssemblerFirstDirective[ NUM_ASSEMBLERS ];
 
 // Prototypes _______________________________________________________________
 
+	int  _6502_FindStackReturnAddress (const WORD & nAddress);
 	int  _6502_GetOpmodeOpbyte( const int iAddress, int & iOpmode_, int & nOpbytes_, const DisasmData_t** pData = NULL );
 	void _6502_GetOpcodeOpmodeOpbyte( int & iOpcode_, int & iOpmode_, int & nOpbytes_ );
 	bool _6502_GetStackReturnAddress( WORD & nAddress_ );


### PR DESCRIPTION
New behavior showing the stack on failure/success. Detect stack state on failure after `JSR` (3 possible states).

1. Failure: RTS address on stack sans extra junk
![2_step_over_0x1f2](https://user-images.githubusercontent.com/7876796/227807995-d24beadc-3086-4360-8024-16c8dccdb483.png)

2. Failure: RTS address on stack with extra junk
![1_step_over_0x1f1](https://user-images.githubusercontent.com/7876796/227807973-90fb3a8a-ee55-448b-80d0-6dffa3e99a34.png)

3. Failure: RTS address not found on stack (!)
![3_step_over_0x1f3](https://user-images.githubusercontent.com/7876796/227808049-771c46c0-b1d4-499e-b977-c03c143bbc15.png)

4. Successful step over, like 2, but with increased max execution steps.
![4_step_over](https://user-images.githubusercontent.com/7876796/227808065-14c72dfa-7502-4768-a980-8f590b779198.png)

