### PR TITLE
Document the disk image size magic numbers.

### DIFF
--- a/bin/A2_DOS33.SYM2
+++ b/bin/A2_DOS33.SYM2
@@ -1,0 +1,93 @@
+// DOS 3.3 Symbols for AppleWin
+// Min debugger version 2.9.2.4
+
+// = Functions =
+symdos33 DOS.COS0    = 9EEB
+symdos33 DOS.COS1    = 9F12
+symdos33 DOS.SCANCMD = 9FCD
+symdos33 DOS.ORTN    = 9FB3
+symdos33 DOS.MVCSW   = A851
+symdos33 DOS.EBLD    = A35D
+symdos33 DOS.EBLD1   = A382
+symdos33 DOS.EBLD2   = A360
+symdos33 DOS.EBLD3   = A36C
+symdos33 DOS.EBSV    = A331
+symdos33 DOS.EBRUN   = A38E
+symdos33 DOS.LD3     = A471
+symdos33 DOS.GNBC    = A1A4
+
+// = Data =
+dw DOS.CFTABA        = AA4F
+db DOS.ISTATE        = AA51
+db DOS.OSTATE        = AA52
+dw DOS.SVOUTS        = AA53
+dw DOS.SVINS         = AA55
+db DOS.CNFTBS        = AA57
+db DOS.DFNFB         = AA58
+db DOS.SVSTK         = AA59
+db DOS.SVX           = AA5A
+db DOS.SVY           = AA5B
+db DOS.SVA           = AA5C
+db DOS.LBUFD         = AA5D
+db DOS.MONMOD        = AA5E
+db DOS.CMDNO         = AA5F
+dw DOS.SVBL          = AA60
+db DOS.SVCMD         = AA62
+db DOS.TEMP1A        = AA63
+db DOS.TEMP2A        = AA64
+db DOS.INOPTS        = AA65
+dw DOS.CV            = AA66
+dw DOS.CD            = AA68
+dw DOS.CS            = AA6A
+dw DOS.CL            = AA6C
+dw DOS.CR            = AA6E
+dw DOS.CB            = AA70
+dw DOS.CA            = AA72
+
+db DOS.PAD_B7DF      = B7DF
+db DOS.NDPGS         = B7E0
+db DOS.BRWCNT        = B7E1
+db DOS.PAD_B7E2      = B7E2
+db DOS.PAD_B7E3      = B7E3
+da DOS.BAOB          = B7E4
+da DOS.ADOSLD        = B7E6
+db DOS.IBTYPE        = B7E8
+db DOS.IBSLOT        = B7E9
+db DOS.IBDRVN        = B7EA
+db DOS.IBVOL         = B7EB
+db DOS.IBTRK         = B7EC
+db DOS.IBSECT        = B7ED
+da DOS.IBDCTP        = B7EE
+da DOS.IBBUFP        = B7F0
+dw DOS.IBDLEN        = B7F2
+db DOS.IBCMD         = B7F4
+
+// = Strings =
+asc T_INIT     A884:A887
+asc T_LOAD     A888:A88B
+asc T_SAVE     A88C:A88F
+asc T_RUN      A890:A892
+asc T_CHAIN    A893:A897
+asc T_DELETE   A898:A89D
+asc T_LOCK     A89E:A8A1
+asc T_UNLOCK   A8A2:A8A7
+asc T_CLOSE    A8A8:A8AC
+asc T_READ     A8AD:A8B0
+asc T_EXEC     A8B1:A8B4
+asc T_WRITE    A8B5:A8B9
+asc T_POSITION A8BA:A8C1
+asc T_OPEN     A8C2:A8C5
+asc T_APPEND   A8C6:A8CB
+asc T_RENAME   A8CC:A8D1
+asc T_CATALOG  A8D2:A8D8
+asc T_MON      A8D9:A8DB
+asc T_NOMON    A8DC:A8E0
+asc T_PR_NUM   A8E1:A8E3
+asc T_IN_NUM   A8E4:A8E6
+asc T_MAXFILES A8E7:A8EE
+asc T_FP       A8EF:A8F0
+asc T_INT      A8F1:A8F3
+asc T_BSAVE    A8F4:A8F8
+asc T_BLOAD    A8F9:A8FD
+asc T_BRUN     A8FE:A901
+asc T_VERIFY   A902:A907

