### PR TITLE
Serial comms: compilation in Linux

### DIFF
--- a/source/SerialComms.cpp
+++ b/source/SerialComms.cpp
@@ -47,6 +47,8 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #define TCP_SERIAL_PORT 1977
 
+const UINT CSuperSerialCard::SERIALPORTITEM_INVALID_COM_PORT = 0;
+
 // Default: 9600-8-N-1
 SSC_DIPSW CSuperSerialCard::m_DIPSWDefault =
 {
@@ -241,6 +243,7 @@ bool CSuperSerialCard::CheckComm()
 			saAddress.sin_addr.s_addr = htonl(INADDR_ANY);
 			if (bind(m_hCommListenSocket, (LPSOCKADDR)&saAddress, sizeof(saAddress)) == SOCKET_ERROR)
 			{
+				closesocket(m_hCommListenSocket);
 				m_hCommListenSocket = INVALID_SOCKET;
 				WSACleanup();
 				return false;
@@ -249,6 +252,7 @@ bool CSuperSerialCard::CheckComm()
 			// bound, so listen
 			if (listen(m_hCommListenSocket, 1) == SOCKET_ERROR)
 			{
+				closesocket(m_hCommListenSocket);
 				m_hCommListenSocket = INVALID_SOCKET;
 				WSACleanup();
 				return false;
@@ -261,6 +265,7 @@ bool CSuperSerialCard::CheckComm()
 					/* unsigned int wMsg */ WM_USER_TCP_SERIAL,
 					/* long lEvent */ (FD_ACCEPT | FD_CONNECT | FD_READ | FD_CLOSE)) != 0)
 			{
+				closesocket(m_hCommListenSocket);
 				m_hCommListenSocket = INVALID_SOCKET;
 				WSACleanup();
 				return false;

--- a/source/SerialComms.cpp
+++ b/source/SerialComms.cpp
@@ -71,7 +71,8 @@ CSuperSerialCard::CSuperSerialCard(UINT slot) :
 	m_strSerialPortChoices(1, '\0'), // Combo box friendly, just in case.
 	m_uTCPChoiceItemIdx(0),
 	m_bCfgSupportDCD(false),
-	m_pExpansionRom(NULL)
+	m_pExpansionRom(NULL),
+	m_hFrameWindow(NULL)
 {
 	if (m_slot != 2)	// fixme
 		ThrowErrorInvalidSlot();
@@ -259,9 +260,10 @@ bool CSuperSerialCard::CheckComm()
 			}
 
 			// now send async events to our app's message handler
+			m_hFrameWindow = GetFrame().g_hFrameWindow;
 			if (WSAAsyncSelect(
 					/* SOCKET s */ m_hCommListenSocket,
-					/* HWND hWnd */ GetFrame().g_hFrameWindow,
+					/* HWND hWnd */ m_hFrameWindow,
 					/* unsigned int wMsg */ WM_USER_TCP_SERIAL,
 					/* long lEvent */ (FD_ACCEPT | FD_CONNECT | FD_READ | FD_CLOSE)) != 0)
 			{
@@ -333,7 +335,7 @@ void CSuperSerialCard::CommTcpSerialCleanup()
 {
 	if (m_hCommListenSocket != INVALID_SOCKET)
 	{
-		WSAAsyncSelect(m_hCommListenSocket, GetFrame().g_hFrameWindow, 0, 0); // Stop event messages
+		WSAAsyncSelect(m_hCommListenSocket, m_hFrameWindow, 0, 0); // Stop event messages
 		closesocket(m_hCommListenSocket);
 		m_hCommListenSocket = INVALID_SOCKET;
 

--- a/source/SerialComms.h
+++ b/source/SerialComms.h
@@ -88,7 +88,7 @@ private:
 	std::string m_currentSerialPortName;
 	DWORD	m_dwSerialPortItem;
 
-	static const UINT SERIALPORTITEM_INVALID_COM_PORT = 0;
+	static const UINT SERIALPORTITEM_INVALID_COM_PORT;
 	std::vector<UINT> m_vecSerialPortsItems;	// Includes "None" & "TCP" items
 	std::string m_strSerialPortChoices;
 	UINT	m_uTCPChoiceItemIdx;

--- a/source/SerialComms.h
+++ b/source/SerialComms.h
@@ -111,6 +111,7 @@ private:
 	HANDLE m_hCommHandle;
 	SOCKET m_hCommListenSocket;
 	SOCKET m_hCommAcceptSocket;
+	HWND m_hFrameWindow; // to avoid variable (de)-initialisation order issues
 
 	//
 


### PR DESCRIPTION
Some initial steps to use `SerialComms` in linux.
Current goal is to enable the TCP mode.
