### PR TITLE
DWORD: introduce a macro for its correct printf format.

### DIFF
--- a/source/Core.cpp
+++ b/source/Core.cpp
@@ -162,7 +162,7 @@ void LogFileTimeUntilFirstKeyRead(void)
 
 	DWORD dwTime = GetTickCount() - dwLogKeyReadTickStart;
 
-	LogFileOutput("Time from emulation reboot until first $C000 access: %d msec\n", dwTime);
+	LogFileOutput("Time from emulation reboot until first $C000 access: %" DWORD_T_FMT " msec\n", dwTime);
 
 	bLogKeyReadDone = true;
 }

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -1953,7 +1953,7 @@ void _BWZ_List ( const Breakpoint_t * aBreakWatchZero, const int iBWZ ) //, bool
 	}
 
 	// ID On Stop Temp HitCounter  Addr Mem Symbol
-	ConsolePrintFormat( "  #%X %c  %c    %c  %c   %08X " CHC_ADDRESS " %04X " CHC_INFO "%s" CHC_SYMBOL " %s",
+	ConsolePrintFormat( "  #%X %c  %c    %c  %c   %08" DWORD_T_FMT " " CHC_ADDRESS " %04X " CHC_INFO "%s" CHC_SYMBOL " %s",
 //		(bZeroBased ? iBWZ + 1 : iBWZ),
 		iBWZ,
 		sEnabledFlags[ aBreakWatchZero[ iBWZ ].bEnabled ? 1 : 0 ],
@@ -6538,7 +6538,7 @@ bool ParseAssemblyListing ( bool bBytesToMemory, bool bAddSymbols )
 		{
 			*p = 0;
 			//	sscanf( sLine, "%s %s %s %s %s %s %s %s", sAddr1, sByte1, sByte2, sByte3, sLineN, sLabel, sAsm, sParam );
-			sscanf( sLine, "%X", &nAddress );
+			sscanf( sLine, "%" DWORD_T_FMT, &nAddress );
 
 			if (nAddress >= INVALID_ADDRESS) // || (sName[0] == 0) )
 				continue;

--- a/source/Debugger/Debugger_Symbols.cpp
+++ b/source/Debugger/Debugger_Symbols.cpp
@@ -652,7 +652,7 @@ int ParseSymbolTable(const std::string & pPathFileName, SymbolTable_Index_e eSym
 					);
 				}
 
-				ConsolePrintFormat( " %sInfo.: %s%-16s %saliases %s$%s%04X %s%-12s%s (%s%s%s)" // MAGIC NUMBER: -MAX_SYMBOLS_LEN
+				ConsolePrintFormat( " %sInfo.: %s%-16s %saliases %s$%s%04" DWORD_T_FMT " %s%-12s%s (%s%s%s)" // MAGIC NUMBER: -MAX_SYMBOLS_LEN
 					, CHC_INFO // 2.9.0.10 was CHC_WARNING, see #479
 					, CHC_SYMBOL
 					, sName
@@ -711,7 +711,7 @@ int ParseSymbolTable(const std::string & pPathFileName, SymbolTable_Index_e eSym
 					);
 				}
 
-				ConsolePrintFormat( "  %s$%s%04X %s%-31s%s"
+				ConsolePrintFormat( "  %s$%s%04" DWORD_T_FMT " %s%-31s%s"
 					, CHC_ARG_SEP
 					, CHC_ADDRESS
 					, nAddress

--- a/source/Speaker.cpp
+++ b/source/Speaker.cpp
@@ -996,7 +996,7 @@ bool Spkr_DSInit()
 
 		hr = SpeakerVoice.lpDSBvoice->GetCurrentPosition(&dwCurrentPlayCursor, &dwCurrentWriteCursor);
 		LogFileOutput("Spkr_DSInit: GetCurrentPosition kludge (%08X)\n", hr);
-		LogOutput("[DSInit] PC=%08X, WC=%08X, Diff=%08X\n", dwCurrentPlayCursor, dwCurrentWriteCursor, dwCurrentWriteCursor-dwCurrentPlayCursor);
+		LogOutput("[DSInit] PC=%08" DWORD_T_FMT ", WC=%08" DWORD_T_FMT ", Diff=%08" DWORD_T_FMT "\n", dwCurrentPlayCursor, dwCurrentWriteCursor, dwCurrentWriteCursor-dwCurrentPlayCursor);
 	}
 
 	return true;

--- a/source/StdAfx.h
+++ b/source/StdAfx.h
@@ -63,6 +63,7 @@ typedef UINT64 uint64_t;
 #else
 #define SIZE_T_FMT "zu"
 #define PTRDIFF_T_FMT "td"
+#define DWORD_T_FMT "lX"
 #endif
 
 #else
@@ -83,5 +84,6 @@ typedef UINT64 uint64_t;
 
 #define SIZE_T_FMT "zu"
 #define PTRDIFF_T_FMT "td"
+#define DWORD_T_FMT "X"
 
 #endif

--- a/source/Utilities.cpp
+++ b/source/Utilities.cpp
@@ -112,7 +112,7 @@ void LoadConfiguration(bool loadImages)
 
 		if (dwLoadedComputerType != dwComputerType)
 		{
-			std::string strText = StrFormat("Unsupported Apple2Type(%d). Changing to %d", dwLoadedComputerType, dwComputerType);
+			std::string strText = StrFormat("Unsupported Apple2Type(%" DWORD_T_FMT "). Changing to %" DWORD_T_FMT, dwLoadedComputerType, dwComputerType);
 
 			LogFileOutput("%s\n", strText.c_str());
 


### PR DESCRIPTION
DWORD is always 32 bits, but in Windows it is a "unsigned long", while in linux it must be a "unsigned int".

Same as we have done for `size_t` and Co.