--- a/docs/Debugger_Changelog.txt
+++ b/docs/Debugger_Changelog.txt
@@ -1,4 +1,5 @@
 /*
+2.9.2.2 Fixed: DB HGR = 2000:3FFF was displaying help instead of being parsed.
 2.9.2.1 Added: Error message when trying to add a symbol > 51 characters.
 
 2.9.2.0 Released with AppleWin 1.30.20.0

--- a/docs/Debugger_Changelog.txt
+++ b/docs/Debugger_Changelog.txt
@@ -1,4 +1,5 @@
 /*
+2.9.2.3 Fixed: DB HGR = 2000:3FFF and DB FOO = 300 wasn't parsing correctly from 2.9.1.3. Fix for commit 48e0fe3a.
 2.9.2.2 Fixed: DB HGR = 2000:3FFF was displaying help instead of being parsed.
 2.9.2.1 Added: Error message when trying to add a symbol > 51 characters.
 

--- a/docs/Debugger_Changelog.txt
+++ b/docs/Debugger_Changelog.txt
@@ -1,4 +1,8 @@
 /*
+2.9.2.5 Added: Symbol table for DOS 3.3 using file A2_DOS33.SYM2
+    Add symbols via: SYMDOS33 <symbol> = <addr>
+    To disable: SYMDOS33 OFF
+    To renable: SYMDOS33 ON
 2.9.2.4 Fixed: DA RESET = 3F2 was displaying help instead of being parsed.
 2.9.2.3 Fixed: DB HGR = 2000:3FFF and DB FOO = 300 wasn't parsing correctly from 2.9.1.3. Fix for commit 48e0fe3a.
 2.9.2.2 Fixed: DB HGR = 2000:3FFF was displaying help instead of being parsed.

--- a/docs/Debugger_Changelog.txt
+++ b/docs/Debugger_Changelog.txt
@@ -1,4 +1,5 @@
 /*
+2.9.2.6 Added: QoL: Turning a symbol table on/off now shows the current status.
 2.9.2.5 Added: Symbol table for DOS 3.3 using file A2_DOS33.SYM2
     Add symbols via: SYMDOS33 <symbol> = <addr>
     To disable: SYMDOS33 OFF

--- a/docs/Debugger_Changelog.txt
+++ b/docs/Debugger_Changelog.txt
@@ -1,4 +1,5 @@
 /*
+2.9.2.4 Fixed: DA RESET = 3F2 was displaying help instead of being parsed.
 2.9.2.3 Fixed: DB HGR = 2000:3FFF and DB FOO = 300 wasn't parsing correctly from 2.9.1.3. Fix for commit 48e0fe3a.
 2.9.2.2 Fixed: DB HGR = 2000:3FFF was displaying help instead of being parsed.
 2.9.2.1 Added: Error message when trying to add a symbol > 51 characters.

--- a/help/CommandLine.html
+++ b/help/CommandLine.html
@@ -95,7 +95,7 @@
 		(Implicitly inserts a RamWorks III card into the aux slot.)<br><br>
 		-load-state &lt;savestate&gt;<br>
 		Load a save-state file (and auto power-on the Apple II).<br>
-		NB. This takes precedent over the -d1, -d2, -s#d#, -h1, -h2, s0-7, -model and -r switches.<br><br>
+		NB. This takes precedent over the -d1, -d2, -s#d#, -h1, -h2, -s#h#, -s0-7, -model and -r switches.<br><br>
 		-f or -full-screen<br>
 		Start in full-screen mode.<br><br>
 		-no-full-screen<br>
@@ -103,7 +103,7 @@
 		-fs-height=&lt;best|nnnn&gt;<br>
 		Use to select a better resolution for full-screen mode.<br>
 		<ul>
-			<li>best: picks the highest resolution where the height is an integer multiple of (192*2)</li>
+			<li>best: picks the highest resolution where the height is an integer multiple of (192*2); or (200*2) when using '-s3 vidhd'</li>
 			<li>nnnn: select a specific resolution with height=nnnn pixels</li>
 		</ul>
 		-fs-width=&lt;nnnn&gt;<br>

--- a/help/ddi-formats.html
+++ b/help/ddi-formats.html
@@ -37,13 +37,13 @@ is probably a DOS order image with extra header information
 before or after the image. In most cases, AppleWin can
 automatically detect this and handle it. </p>
 
-<p>Some disk drives were able to handle 40+ tracks.  AppleWin accept disk images up to 40 tracks -- 163,840 bytes -- as long as the disk image is a multiple of 4,096 bytes / track.</p>
-
 <p>Due to some games being incorrectly converted to a disk image AppleWin also accepts disk images of sizes:
 <ul>
   <li>143,403 bytes (<i>Castle Wolfenstein</i>)</li>
   <li>143,488 bytes (<i>Rescue Raiders</i>)</li>
 </ul>
+
+<p>Some disk drives were able to handle 40+ tracks.  AppleWin accept disk images up to 40 tracks -- 163,840 bytes -- as long as the disk image is a multiple of 4,096 bytes / track.</p>
 
 <p style="font-weight: bold;">ProDOS Order
 Images: </p>

--- a/help/ddi-formats.html
+++ b/help/ddi-formats.html
@@ -27,15 +27,23 @@ sectors. If you run a DOS program on the Apple which reads in
 sectors one by one and then transfers them over a serial line to
 the PC, you will get a DOS order disk image. </p>
 
-<p>Apple floppy disks contained 35 tracks with
+<p>Apple floppy disks (normally) contain 35 tracks with
 16 sectors per track, for a total of 560 sectors. Each of these
 sectors contained 256 bytes of information, for a total of
 143,360 bytes per disk. Therefore, DOS order disk images are
 always at least 143,360 bytes long. Sometimes on the Internet you
-will see a disk image that is 143,488 or 143,616 bytes long; this
+will see a disk image that is not 143,360 bytes long; this
 is probably a DOS order image with extra header information
 before or after the image. In most cases, AppleWin can
 automatically detect this and handle it. </p>
+
+<p>Some disk drives were able to handle 40+ tracks.  AppleWin accept disk images up to 40 tracks -- 163,840 bytes -- as long as the disk image is a multiple of 4,096 bytes / track.</p>
+
+<p>Due to some games being incorrectly converted to a disk image AppleWin also accepts disk images of sizes:
+<ul>
+  <li>143,403 bytes (<i>Castle Wolfenstein</i>)</li>
+  <li>143,488 bytes (<i>Rescue Raiders</i>)</li>
+</ul>
 
 <p style="font-weight: bold;">ProDOS Order
 Images: </p>

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -53,7 +53,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #define MAKE_VERSION(a,b,c,d) ((a<<24) | (b<<16) | (c<<8) | (d))
 
 	// See /docs/Debugger_Changelog.txt for full details
-	const int DEBUGGER_VERSION = MAKE_VERSION(2,9,2,1);
+	const int DEBUGGER_VERSION = MAKE_VERSION(2,9,2,2);
 
 
 // Public _________________________________________________________________________________________

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -53,7 +53,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #define MAKE_VERSION(a,b,c,d) ((a<<24) | (b<<16) | (c<<8) | (d))
 
 	// See /docs/Debugger_Changelog.txt for full details
-	const int DEBUGGER_VERSION = MAKE_VERSION(2,9,2,3);
+	const int DEBUGGER_VERSION = MAKE_VERSION(2,9,2,4);
 
 
 // Public _________________________________________________________________________________________

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -53,7 +53,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #define MAKE_VERSION(a,b,c,d) ((a<<24) | (b<<16) | (c<<8) | (d))
 
 	// See /docs/Debugger_Changelog.txt for full details
-	const int DEBUGGER_VERSION = MAKE_VERSION(2,9,2,2);
+	const int DEBUGGER_VERSION = MAKE_VERSION(2,9,2,3);
 
 
 // Public _________________________________________________________________________________________

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -53,7 +53,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #define MAKE_VERSION(a,b,c,d) ((a<<24) | (b<<16) | (c<<8) | (d))
 
 	// See /docs/Debugger_Changelog.txt for full details
-	const int DEBUGGER_VERSION = MAKE_VERSION(2,9,2,5);
+	const int DEBUGGER_VERSION = MAKE_VERSION(2,9,2,6);
 
 
 // Public _________________________________________________________________________________________

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -53,7 +53,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #define MAKE_VERSION(a,b,c,d) ((a<<24) | (b<<16) | (c<<8) | (d))
 
 	// See /docs/Debugger_Changelog.txt for full details
-	const int DEBUGGER_VERSION = MAKE_VERSION(2,9,2,4);
+	const int DEBUGGER_VERSION = MAKE_VERSION(2,9,2,5);
 
 
 // Public _________________________________________________________________________________________
@@ -8906,6 +8906,10 @@ void DebugInitialize ()
 	CmdSymbolsLoad(0);
 
 	g_iCommand = CMD_SYMBOLS_APPLESOFT;
+	CmdSymbolsLoad(0);
+
+	// 2.9.2.5 Added: Symbol table A2_DOS33.SYM2
+	g_iCommand = CMD_SYMBOLS_DOS33;
 	CmdSymbolsLoad(0);
 
 	// ,0x7,0xFF // Treat zero-page as data

--- a/source/Debugger/Debugger_DisassemblerData.cpp
+++ b/source/Debugger/Debugger_DisassemblerData.cpp
@@ -82,6 +82,9 @@ WORD _GetDataRange (int nArgs, int iArg, DisasmData_t& tData_)
 	else
 	{
 		// DB foo = 300 // nArgs == 3
+		// 2.9.2.3: Fixed: DB HGR = 2000:3FFF and DB FOO = 300 wasn't parsing correctly from 2.9.1.3. Fix for commit 48e0fe3a.
+		if (g_aArgs[iArg].eToken == TOKEN_EQUAL)
+			iArg++;
 
 		RangeType_t eRange = Range_Get( nAddress, nAddress2, iArg);
 		if ((eRange == RANGE_HAS_END) ||
@@ -97,10 +100,7 @@ WORD _GetDataRange (int nArgs, int iArg, DisasmData_t& tData_)
 				// 2.9.1.1 Add: Support for equal sign, also make it optional for command DB
 				// DB FOO   300
 				// DB FOO = 300
-				if (g_aArgs[2].bType == TOKEN_EQUAL)
-					nAddress = g_aArgs[ 3 ].nValue;
-				else
-					nAddress = g_aArgs[ 2 ].nValue;
+				nAddress = g_aArgs[ iArg ].nValue;
 			}
 			else
 				nAddress = g_aArgs[ 1 ].nValue;

--- a/source/Debugger/Debugger_DisassemblerData.cpp
+++ b/source/Debugger/Debugger_DisassemblerData.cpp
@@ -373,7 +373,8 @@ Update_t _CmdDisasmDataDefByteX (int nArgs)
 	// To "return to code" use ."X" 
 	int iCmd = g_aArgs[0].nValue - NOP_BYTE_1;
 
-	if (nArgs > 4) // 2.7.0.31 Bug fix: DB range, i.e. DB 174E:174F
+	// 2.9.2.2: Bug fix: DB HGR = 2000:3FFF was displaying help instead of being parsed.
+	if (nArgs > 5) // 2.7.0.31 Bug fix: DB range, i.e. DB 174E:174F
 	{
 		return Help_Arg_1( CMD_DEFINE_DATA_BYTE1 + iCmd );
 	}

--- a/source/Debugger/Debugger_DisassemblerData.cpp
+++ b/source/Debugger/Debugger_DisassemblerData.cpp
@@ -490,7 +490,8 @@ Update_t CmdDisasmDataDefAddress16 (int nArgs)
 {
 	int iCmd = NOP_WORD_1 - g_aArgs[0].nValue;
 
-	if (! ((nArgs <= 2) || (nArgs == 4)))
+	// 2.9.2.4 Fixed: DA RESET = 3F2 was displaying help instead of being parsed.
+	if (nArgs > 4)
 	{
 		return Help_Arg_1( CMD_DEFINE_DATA_WORD1 + iCmd );
 	}

--- a/source/Debugger/Debugger_Symbols.cpp
+++ b/source/Debugger/Debugger_Symbols.cpp
@@ -281,7 +281,7 @@ Update_t CmdSymbolsClear (int nArgs)
 
 // Format the summary of the specified symbol table
 //===========================================================================
-std::string _CmdSymbolsInfoHeader( int iTable, int nDisplaySize /* = 0 */ )
+std::string _CmdSymbolsInfoHeader ( int iTable, int nDisplaySize /* = 0 */ )
 {
 	// Common case is to use/calc the table size
 	bool bActive = (g_bDisplaySymbolTables & (1 << iTable)) ? true : false;
@@ -294,6 +294,20 @@ std::string _CmdSymbolsInfoHeader( int iTable, int nDisplaySize /* = 0 */ )
 		, g_aSymbolTableNames[ iTable ]
 		, bActive ? CHC_NUM_DEC : CHC_WARNING, nSymbols
 	);
