### PR TITLE
More cleanup

### DIFF
--- a/source/FrameBase.h
+++ b/source/FrameBase.h
@@ -50,7 +50,7 @@ public:
 	virtual std::shared_ptr<NetworkBackend> CreateNetworkBackend(const std::string & interfaceName) = 0;
 
 	// create an object to write sound output to
-	virtual std::shared_ptr<SoundBuffer> CreateSoundBuffer(DWORD dwFlags, DWORD dwBufferSize, DWORD nSampleRate, int nChannels, LPCSTR pDevName) = 0;
+	virtual std::shared_ptr<SoundBuffer> CreateSoundBuffer(uint32_t dwBufferSize, uint32_t nSampleRate, int nChannels, const char* pszVoiceName) = 0;
 
 	// FindResource, MAKEINTRESOURCE, SizeofResource, LoadResource, LockResource
 	// Return pointer to resource if size is correct.

--- a/source/MockingboardCardManager.cpp
+++ b/source/MockingboardCardManager.cpp
@@ -283,7 +283,7 @@ bool MockingboardCardManager::Init(void)
 	if (!DSAvailable())
 		return false;
 
-	HRESULT hr = DSGetSoundBuffer(&m_mockingboardVoice, DSBCAPS_CTRLVOLUME, SOUNDBUFFER_SIZE, MockingboardCard::SAMPLE_RATE, MockingboardCard::NUM_MB_CHANNELS, "MB");
+	HRESULT hr = DSGetSoundBuffer(&m_mockingboardVoice, SOUNDBUFFER_SIZE, MockingboardCard::SAMPLE_RATE, MockingboardCard::NUM_MB_CHANNELS, "MB");
 	LogFileOutput("MBCardMgr: DSGetSoundBuffer(), hr=0x%08X\n", hr);
 	if (FAILED(hr))
 	{

--- a/source/SSI263.cpp
+++ b/source/SSI263.cpp
@@ -845,7 +845,7 @@ bool SSI263::DSInit(void)
 	if (!DSAvailable())
 		return false;
 
-	HRESULT hr = DSGetSoundBuffer(&SSI263SingleVoice, DSBCAPS_CTRLVOLUME, m_kDSBufferByteSize, SAMPLE_RATE_SSI263, m_kNumChannels, "SSI263");
+	HRESULT hr = DSGetSoundBuffer(&SSI263SingleVoice, m_kDSBufferByteSize, SAMPLE_RATE_SSI263, m_kNumChannels, "SSI263");
 	LogFileOutput("SSI263::DSInit: DSGetSoundBuffer(), hr=0x%08X\n", hr);
 	if (FAILED(hr))
 	{

--- a/source/SoundCore.cpp
+++ b/source/SoundCore.cpp
@@ -148,11 +148,11 @@ HRESULT DSGetLock(const std::shared_ptr<SoundBuffer>& pVoice, uint32_t dwOffset,
 
 //-----------------------------------------------------------------------------
 
-HRESULT DSGetSoundBuffer(VOICE* pVoice, uint32_t dwFlags, uint32_t dwBufferSize, uint32_t nSampleRate, int nChannels, const char* pszDevName)
+HRESULT DSGetSoundBuffer(VOICE* pVoice, uint32_t dwBufferSize, uint32_t nSampleRate, int nChannels, const char* pszVoiceName)
 {
-	pVoice->name = pszDevName;
+	pVoice->name = pszVoiceName;
 
-	std::shared_ptr<SoundBuffer> soundBuffer = GetFrame().CreateSoundBuffer(dwFlags, dwBufferSize, nSampleRate, nChannels, pszDevName);
+	std::shared_ptr<SoundBuffer> soundBuffer = GetFrame().CreateSoundBuffer(dwBufferSize, nSampleRate, nChannels, pszVoiceName);
 	if (!soundBuffer)
 		return E_FAIL;
 

--- a/source/SoundCore.h
+++ b/source/SoundCore.h
@@ -39,7 +39,7 @@ HRESULT DSGetLock(const std::shared_ptr<SoundBuffer>& pVoice, uint32_t dwOffset,
 					  SHORT** ppDSLockedBuffer0, DWORD* pdwDSLockedBufferSize0,
 					  SHORT** ppDSLockedBuffer1, DWORD* pdwDSLockedBufferSize1);
 
-HRESULT DSGetSoundBuffer(VOICE* pVoice, uint32_t dwFlags, uint32_t dwBufferSize, uint32_t nSampleRate, int nChannels, const char* pszDevName);
+HRESULT DSGetSoundBuffer(VOICE* pVoice, uint32_t dwBufferSize, uint32_t nSampleRate, int nChannels, const char* pszVoiceName);
 void DSReleaseSoundBuffer(VOICE* pVoice);
 
 bool DSVoiceStop(PVOICE Voice);

--- a/source/Speaker.cpp
+++ b/source/Speaker.cpp
@@ -960,7 +960,7 @@ bool Spkr_DSInit()
 
 	SpeakerVoice.bIsSpeaker = true;
 
-	HRESULT hr = DSGetSoundBuffer(&SpeakerVoice, DSBCAPS_CTRLVOLUME, g_dwDSSpkrBufferSize, SPKR_SAMPLE_RATE, g_nSPKR_NumChannels, "Spkr");
+	HRESULT hr = DSGetSoundBuffer(&SpeakerVoice, g_dwDSSpkrBufferSize, SPKR_SAMPLE_RATE, g_nSPKR_NumChannels, "Spkr");
 	if (FAILED(hr))
 	{
 		LogFileOutput("Spkr_DSInit: DSGetSoundBuffer failed (%08X)\n", hr);

--- a/source/StdAfx.h
+++ b/source/StdAfx.h
@@ -18,15 +18,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
-#if _MSC_VER >= 1600	// <stdint.h> supported from VS2010 (cl.exe v16.00)
 #include <stdint.h> // cleanup WORD DWORD -> uint16_t uint32_t
-#else
-typedef INT8 int8_t;
-typedef UINT8 uint8_t;
-typedef UINT16 uint16_t;
-typedef UINT32 uint32_t;
-typedef UINT64 uint64_t;
-#endif
 
 #include <windows.h>
 #include <winuser.h> // WM_MOUSEWHEEL
@@ -56,15 +48,7 @@ typedef UINT64 uint64_t;
 
 #define USE_SPEECH_API
 
-#if _MSC_VER < 1900
-#ifdef _WIN64
-#define SIZE_T_FMT "llu"
-#else
-#define SIZE_T_FMT "lu"
-#endif
-#else
 #define SIZE_T_FMT "zu"
-#endif
 
 #else // !_WIN32
 

--- a/source/StdAfx.h
+++ b/source/StdAfx.h
@@ -77,6 +77,7 @@ typedef UINT64 uint64_t;
 #include <algorithm>
 #include <string>
 #include <vector>
+#include <memory>
 
 // NOTE: this is a local version of windows.h with aliases for windows functions when not
 //       building in a windows environment (!_WIN32)

--- a/source/StrFormat.cpp
+++ b/source/StrFormat.cpp
@@ -17,29 +17,7 @@ std::string StrFormatV(const char* format, va_list va)
 {
 	size_t const bufsz_base = 2048; // Big enough for most cases.
 	char buf[bufsz_base];
-#if defined(_MSC_VER) && _MSC_VER < 1900
-#pragma warning(push)
-#pragma warning(disable: 4996) // warning _vsnprintf() is unsafe.
-	// VS2013 or before, _vsnprintf() cannot return required buffer size in case of overflow.
-	// MSVC seems fine not needing va_copy(), otherwise va_copy() may need to be called twice
-	// to be accurate. Not calling va_copy() here to keep things simpler.
-	int len = _vsnprintf(buf, sizeof(buf), format, va);
-	if (len >= 0 && size_t(len) <= sizeof(buf))
-	{
-		// _vsnprintf() can fill up the full buffer without nul termination.
-		return std::string(buf, size_t(len)); // No overflow.
-	}
-	else
-	{
-		// Overflow, need bigger buffer.
-		len = _vsnprintf(NULL, 0, format, va); // Get required buffer size.
-		std::string s(size_t(len), '\0');
-		len = _vsnprintf(&(*s.begin()), s.length() + 1, format, va);
-		assert(size_t(len) == s.length());
-		return s;
-	}
-#pragma warning(pop)
-#else
+
 	// Need to call va_copy() so va can be used potentially for a second time.
 	// glibc on Linux *certainly* needs this while MSVC is fine without it though.
 	va_list va_copied;
@@ -63,5 +41,4 @@ std::string StrFormatV(const char* format, va_list va)
 		assert(size_t(len) == s.length());
 		return s;
 	}
-#endif
 }

--- a/source/StrFormat.h
+++ b/source/StrFormat.h
@@ -2,14 +2,7 @@
 
 #include <cstdarg>
 #include <string>
-
-#if defined(_MSC_VER) && _MSC_VER < 1600
-#include <basetsd.h>
-typedef UINT8 uint8_t;
-typedef UINT16 uint16_t;
-#else
 #include <cstdint>
-#endif
 
 #ifdef _WIN32
 #define ATTRIBUTE_FORMAT_PRINTF(a, b)

--- a/source/Windows/DXSoundBuffer.cpp
+++ b/source/Windows/DXSoundBuffer.cpp
@@ -48,7 +48,7 @@ static UINT g_uDSInitRefCount = 0;
 
 //-----------------------------------------------------------------------------
 
-std::shared_ptr<SoundBuffer> DXSoundBuffer::create(DWORD dwFlags, DWORD dwBufferSize, DWORD nSampleRate, int nChannels)
+std::shared_ptr<SoundBuffer> DXSoundBuffer::create(uint32_t dwBufferSize, uint32_t nSampleRate, int nChannels)
 {
 	if (!g_lpDS)
 		return NULL;
@@ -67,7 +67,7 @@ std::shared_ptr<SoundBuffer> DXSoundBuffer::create(DWORD dwFlags, DWORD dwBuffer
 	dsbdesc.dwSize = sizeof(dsbdesc);
 	dsbdesc.dwBufferBytes = dwBufferSize;
 	dsbdesc.lpwfxFormat = &wavfmt;
-	dsbdesc.dwFlags = dwFlags | DSBCAPS_GETCURRENTPOSITION2 | DSBCAPS_STICKYFOCUS;
+	dsbdesc.dwFlags = DSBCAPS_CTRLVOLUME | DSBCAPS_GETCURRENTPOSITION2 | DSBCAPS_STICKYFOCUS;
 
 	LPDIRECTSOUNDBUFFER pBuffer;
 

--- a/source/Windows/DXSoundBuffer.h
+++ b/source/Windows/DXSoundBuffer.h
@@ -5,7 +5,7 @@
 class DXSoundBuffer : public SoundBuffer
 {
 public:
-	static std::shared_ptr<SoundBuffer> create(DWORD dwFlags, DWORD dwBufferSize, DWORD nSampleRate, int nChannels);
+	static std::shared_ptr<SoundBuffer> create(uint32_t dwBufferSize, uint32_t nSampleRate, int nChannels);
 
 	DXSoundBuffer(LPDIRECTSOUNDBUFFER pBuffer);
 	virtual ~DXSoundBuffer();

--- a/source/Windows/Win32Frame.cpp
+++ b/source/Windows/Win32Frame.cpp
@@ -632,7 +632,7 @@ std::shared_ptr<NetworkBackend> Win32Frame::CreateNetworkBackend(const std::stri
 	return backend;
 }
 
-std::shared_ptr<SoundBuffer> Win32Frame::CreateSoundBuffer(DWORD dwFlags, DWORD dwBufferSize, DWORD nSampleRate, int nChannels, LPCSTR pDevName)
+std::shared_ptr<SoundBuffer> Win32Frame::CreateSoundBuffer(uint32_t dwBufferSize, uint32_t nSampleRate, int nChannels, const char* pszVoiceName)
 {
-	return DXSoundBuffer::create(dwFlags, dwBufferSize, nSampleRate, nChannels);
+	return DXSoundBuffer::create(dwBufferSize, nSampleRate, nChannels);
 }

--- a/source/Windows/Win32Frame.h
+++ b/source/Windows/Win32Frame.h
@@ -60,7 +60,7 @@ public:
 	virtual std::string Video_GetScreenShotFolder() const;
 
 	virtual std::shared_ptr<NetworkBackend> CreateNetworkBackend(const std::string& interfaceName);
-	virtual std::shared_ptr<SoundBuffer> CreateSoundBuffer(DWORD dwFlags, DWORD dwBufferSize, DWORD nSampleRate, int nChannels, LPCSTR pDevName);
+	virtual std::shared_ptr<SoundBuffer> CreateSoundBuffer(uint32_t dwBufferSize, uint32_t nSampleRate, int nChannels, const char* pszVoiceName);
 
 	bool GetFullScreenShowSubunitStatus(void);
 	bool GetWindowedModeShowDiskiiStatus(void);

--- a/source/Windows/WinFrame.cpp
+++ b/source/Windows/WinFrame.cpp
@@ -53,9 +53,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "../resource/resource.h"
 #include "Configuration/PropertySheet.h"
 #include "Debugger/Debug.h"
-#if _MSC_VER < 1900	// VS2013 or before (cl.exe v18.x or before)
-#include <sys/stat.h>
-#endif
 
 //#define ENABLE_MENU 0
 #define DEBUG_KEY_MESSAGES 0

--- a/source/YamlHelper.cpp
+++ b/source/YamlHelper.cpp
@@ -391,11 +391,7 @@ float YamlLoadHelper::LoadFloat(const std::string& key)
 		m_bDoGetMapRemainder = false;
 		throw std::runtime_error(m_currentMapName + ": Missing: " + key);
 	}
-#if (_MSC_VER >= 1900)
-	return strtof(value.c_str(), NULL);			// MSVC++ 14.0  _MSC_VER == 1900 (Visual Studio 2015 version 14.0)
-#else
-	return (float) strtod(value.c_str(), NULL);	// NB. strtof() requires VS2015
-#endif
+	return strtof(value.c_str(), NULL);
 }
 
 double YamlLoadHelper::LoadDouble(const std::string& key)

--- a/test/TestCPU6502/stdafx.h
+++ b/test/TestCPU6502/stdafx.h
@@ -10,14 +10,6 @@
 
 #include <windows.h>
 
-#if _MSC_VER >= 1600	// <stdint.h> supported from VS2010 (cl.exe v16.00)
 #include <stdint.h> // cleanup WORD DWORD -> uint16_t uint32_t
-#else
-#include <BaseTsd.h>
-typedef UINT8 uint8_t;
-typedef UINT16 uint16_t;
-typedef UINT32 uint32_t;
-typedef UINT64 uint64_t;
-#endif
 
 #include <string>


### PR DESCRIPTION
1. `SoundBuffer`: move Windows only flags to `DXSoundBuffer`
2. Remove checks for old `_MSC_VER` values