### PR TITLE
Double dot in disk filename

### DIFF
--- a/source/Windows/WinFrame.cpp
+++ b/source/Windows/WinFrame.cpp
@@ -2824,7 +2824,7 @@ void Win32Frame::ProcessDiskPopupMenu(HWND hwnd, POINT pt, const int iDrive)
 			    ;
 
 		std::string sFileName( StrFormat(
-			  "blank_%s_%04d_%3s_%02d_%02dh_%02dm_%02ds.%s"
+			  "blank_%s_%04d_%3s_%02d_%02dh_%02dm_%02ds%s"
 			, bIsFloppy ? "floppy" : "hard"
 			, year, mon, day, hour, min, sec
 			, sExtension.c_str()


### PR DESCRIPTION
Small typo, you have 2 dots in the extension for the filename when creating new disks.