+}
+
+//===========================================================================
+std::string _CmdSymbolsSummaryStatus ( int iTable )
+{
+	bool bActive = (g_bDisplaySymbolTables & (1 << iTable)) ? true : false;
+	int iParam  = bActive
+	            ? PARAM_ON
+	            : PARAM_OFF
+	            ;
+	std::string sSymbolSummary = _CmdSymbolsInfoHeader( iTable );
+	sSymbolSummary += StrFormat( "%s(%s%s%s)", CHC_ARG_SEP, CHC_COMMAND, g_aParameters[ iParam ].m_sName,  CHC_ARG_SEP );
+
+	return sSymbolSummary;
 }
 
 //===========================================================================
@@ -1057,7 +1071,7 @@ Update_t _CmdSymbolsCommon ( int nArgs, int bSymbolTables )
 				int iTable = _GetSymbolTableFromFlag( bSymbolTables );
 				if (iTable != NUM_SYMBOL_TABLES)
 				{
-					ConsolePrint( _CmdSymbolsInfoHeader( iTable ).c_str() );
+					ConsolePrint( _CmdSymbolsSummaryStatus( iTable ).c_str() );
 				}
 				return ConsoleUpdate() | UPDATE_DISASM;
 			}
@@ -1068,7 +1082,7 @@ Update_t _CmdSymbolsCommon ( int nArgs, int bSymbolTables )
 				int iTable = _GetSymbolTableFromFlag( bSymbolTables );
 				if (iTable != NUM_SYMBOL_TABLES)
 				{
-					ConsolePrint( _CmdSymbolsInfoHeader( iTable ).c_str() );
+					ConsolePrint( _CmdSymbolsSummaryStatus( iTable ).c_str() );
 				}
 				return ConsoleUpdate() | UPDATE_DISASM;
 			}

