### PR TITLE
DebugFont: use an ID which is a valid macro.

### DIFF
--- a/AppleWinExpress2019.vcxproj.filters
+++ b/AppleWinExpress2019.vcxproj.filters
@@ -817,10 +817,18 @@
     <None Include="resource\Disk2-13sector.rom">
       <Filter>Resource Files</Filter>
     </None>
-    <None Include="resource\Hddrvr-v2.bin" />
-    <None Include="resource\HDC-SmartPort.bin" />
-    <None Include="resource\Apple2_Video.rom" />
-    <None Include="resource\Apple2e_Enhanced_Video.rom" />
+    <None Include="resource\Apple2_Video.rom">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="resource\Apple2e_Enhanced_Video.rom">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="resource\HDC-SmartPort.bin">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="resource\Hddrvr-v2.bin">
+      <Filter>Resource Files</Filter>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Text Include="docs\CodingConventions.txt">

--- a/resource/Applewin.rc
+++ b/resource/Applewin.rc
@@ -76,7 +76,7 @@ IDB_CHARSET8C           BITMAP                  "CHARSET8C.bmp"
 HELP_BUTTON             BITMAP                  "HELP.BMP"
 DRIVESWAP_BUTTON        BITMAP                  "DRIVESWAP.BMP"
 IDB_APPLEWIN            BITMAP                  "ApplewinLogo.bmp"
-IDB_DEBUG_FONT_7X8      BITMAP                  "Debug_Font.bmp"
+IDB_DEBUG_FONT_7_by_8   BITMAP                  "Debug_Font.bmp"
 
 /////////////////////////////////////////////////////////////////////////////
 //

--- a/resource/resource.h
+++ b/resource/resource.h
@@ -59,6 +59,7 @@
 #define IDB_CHARSET8M                   157
 #define IDB_CHARSET82                   158
 #define IDB_CHARSET8C                   159
+#define IDB_DEBUG_FONT_7_by_8           160
 #define IDC_KEYB_BUFFER_ENABLE          1005
 #define IDC_SAVESTATE                   1006
 #define IDC_SAVESTATE_ON_EXIT           1007
@@ -141,7 +142,7 @@
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NO_MFC                     1
-#define _APS_NEXT_RESOURCE_VALUE        160
+#define _APS_NEXT_RESOURCE_VALUE        161
 #define _APS_NEXT_COMMAND_VALUE         40012
 #define _APS_NEXT_CONTROL_VALUE         1083
 #define _APS_NEXT_SYMED_VALUE           101

--- a/source/Debugger/Debugger_Display.cpp
+++ b/source/Debugger/Debugger_Display.cpp
@@ -42,6 +42,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "../Memory.h"
 #include "../Mockingboard.h"
 #include "../NTSC.h"
+#include "../resource/resource.h"
 
 // NEW UI debugging - force display ALL meta-info (regs, stack, bp, watches, zp) for debugging purposes
 #define DEBUG_FORCE_DISPLAY 0
@@ -593,7 +594,7 @@ HDC GetConsoleFontDC(void)
 		// DRAW THE SOURCE IMAGE INTO THE SOURCE BIT BUFFER
 		HDC tmpDC = CreateCompatibleDC(hFrameDC);
 		// Pre-scaled bitmap
-		HBITMAP tmpFont = LoadBitmap(win32Frame.g_hInstance, TEXT("IDB_DEBUG_FONT_7x8"));  // Bitmap must be 112x128 as defined above
+		HBITMAP tmpFont = LoadBitmap(win32Frame.g_hInstance, MAKEINTRESOURCE(IDB_DEBUG_FONT_7_by_8));  // Bitmap must be 112x128 as defined above
 		SelectObject(tmpDC, tmpFont);
 		BitBlt(g_hConsoleFontDC, 0, 0, CONSOLE_FONT_BITMAP_WIDTH, CONSOLE_FONT_BITMAP_HEIGHT,
 			tmpDC, 0, 0,


### PR DESCRIPTION
Simplifies linux resource embedding.