### PR TITLE
Update keyboard help docs

### DIFF
--- a/help/keyboard.html
+++ b/help/keyboard.html
@@ -5,6 +5,15 @@
 <body style="font-family: verdana; background-color: rgb(255, 255, 255);" alink="#008000" link="#008000" vlink="#008000">
 		<h2 style="color: rgb(0, 128, 0);">Using the Keyboard</h2>
 		<hr size="4">
+		<p>Normally to start an Apple 2 computer you would insert a floppy into 
+			the floppy disk drive and power it on. If you don't have a disk inserted 
+			the drive motor will stay on indefinitely.  To enter Applesoft BASIC instead (and stop the disk 
+			drive from spinning) you would press Ctrl-Reset. In AppleWin this sequence is 
+			<span style="font-style: italic;">analogous</span> to pressing the following keys:</p>
+		<ul>
+			<li><span style="font-weight: bold;">F2</span> (Power On), and
+			<li><span style="font-weight: bold;">Ctrl-F2</span> (Ctrl-Reset.)
+		</ul>
 		<p>The Apple //e keyboard was very similar to the PC keyboard, and most keys 
 			correspond directly between the two keyboards. However, there were a few keys 
 			on the Apple //e that are not on the PC; these are described below:</p>

--- a/help/keyboard.html
+++ b/help/keyboard.html
@@ -16,7 +16,10 @@
 		</ul>
 		<p>The Apple //e keyboard was very similar to the PC keyboard, and most keys 
 			correspond directly between the two keyboards. However, there were a few keys 
-			on the Apple //e that are not on the PC; these are described below:</p>
+			on the Apple //e that are not on the PC -- this is due to Apple innovating 
+			meta keys (Open Apple and Closed Apple) before Microsoft copied 
+			the concept years later with the Windows key. These are described below:
+		</p>
 		<p><span style="font-weight: bold;">Reset</span>:<br>
 			On the Apple //e, you could usually press Control+Reset to interrupt a running 
 			program. With the Apple //e Emulator, you may emulate this key sequence with


### PR DESCRIPTION
A recent post on reddit reminded me that I had an update to the help docs that I had forgotten about.

Over the years I've seen a  few users (new to AppleWin) have questions on how to "Start using AppleWin".  The current help _Using the Keyboard_ doesn't explain the first-step: that `F2` powers the machine on!  Whoops-a-daisy.

This PR helps document the "workflow" (power machine on, Ctrl-Reset) to minimize feeling lost.

Maybe this should go under _Quick Start_ instead?
