### PR TITLE
Update BMP import from GIMP 2.10 with X8 R8 G8 B8

### DIFF
--- a/docs/Debugger_Changelog.txt
+++ b/docs/Debugger_Changelog.txt
@@ -1,4 +1,16 @@
 /*
+2.9.1.18 Fixed: NTSC LOAD was failing to import BMPs exported from GIMP.
+    To export a 64x256 bitmap from GIMP:
+      1. File, Export As...
+      2. Use a file extension of .bmp
+      3. Export Image as BMP
+         Compatibility Options
+           [x] Do not write color space information
+         Advanced Options
+           32 Bits
+             (x) X8 R8 G8 B8
+    In the debugger load your .bmp file:
+      NTSC LOAD palette.bmp
 2.9.1.17 Fixed: Ctrl-Space failing to step over a long sub-routine (and wasn't providing any feedback on why it failed.) GH #1194
     Increased the max steps to 0xFFFFF (from 0xFFFF)
     If step-over succeeds the debugger's feedback is:

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -53,7 +53,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #define MAKE_VERSION(a,b,c,d) ((a<<24) | (b<<16) | (c<<8) | (d))
 
 	// See /docs/Debugger_Changelog.txt for full details
-	const int DEBUGGER_VERSION = MAKE_VERSION(2,9,1,17);
+	const int DEBUGGER_VERSION = MAKE_VERSION(2,9,1,18);
 
 
 // Public _________________________________________________________________________________________
@@ -5542,6 +5542,10 @@ Update_t CmdNTSC (int nArgs)
 							&&  (bmp.nGreenMask == 0x00FF0000 )
 							&&  (bmp.nBlueMask  == 0x0000FF00 ))
 								bSwizzle = true;
+							if ((bmp.nRedMask   == 0x00FF0000 ) // Gimp 32 Bits, X8 R8 G8 B8
+							&&  (bmp.nGreenMask == 0x0000FF00 )
+							&&  (bmp.nBlueMask  == 0x000000FF ))
+								bSwizzle = false;
 						}
 					}
 				}


### PR DESCRIPTION
This patch makes the debugger `NTSC LOAD` properly import Windows BMP files exported from GIMP again.   (Found while investigating issue #357 and re-verifying the NTSC palette loading in post 1.26.)

# Technical Details

Apparently GIMP changed the way they save BMPs now.

There are multiple version of a Windows BMP file.

Struct Size 

* 0x28 version 3 (and prior?)
* 0x38 version 4 which has Red, Green, and Blue channel masks. (Wish hardware and graphics people would just pick ONE bloody RGBA standard for once but I digress...)

The original `.bmp` files `Default_NTSC_Palette.bmp`, `White_NTSC_Palette.bmp`, `Black_NTSC_Palette.bmp`, `Tweaked_Palette.bmp` on my page http://michael.peopleofhonoronly.com/dev/applewin/ntsc/ have different Red, Green, Blue masks.  Re-exporting them as `.bmp` will cause the debugger to fail to load these due to GIMP 2.10 changing the Red, Green, Blue masks which was causing an incorrect swizzling.
