### PR TITLE
Fix read of uninitialised values in sound_ay_overlay().

### DIFF
--- a/source/AY8910.cpp
+++ b/source/AY8910.cpp
@@ -121,6 +121,7 @@ void AY8913::init(void)
 
 AY8913::AY8913(void)
 {
+	memset(sound_ay_registers, 0, sizeof(sound_ay_registers));
 	init();
 	m_fCurrentCLK_AY8910 = g_fCurrentCLK6502;
 };


### PR DESCRIPTION
Otherwise when it gets here

https://github.com/AppleWin/AppleWin/blob/771282a79265cfc8a5c1c0a91cc9740e10d54e20/source/AY8910.cpp#L526

the first entry is initialised, but 0 and 1 are needed here

https://github.com/AppleWin/AppleWin/blob/771282a79265cfc8a5c1c0a91cc9740e10d54e20/source/AY8910.cpp#L540-L541
