### PR TITLE
Debugger df qol

### DIFF
--- a/docs/Debugger_Changelog.txt
+++ b/docs/Debugger_Changelog.txt
@@ -1,4 +1,5 @@
 /*
+2.9.1.22 Fixed: `df FAC` was incorrectly getting marked up as `db`
 2.9.1.21 Fixed: `df` showing zero was displaying 0 instead 0.0
 2.9.1.20 Fixed: Changed DISK INFO to have 1 line abbreviation for disk state
 2.9.1.19 Added: QoL to DISK INFO.

--- a/docs/Debugger_Changelog.txt
+++ b/docs/Debugger_Changelog.txt
@@ -1,4 +1,5 @@
 /*
+2.9.1.21 Fixed: `df` showing zero was displaying 0 instead 0.0
 2.9.1.20 Fixed: Changed DISK INFO to have 1 line abbreviation for disk state
 2.9.1.19 Added: QoL to DISK INFO.
     Colorized numbers and status to improve readability.

--- a/docs/Debugger_Changelog.txt
+++ b/docs/Debugger_Changelog.txt
@@ -1,4 +1,5 @@
 /*
+2.9.1.23 Fixed: Show floating-point values in scientific notation.
 2.9.1.22 Fixed: `df FAC` was incorrectly getting marked up as `db`
 2.9.1.21 Fixed: `df` showing zero was displaying 0 instead 0.0
 2.9.1.20 Fixed: Changed DISK INFO to have 1 line abbreviation for disk state

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -53,7 +53,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #define MAKE_VERSION(a,b,c,d) ((a<<24) | (b<<16) | (c<<8) | (d))
 
 	// See /docs/Debugger_Changelog.txt for full details
-	const int DEBUGGER_VERSION = MAKE_VERSION(2,9,1,20);
+	const int DEBUGGER_VERSION = MAKE_VERSION(2,9,1,21);
 
 
 // Public _________________________________________________________________________________________

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -53,7 +53,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #define MAKE_VERSION(a,b,c,d) ((a<<24) | (b<<16) | (c<<8) | (d))
 
 	// See /docs/Debugger_Changelog.txt for full details
-	const int DEBUGGER_VERSION = MAKE_VERSION(2,9,1,21);
+	const int DEBUGGER_VERSION = MAKE_VERSION(2,9,1,22);
 
 
 // Public _________________________________________________________________________________________

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -53,7 +53,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #define MAKE_VERSION(a,b,c,d) ((a<<24) | (b<<16) | (c<<8) | (d))
 
 	// See /docs/Debugger_Changelog.txt for full details
-	const int DEBUGGER_VERSION = MAKE_VERSION(2,9,1,22);
+	const int DEBUGGER_VERSION = MAKE_VERSION(2,9,1,23);
 
 
 // Public _________________________________________________________________________________________

--- a/source/Debugger/Debugger_Assembler.h
+++ b/source/Debugger/Debugger_Assembler.h
@@ -103,7 +103,7 @@
 	// NOTE: Keep in sync!  AsmCustomDirective_e  g_aAssemblerDirectives
 	enum AsmCustomDirective_e
 	{
-		 ASM_DEFINE_BYTE	
+		 ASM_DEFINE_BYTE
 		,ASM_DEFINE_WORD
 //		,ASM_DEFINE_ADDRESS_8
 		,ASM_DEFINE_ADDRESS_16

--- a/source/Debugger/Debugger_Disassembler.cpp
+++ b/source/Debugger/Debugger_Disassembler.cpp
@@ -566,7 +566,7 @@ void FormatNopcodeBytes(WORD nBaseAddress, DisasmLine_t& line_)
 				else
 				{
 					const double f    = fac.mantissa * pow( 2.0, fac.exponent - 32 );
-					//std::string sFac = StrFormat( "s%1X m%04X e%08X", fac.negative, fac.mantissa, fac.exponent );
+					//std::string sFac = StrFormat( "s%1X m%08X e%02X", fac.negative, fac.mantissa, fac.exponent & 0xFF );
 					// 2.9.1.23: Show floating-point values in scientific notation.
 					std::string  sFac = StrFormat( "%c%e", aSign[ fac.negative ], f );
 					if ((pDst + sFac.length()) < pEnd)

--- a/source/Debugger/Debugger_Disassembler.cpp
+++ b/source/Debugger/Debugger_Disassembler.cpp
@@ -567,7 +567,8 @@ void FormatNopcodeBytes(WORD nBaseAddress, DisasmLine_t& line_)
 				{
 					const double f    = fac.mantissa * pow( 2.0, fac.exponent - 32 );
 					//std::string sFac = StrFormat( "s%1X m%04X e%08X", fac.negative, fac.mantissa, fac.exponent );
-					std::string  sFac = StrFormat( "%c%f", aSign[ fac.negative ], f );
+					// 2.9.1.23: Show floating-point values in scientific notation.
+					std::string  sFac = StrFormat( "%c%e", aSign[ fac.negative ], f );
 					if ((pDst + sFac.length()) < pEnd)
 					{
 						memcpy(pDst, sFac.c_str(), sFac.length());

--- a/source/Debugger/Debugger_Disassembler.cpp
+++ b/source/Debugger/Debugger_Disassembler.cpp
@@ -553,8 +553,15 @@ void FormatNopcodeBytes(WORD nBaseAddress, DisasmLine_t& line_)
 				const char aSign[2] = { '+', '-' };
 				if (fac.isZero)
 				{
-					if ((pDst + 1) < pEnd)
-						*pDst++ = '0';
+					// 2.9.1.21 Fixed: `df` showing zero was displaying 0 instead 0.0
+					// Format 0.0 so users know this is a floating point value
+					std::string sFac( "0.0" );
+					if ((pDst + 3) < pEnd)
+					{
+						memcpy(pDst, sFac.c_str(), sFac.length());
+						pDst += sFac.length();
+					}
+					// No room???
 				}
 				else
 				{

--- a/source/Debugger/Debugger_Disassembler.cpp
+++ b/source/Debugger/Debugger_Disassembler.cpp
@@ -566,7 +566,7 @@ void FormatNopcodeBytes(WORD nBaseAddress, DisasmLine_t& line_)
 				else
 				{
 					const double f    = fac.mantissa * pow( 2.0, fac.exponent - 32 );
-					//std::string sFac = StrFormat( "s%1X m%04X e%02X", fac.negative, fac.mantissa, fac.exponent );
+					//std::string sFac = StrFormat( "s%1X m%04X e%08X", fac.negative, fac.mantissa, fac.exponent );
 					std::string  sFac = StrFormat( "%c%f", aSign[ fac.negative ], f );
 					if ((pDst + sFac.length()) < pEnd)
 					{

--- a/source/Debugger/Debugger_DisassemblerData.cpp
+++ b/source/Debugger/Debugger_DisassemblerData.cpp
@@ -391,8 +391,13 @@ Update_t _CmdDisasmDataDefByteX (int nArgs)
 	WORD nAddress = _CmdDefineByteRange( nArgs, iArg, tData );
 
 	// TODO: Allow user to select which assembler to use for displaying directives!
-//	tData.iDirective = FIRST_M_DIRECTIVE + ASM_M_DEFINE_BYTE;
 	tData.iDirective = g_aAssemblerFirstDirective[ g_iAssemblerSyntax ] + ASM_DEFINE_BYTE;
+
+	// 2.9.1.22 Fixed: `df FAC` was incorrectly getting marked up as `db`
+	if (g_aArgs[0].nValue == NOP_FAC)
+	{
+		tData.iDirective = g_aAssemblerFirstDirective[ g_iAssemblerSyntax ] + ASM_DEFINE_FLOAT;
+	}
 
 	tData.eElementType = (Nopcode_e)( NOP_BYTE_1 + iCmd );
 	tData.bSymbolLookup = false;
@@ -552,6 +557,18 @@ Update_t CmdDisasmDataDefByte8 ( int nArgs )
 // Command: DF
 // Usage:
 //     DF <addr>
+// Applesoft has several floating-point constants in ROM.
+// i.e.
+//     300:A0 E9     LDY #>$E932
+//     302:A9 32     LDA #<$E932
+//     304:20 F9 EA  JSR LOAD.FAC.FROM.YA
+//     307:4C 2E ED  JMP PRINT.FAC
+//
+// Addr  Symbol         FAC         Value     
+// E913  CON.ONE        8100000000  1.0       
+// E92D  CON.SQR.HALF   803504F334  .707106781
+// E932  CON.SQR.TWO    813504F334  1.41421356
+// etc.
 Update_t CmdDisasmDataDefFloat(int nArgs)
 {
 	g_aArgs[0].nValue = NOP_FAC;

--- a/source/Debugger/Debugger_DisassemblerData.cpp
+++ b/source/Debugger/Debugger_DisassemblerData.cpp
@@ -362,7 +362,6 @@ Update_t CmdDisasmDataList (int nArgs)
 
 // TODO: merge _CmdDisasmDataDefByteX() and _CmdDisasmDataDefWordX
 //       add params( iDirective, iOpcode ) to allow ASM_DEFINE_FLOAT, NOP_FAC
-
 //===========================================================================
 Update_t _CmdDisasmDataDefByteX (int nArgs)
 {
@@ -382,9 +381,9 @@ Update_t _CmdDisasmDataDefByteX (int nArgs)
 	DisasmData_t tData;
 	int iArg = 2;
 
-	if (nArgs == 3 ) // 2.7.0.31 Bug fix: DB range, i.e. DB 174E:175F
+	if (nArgs == 3) // 2.7.0.31 Bug fix: DB range, i.e. DB 174E:175F
 	{
-		if ( g_aArgs[ 2 ].eToken == TOKEN_COLON )
+		if (g_aArgs[ 2 ].eToken == TOKEN_COLON)
 			iArg = 1;
 	}
 


### PR DESCRIPTION
@tomcw Some small Quality of Life for the debugger `df` command.

Before:
![before](https://github.com/AppleWin/AppleWin/assets/7876796/1f6b15d7-38df-4d2c-acf4-49daba0bfc36)


After:
![after](https://github.com/AppleWin/AppleWin/assets/7876796/b8a6f610-2a17-4e88-b069-2530ac70d4d1)
