### PR TITLE
Allow alternate directory for built-in symbols

### DIFF
--- a/source/Core.cpp
+++ b/source/Core.cpp
@@ -61,6 +61,7 @@ AppMode_e	g_nAppMode = MODE_LOGO;
 std::string g_sStartDir;	// NB. AppleWin.exe maybe relative to this! (GH#663)
 std::string g_sProgramDir;	// Directory of where AppleWin executable resides
 std::string g_sCurrentDir;	// Also Starting Dir.  Debugger uses this when load/save
+std::string g_sBuiltinSymbolsDir; // Alternate directory for built-in debug symbols
 
 bool      g_bRestart = false;
 

--- a/source/Core.h
+++ b/source/Core.h
@@ -38,6 +38,7 @@ extern AppMode_e g_nAppMode;
 extern std::string g_sStartDir;
 extern std::string g_sProgramDir;
 extern std::string g_sCurrentDir;
+extern std::string g_sBuiltinSymbolsDir;
 
 bool SetCurrentImageDir(const std::string& pszImageDir);
 

--- a/source/Debugger/Debugger_Symbols.cpp
+++ b/source/Debugger/Debugger_Symbols.cpp
@@ -751,13 +751,13 @@ Update_t CmdSymbolsLoad (int nArgs)
 	{
 		sFileName = g_sProgramDir + g_sFileNameSymbols[ iSymbolTable ];
 		nSymbols = ParseSymbolTable( sFileName, (SymbolTable_Index_e) iSymbolTable );
-        
-        // Try optional alternate location
-        if (nSymbols == 0 && !g_sBuiltinSymbolsDir.empty())
-        {
-            sFileName = g_sBuiltinSymbolsDir + g_sFileNameSymbols[ iSymbolTable ];
-            nSymbols = ParseSymbolTable( sFileName, (SymbolTable_Index_e) iSymbolTable );
-        }
+
+		// Try optional alternate location
+		if (nSymbols == 0 && !g_sBuiltinSymbolsDir.empty())
+		{
+			sFileName = g_sBuiltinSymbolsDir + g_sFileNameSymbols[ iSymbolTable ];
+			nSymbols = ParseSymbolTable( sFileName, (SymbolTable_Index_e) iSymbolTable );
+		}
 	}
 
 	int iArg = 1;

--- a/source/Debugger/Debugger_Symbols.cpp
+++ b/source/Debugger/Debugger_Symbols.cpp
@@ -753,7 +753,7 @@ Update_t CmdSymbolsLoad (int nArgs)
 		nSymbols = ParseSymbolTable( sFileName, (SymbolTable_Index_e) iSymbolTable );
 
 		// Try optional alternate location
-		if (nSymbols == 0 && !g_sBuiltinSymbolsDir.empty())
+		if ((nSymbols == 0) && !g_sBuiltinSymbolsDir.empty())
 		{
 			sFileName = g_sBuiltinSymbolsDir + g_sFileNameSymbols[ iSymbolTable ];
 			nSymbols = ParseSymbolTable( sFileName, (SymbolTable_Index_e) iSymbolTable );

--- a/source/Debugger/Debugger_Symbols.cpp
+++ b/source/Debugger/Debugger_Symbols.cpp
@@ -749,8 +749,15 @@ Update_t CmdSymbolsLoad (int nArgs)
 	// Debugger will call us with 0 args on startup as a way to pre-load symbol tables
 	if (! nArgs)
 	{
-		sFileName += g_sFileNameSymbols[ iSymbolTable ];
+		sFileName = g_sProgramDir + g_sFileNameSymbols[ iSymbolTable ];
 		nSymbols = ParseSymbolTable( sFileName, (SymbolTable_Index_e) iSymbolTable );
+        
+        // Try optional alternate location
+        if (nSymbols == 0 && !g_sBuiltinSymbolsDir.empty())
+        {
+            sFileName = g_sBuiltinSymbolsDir + g_sFileNameSymbols[ iSymbolTable ];
+            nSymbols = ParseSymbolTable( sFileName, (SymbolTable_Index_e) iSymbolTable );
+        }
 	}
 
 	int iArg = 1;


### PR DESCRIPTION
needed because macOS apps are a bundle (tree of directories) and resources are packaged somewhere within, not necessarily in the same directory as the executable.

probably doesn't deal with the case of user-supplied symbols, but I haven't gotten that far yet...

https://github.com/sh95014/AppleWin/issues/12