### PR TITLE
1204 debugger long input crash

### DIFF
--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -7154,6 +7154,9 @@ void WindowUpdateConsoleDisplayedSize ()
 		g_nConsoleDisplayWidth = CONSOLE_WIDTH - 1;
 		g_bConsoleFullWidth = true;
 	}
+
+	g_nConsoleInputMaxLen      = g_nConsoleDisplayWidth-1; // -1 prompt at SOL, -1 for cursor at EOL
+	g_nConsoleInputScrollWidth = g_nConsoleDisplayWidth-1; // Maximum number of characters for the horizontol scrolling window on the input line
 #else
 	g_nConsoleDisplayWidth = (CONSOLE_WIDTH / 2) + 10;
 	g_bConsoleFullWidth = false;

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -7155,7 +7155,7 @@ void WindowUpdateConsoleDisplayedSize ()
 		g_bConsoleFullWidth = true;
 	}
 
-	g_nConsoleInputMaxLen      = g_nConsoleDisplayWidth-1; // -1 prompt at SOL, -1 for cursor at EOL
+	g_nConsoleInputMaxLen      = g_nConsoleDisplayWidth-1; // -1 prompt at Start-of-Line, -1 for cursor at End-of-Line
 	g_nConsoleInputScrollWidth = g_nConsoleDisplayWidth-1; // Maximum number of characters for the horizontol scrolling window on the input line
 #else
 	g_nConsoleDisplayWidth = (CONSOLE_WIDTH / 2) + 10;

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -9043,7 +9043,7 @@ void DebuggerInputConsoleChar ( TCHAR ch )
 			return;
 	}
 	
-	if (g_nConsoleInputChars > (g_nConsoleDisplayWidth-1))
+	if (g_nConsoleInputChars > g_nConsoleInputMaxLen)
 		return;
 
 	if ((ch >= CHAR_SPACE) && (ch <= 126)) // HACK MAGIC # 32 -> ' ', # 126 

--- a/source/Debugger/Debugger_Console.cpp
+++ b/source/Debugger/Debugger_Console.cpp
@@ -354,7 +354,7 @@ void ConsoleConvertFromText ( conchar_t * sText, const char * pText )
 //===========================================================================
 Update_t ConsoleDisplayError ( const char * pText )
 {
-	ConsoleBufferPush( pText );
+	ConsolePrintFormat( CHC_ERROR "%s", pText );
 	return ConsoleUpdate();
 }
 