--- a/source/DiskImageHelper.cpp
+++ b/source/DiskImageHelper.cpp
@@ -601,10 +601,39 @@ bool CImageBase::IsValidImageSize(const uint32_t uImageSize)
 	}
 	else
 	{
-		// TODO: Applewin.chm mentions images of size 143,616 bytes ("Disk Image Formats")
-		bValidSize = (  ((uImageSize >= 143105) && (uImageSize <= 143364)) ||
-						 (uImageSize == 143403) ||
-						 (uImageSize == 143488) );
+		// AppleWin.chm (Disks and Disk Images > Disk Image Formats) mentions disk images of sizes 143,488 and 143,616 bytes
+		//     "Sometimes on the Internet you will see a disk image that is 143,488 or 143,616 bytes long;"
+		// ... but doesn't mention where these magic numbers come from.
+		// Also, AppleWin doesn't even check for the 143,616 size!
+		//
+		// Mame in mame/src/lib/formats/ap2_dsk.cpp checks for sizes ...
+		//     143403,
+		//     143363,
+		//     143358, and
+		//     143195
+		// ... but also doesn't list references/sources/examples.
+		//
+		// Searching the Internet for these disk sizes we find them in a mame commit from 2019!
+		//     https://github.com/mamedev/mame/commit/b380514764cf857469bae61c11143a19f79a74c5
+		// They are in the old file hash/apple2.xml. It has been renamed/moved to apple2_flop_misc.xml
+		//    https://github.com/mamedev/mame/blob/master/hash/apple2_flop_misc.xml
+		//
+		// | Size   | # | Disk Image Name                                                                        |
+		// |-------:|--:|:---------------------------------------------------------------------------------------|
+		// | 143105 | ? | ??? Smallest Valid Size ???                                                            |
+		// | 143195 | 1 | bard's tale iii - the thief of fate, the (1988)(interplay)(disk 3 of 4)(dungeon 1).dsk |
+		// | 143358 | 1 | bard's tale iii - the thief of fate, the (1988)(interplay)(disk 1 of 4).dsk            |
+		// | 143358 | 2 | bard's tale iii - the thief of fate, the (1988)(interplay)(disk 2 of 4)(character).dsk |
+		// | 143358 | 3 | bard's tale iii - the thief of fate, the (1988)(interplay)(disk 3 of 4)(dungeon 2).dsk |
+		// | 143363 | 1 | bandits (1982)(sirius software)[o].dsk                                                 |
+		// | 143363 | 2 | berzap (1984)(infinity limited)[cr krackle - magic merlin][o].dsk                      |
+		// | 143363 | 3 | f15_strike_eagle.dsk                                                                   |
+		// | 143364 | ? | ??? Largest Valid Size ??????                                                          |
+		// | 143403 | 1 | castle wolfenstein (1981)(muse).do                                                     |
+		// | 143488 | 1 | rescue_raiders.dsk                                                                     |
+		bValidSize = (  ((uImageSize >= 143105) && (uImageSize <= 143364))
+					||	 (uImageSize == 143403)     //  43 byte header (Pre or Post?) + 35 Tracks * 16 Sectors/Track * 256 Bytes/Sector
+					||	 (uImageSize == 143488) );  // 128 byte header (Pre or Post?) + 35 Tracks * 16 Sectors/Track * 256 Bytes/Sector
 	}
 
 	if (bValidSize)

