### PR TITLE
Avoid a potential memory leak if RamWorks memory size were configurable.

### DIFF
--- a/source/Memory.cpp
+++ b/source/Memory.cpp
@@ -1296,7 +1296,7 @@ void MemDestroy()
 	delete [] pCxRomPeripheral;
 
 #ifdef RAMWORKS
-	for (UINT i=1; i<g_uMaxExPages; i++)
+	for (UINT i=1; i<kMaxExMemoryBanks; i++)
 	{
 		if (RWpages[i])
 		{


### PR DESCRIPTION
And add an accessor.

This is not an issue in AW, but it happens if one allows to configure RW size.
The check for NULL is enough to detect exactly which ones were allocated.
