### PR TITLE
Minor bugs in SSI263

### DIFF
--- a/source/SSI263.cpp
+++ b/source/SSI263.cpp
@@ -323,6 +323,11 @@ void SSI263::Votrax_Write(BYTE value)
 
 void SSI263::Play(unsigned int nPhoneme)
 {
+	if (!SSI263SingleVoice.lpDSBvoice)
+	{
+		return;
+	}
+
 	if (!SSI263SingleVoice.bActive)
 	{
 		bool bRes = DSZeroVoiceBuffer(&SSI263SingleVoice, m_kDSBufferByteSize);

--- a/source/SSI263.cpp
+++ b/source/SSI263.cpp
@@ -900,7 +900,7 @@ void SSI263::LoadSnapshot(YamlLoadHelper& yamlLoadHelper, PHASOR_MODE mode, UINT
 
 	//
 
-	_ASSERT(m_device != -1);
+	_ASSERT(m_device != BYTE(-1));
 	SetCardMode(mode);
 
 	// Only need to directly assert IRQ for Phasor mode (for Mockingboard mode it's done via UpdateIFR() in parent)


### PR DESCRIPTION
Fix an assertion that would never trigger.
Avoid assertion (or segfault) when running with `-no-mb`.