### PR TITLE
Mockingboard: do not play sound unless a card is present.

### DIFF
--- a/source/MockingboardCardManager.cpp
+++ b/source/MockingboardCardManager.cpp
@@ -220,13 +220,17 @@ void MockingboardCardManager::Update(const ULONG executedCycles)
 	// NB. CardManager has just called each card's Update()
 
 	bool active = false;
+	bool present = false;
 	for (UINT i = SLOT0; i < NUM_SLOTS; i++)
 	{
 		if (IsMockingboard(i))
+		{
 			active |= dynamic_cast<MockingboardCard&>(GetCardMgr().GetRef(i)).IsAnyTimer1Active();
+			present = true;
+		}
 	}
 
-	if (active)
+	if (!present || active)
 		return;
 
 	// No 6522 TIMER1's are active, so periodically update AY8913's here...


### PR DESCRIPTION
This change improves

1. save some CPU cycles if no card is present
2. help debugging IDirectSoundBuffer underruns

The are NO underruns, but with this patch, when the read pointer overtakes the write point, it is a real underrun.