### PR TITLE
remove reference to processor status register

### DIFF
--- a/help/dbg-registers.html
+++ b/help/dbg-registers.html
@@ -16,13 +16,11 @@
 			<li>
 				<p style="MARGIN-BOTTOM: 0in"><b>Y</b>, the 2<sup>nd</sup> Index Register,</p>
 			<li>
-				<p style="MARGIN-BOTTOM: 0in"><b>PC</b>, the Program Counter,
+				<p style="MARGIN-BOTTOM: 0in"><b>PC</b>, the Program Counter, and
 				</p>
 			<li>
-				<p style="MARGIN-BOTTOM: 0in"><b>S</b>, the Stack Pointer, and
+				<p style="MARGIN-BOTTOM: 0in"><b>S</b>, the Stack Pointer.
 				</p>
-			<li>
-				<p><b>P</b>, the Processor Status Register (Flags).</p>
 			</li>
 		</ul>
 		<p>You can set a Register to a hex Value, Symbol, or Expression.&nbsp; (See the 
@@ -100,16 +98,6 @@ S ##</span></b></font></font></p>
 								<td width="75%">
 									<p><i><span style="BACKGROUND: 0% 50%; moz-background-clip: initial; moz-background-origin: initial; moz-background-inline-policy: initial">Set
 Stack Register to (an 8-Bit) Offset</span></i></p>
-								</td>
-							</tr>
-							<tr bgcolor="#cccccc">
-								<td width="25%">
-									<p><font color="#000000"><font face="Courier"><b><span style="BACKGROUND: 0% 50%; moz-background-clip: initial; moz-background-origin: initial; moz-background-inline-policy: initial">R
-P ##</span></b></font></font></p>
-								</td>
-								<td width="75%">
-									<p><i><span style="BACKGROUND: 0% 50%; moz-background-clip: initial; moz-background-origin: initial; moz-background-inline-policy: initial">Set
-Processor Status Register (flags) to (a byte) Value</span></i></p>
 								</td>
 							</tr>
 						</tbody>


### PR DESCRIPTION
The "R P \<xx\>" command doesn't actually work:

```
>r p ff
Category: CPU
R, Set register
 Usage: <reg> <value | expression | symbol>
  Where <reg> is one of: A X Y PC SP 
 See also: OPERATORS
 Examples:
  R PC RESET + 1
  R PC $FC58
  R A  A1
  R A  $A1
  R A  #A1
```

so this PR removes the reference in the help doc.