### PR TITLE
Debugger: 2.9.1.25 Fixed: R P ## wasn't setting P flag status register.

### DIFF
--- a/docs/Debugger_Changelog.txt
+++ b/docs/Debugger_Changelog.txt
@@ -1,4 +1,5 @@
 /*
+2.9.1.25 Fixed: R P ## wasn't setting P flag status register.
 2.9.1.24 Fixed: Disassembly line when at PC for BW mode. GH #1231
 2.9.1.23 Fixed: Show floating-point values in scientific notation.
 2.9.1.22 Fixed: `df FAC` was incorrectly getting marked up as `db`

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -53,7 +53,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #define MAKE_VERSION(a,b,c,d) ((a<<24) | (b<<16) | (c<<8) | (d))
 
 	// See /docs/Debugger_Changelog.txt for full details
-	const int DEBUGGER_VERSION = MAKE_VERSION(2,9,1,24);
+	const int DEBUGGER_VERSION = MAKE_VERSION(2,9,1,25);
 
 
 // Public _________________________________________________________________________________________
@@ -6091,6 +6091,7 @@ Update_t CmdRegisterSet (int nArgs)
 				case PARAM_REG_SP: regs.sp = b | 0x100; break;
 				case PARAM_REG_X : regs.x  = b; break;
 				case PARAM_REG_Y : regs.y  = b; break;
+				case PARAM_FLAGS : regs.ps = b; break;
 				default:        return Help_Arg_1( CMD_REGISTER_SET );
 			}
 		}

--- a/source/Debugger/Debugger_Help.cpp
+++ b/source/Debugger/Debugger_Help.cpp
@@ -784,7 +784,7 @@ Update_t CmdHelpSpecific (int nArgs)
 	// Registers
 		case CMD_REGISTER_SET:
 			ConsoleColorizePrint( " Usage: <reg> <value | expression | symbol>" );
-			ConsoleBufferPush( "  Where <reg> is one of: A X Y PC SP " );
+			ConsoleBufferPush( "  Where <reg> is one of: A X Y P PC SP " );
 			ConsoleColorizePrintFormat( " See also: %s%s"
 				, CHC_CATEGORY
 				, g_aParameters[ PARAM_CAT_OPERATORS ].m_sName );
@@ -794,6 +794,7 @@ Update_t CmdHelpSpecific (int nArgs)
 			ConsolePrintFormat( "%s  R A  A1"       , CHC_EXAMPLE );
 			ConsolePrintFormat( "%s  R A  $A1"      , CHC_EXAMPLE );
 			ConsolePrintFormat( "%s  R A  #A1"      , CHC_EXAMPLE );
+			ConsolePrintFormat( "%s  R P  0"        , CHC_EXAMPLE );
 			break;
 		case CMD_SOURCE:
 //			ConsoleBufferPush( " Reads assembler source file." );


### PR DESCRIPTION
Fix `R P` oversight not setting status register.

This invalidates PR #1233.