--- a/source/DiskImageHelper.cpp
+++ b/source/DiskImageHelper.cpp
@@ -631,6 +631,8 @@ bool CImageBase::IsValidImageSize(const uint32_t uImageSize)
 		// | 143364 | ? | ??? Largest Valid Size ??????                                                          |
 		// | 143403 | 1 | castle wolfenstein (1981)(muse).do                                                     |
 		// | 143488 | 1 | rescue_raiders.dsk                                                                     |
+		//
+		// NOTE: Update help/ddi-formats.html if the following disk sizes change.
 		bValidSize = (  ((uImageSize >= 143105) && (uImageSize <= 143364))
 					||	 (uImageSize == 143403)     //  43 byte header (Pre or Post?) + 35 Tracks * 16 Sectors/Track * 256 Bytes/Sector
 					||	 (uImageSize == 143488) );  // 128 byte header (Pre or Post?) + 35 Tracks * 16 Sectors/Track * 256 Bytes/Sector

--- a/source/DiskImageHelper.cpp
+++ b/source/DiskImageHelper.cpp
@@ -601,7 +601,7 @@ bool CImageBase::IsValidImageSize(const uint32_t uImageSize)
 	}
 	else
 	{
-		// AppleWin.chm (Disks and Disk Images > Disk Image Formats) mentions disk images of sizes 143,488 and 143,616 bytes
+		// AppleWin.chm (Disks and Disk Images > Disk Image Formats) used to mention disk images of sizes 143,488 and 143,616 bytes
 		//     "Sometimes on the Internet you will see a disk image that is 143,488 or 143,616 bytes long;"
 		// ... but doesn't mention where these magic numbers come from.
 		// Also, AppleWin doesn't even check for the 143,616 size!


### PR DESCRIPTION
@tomcw I tracked down almost all of the magic numbers for disk sizes in DiskImageHelper.cpp mentioned in #1370.

Do we need update the AppleWin.chm and change this line?

> "Sometimes on the Internet you will see a disk image that is 143,488 or 143,616 bytes long;"

To something more like this?

"Sometimes on the Internet you will see a disk image that is not 143,360 bytes long;"