--- a/source/Debugger/Debugger_Console.cpp
+++ b/source/Debugger/Debugger_Console.cpp
@@ -461,7 +461,8 @@ bool ConsoleInputClear ()
 //===========================================================================
 bool ConsoleInputChar ( char ch )
 {
-	if (g_nConsoleInputChars < g_nConsoleDisplayWidth) // bug? include prompt?
+	if (g_nConsoleInputChars < (g_nConsoleDisplayWidth-1)) // GH #1204 Need to count the space at EOL for the cursor
+
 	{
 		g_pConsoleInput[ g_nConsoleInputChars ] = ch;
 		g_nConsoleInputChars++;

--- a/source/Debugger/Debugger_Console.cpp
+++ b/source/Debugger/Debugger_Console.cpp
@@ -80,11 +80,13 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 		char g_aConsoleInput[ CONSOLE_WIDTH ]; // = g_aConsoleDisplay[0];
 
 		// Cooked input line (no prompt)
-		int          g_nConsoleInputChars  = 0;
-		      char * g_pConsoleInput       = 0; // points to past prompt
-		const char * g_pConsoleFirstArg    = 0; // points to first arg
-		bool         g_bConsoleInputQuoted = false; // Allows lower-case to be entered
-		char         g_nConsoleInputSkip   = '~';
+		      int    g_nConsoleInputChars       = 0;
+		      char * g_pConsoleInput            = 0; // points to past prompt
+		      int    g_nConsoleInputMaxLen      = 0;
+		      int    g_nConsoleInputScrollWidth = 0;
+		const char * g_pConsoleFirstArg         = 0; // points to first arg
+		      bool   g_bConsoleInputQuoted      = false; // Allows lower-case to be entered
+		      char   g_nConsoleInputSkip        = '~';
 
 // Prototypes _______________________________________________________________
 

--- a/source/Debugger/Debugger_Console.cpp
+++ b/source/Debugger/Debugger_Console.cpp
@@ -430,7 +430,7 @@ bool ConsoleInputBackSpace ()
 {
 	if (g_nConsoleInputChars)
 	{
-		g_pConsoleInput[ g_nConsoleInputChars ] = CHAR_SPACE;
+		g_pConsoleInput[ g_nConsoleInputChars ] = 0;
 
 		g_nConsoleInputChars--;
 

--- a/source/Debugger/Debugger_Console.cpp
+++ b/source/Debugger/Debugger_Console.cpp
@@ -463,8 +463,7 @@ bool ConsoleInputClear ()
 //===========================================================================
 bool ConsoleInputChar ( char ch )
 {
-	if (g_nConsoleInputChars < (g_nConsoleDisplayWidth-1)) // GH #1204 Need to count the space at EOL for the cursor
-
+	if (g_nConsoleInputChars < g_nConsoleInputMaxLen) // GH #1204 Need to count the space at EOL for the cursor
 	{
 		g_pConsoleInput[ g_nConsoleInputChars ] = ch;
 		g_nConsoleInputChars++;

--- a/source/Debugger/Debugger_Console.h
+++ b/source/Debugger/Debugger_Console.h
@@ -245,11 +245,12 @@
 		extern char g_aConsoleInput[ CONSOLE_WIDTH ];
 
 		// Cooked input line (no prompt)
-		extern int          g_nConsoleInputChars  ;
-		extern       char * g_pConsoleInput       ; // points to past prompt
-		extern const char * g_pConsoleFirstArg    ; // points to first arg
-		extern bool         g_bConsoleInputQuoted ;
-
+		extern       int    g_nConsoleInputChars      ;
+		extern       char * g_pConsoleInput           ; // points to past prompt
+		extern       int    g_nConsoleInputMaxLen     ; // = g_nConsoleDisplayWidth-1 = 78 // Maximum number of characters allowed on input line
+		extern       int    g_nConsoleInputScrollWidth; // = g_nConsoleDisplayWidth-1 = 78 // Maximum number of characters for the horizontol scrolling window on the input line
+		extern const char * g_pConsoleFirstArg        ; // points to first arg
+		extern       bool   g_bConsoleInputQuoted     ;
 		extern char         g_nConsoleInputSkip   ;
 
 

--- a/source/Debugger/Debugger_Display.cpp
+++ b/source/Debugger/Debugger_Display.cpp
@@ -1310,13 +1310,13 @@ void DrawConsoleInput ()
 		//  [--------]       g_nConsoleInputScrollWidth = 10
 		// >6789ABCDEF_      g_nConsoleInputMaxLen      = 16
 		static char aScrollingInput[ CONSOLE_WIDTH+1 ];
-		aScrollingInput[0] = g_aConsoleInput[0];                                           // 1. SOL
+		aScrollingInput[0] = g_aConsoleInput[0];                                           // 1. Start-of-Line
 
 		const int nInputOffset =      g_nConsoleInputChars - g_nConsoleInputScrollWidth  ; // 2. Middle
 		const int nInputWidth  = min( g_nConsoleInputChars,  g_nConsoleInputScrollWidth ); // NOTE: Keep in Sync! DrawConsoleInput() and DrawConsoleCursor()
 		strncpy( aScrollingInput+1, g_aConsoleInput + 1 + nInputOffset, nInputWidth );     // +1 to skip prompt
 
-		aScrollingInput[ g_nConsoleInputScrollWidth+1 ] = 0;                               // 3. EOL leave room for cursor
+		aScrollingInput[ g_nConsoleInputScrollWidth+1 ] = 0;                               // 3. End-of-Line leave room for cursor
 
 		PrintText( aScrollingInput, rect );
 	}


### PR DESCRIPTION
Included in this PR:

1. Clamp long input line in the debugger
2. Fix backspace showing garbage on the input line when the input line is max characters (78)
3. Add preliminary support for for scrolling a long input line when enabled
4. Colorize the `Illegal Command`

To fully enable a long input line more minor work needs to be done (`ConsoleDisplayPush( ConsoleInputPeek() );` to auto-wrap long lines) but this gets us mostly there.

See #1204 for analysis.