### PR TITLE
Fix initial volume of SSI263 and after a Load State.

### DIFF
--- a/source/MockingboardCardManager.cpp
+++ b/source/MockingboardCardManager.cpp
@@ -299,10 +299,6 @@ bool MockingboardCardManager::Init(void)
 	if (!bRes)
 		return false;
 
-	// Volume might've been setup from value in Registry
-	if (!m_mockingboardVoice.nVolume)
-		m_mockingboardVoice.nVolume = DSBVOLUME_MAX;
-
 	hr = m_mockingboardVoice.lpDSBvoice->SetVolume(m_mockingboardVoice.nVolume);
 	LogFileOutput("MBCardMgr: SetVolume(), hr=0x%08X\n", hr);
 

--- a/source/SSI263.cpp
+++ b/source/SSI263.cpp
@@ -919,10 +919,6 @@ bool SSI263::Init(void)
 	// . NB. we have 2x SSI263 per MB card, and it's rare if 1 is used (and *extremely* rare if 2 are used!)
 	// . Not so rare, as TotalReplay (at boot) will try to detect an SSI263 (by playing a $00 phoneme).
 
-	// Volume might've been setup from value in Registry
-	if (!SSI263SingleVoice.nVolume)
-		SSI263SingleVoice.nVolume = DSBVOLUME_MAX;
-
 	hr = SSI263SingleVoice.lpDSBvoice->SetVolume(SSI263SingleVoice.nVolume);
 	LogFileOutput("SSI263::DSInit: SetVolume(), hr=0x%08X\n", hr);
 

--- a/source/SaveState.cpp
+++ b/source/SaveState.cpp
@@ -403,7 +403,11 @@ static void Snapshot_LoadState_v2(void)
 		GetVideo().SetVidHD(false);			// Set true later only if VidHDCard is instantiated
 		GetVideo().VideoResetState();
 		GetVideo().SetVideoRefreshRate(VR_60HZ);	// Default to 60Hz as older save-states won't contain refresh rate
-		GetCardMgr().GetMockingboardCardMgr().InitializeForLoadingSnapshot();	// GH#609
+
+		MockingboardCardManager &mockingboardCardManager = GetCardMgr().GetMockingboardCardMgr();
+
+		mockingboardCardManager.InitializeForLoadingSnapshot(); // GH#609
+
 #ifdef USE_SPEECH_API
 		g_Speech.Reset();
 #endif
@@ -417,7 +421,10 @@ static void Snapshot_LoadState_v2(void)
 				throw std::runtime_error("Unknown top-level scalar: " + scalar);
 		}
 
-		GetCardMgr().GetMockingboardCardMgr().SetCumulativeCycles();
+		// refresh the volume of any new SSI263 card
+		mockingboardCardManager.SetVolume(mockingboardCardManager.GetVolume(), GetPropertySheet().GetVolumeMax());
+		mockingboardCardManager.SetCumulativeCycles();
+
 		frame.SetLoadedSaveStateFlag(true);
 
 		// NB. The following disparity should be resolved:

--- a/source/SoundCore.h
+++ b/source/SoundCore.h
@@ -22,7 +22,7 @@ struct VOICE
 	{
 		bActive = false;
 		bMute = false;
-		nVolume = 0;
+		nVolume = DSBVOLUME_MAX;
 		nFadeVolume = 0;
 		dwUserVolume = 0;
 		bIsSpeaker = false;

--- a/source/Speaker.cpp
+++ b/source/Speaker.cpp
@@ -973,12 +973,6 @@ bool Spkr_DSInit()
 		return false;
 	}
 
-	SpeakerVoice.bActive = true;
-
-	// Volume might've been setup from value in Registry
-	if(!SpeakerVoice.nVolume)
-		SpeakerVoice.nVolume = DSBVOLUME_MAX;
-
 	hr = SpeakerVoice.lpDSBvoice->SetVolume(SpeakerVoice.nVolume);
 	LogFileOutput("Spkr_DSInit: SetVolume(%d) res = %08X\n", SpeakerVoice.nVolume, (uint32_t)hr);
 

--- a/source/Utilities.cpp
+++ b/source/Utilities.cpp
@@ -203,12 +203,6 @@ void LoadConfiguration(bool loadImages)
 	if(REGLOAD(REGVALUE_THE_FREEZES_F8_ROM, &dwTmp))
 		GetPropertySheet().SetTheFreezesF8Rom(dwTmp);
 
-	if(REGLOAD(REGVALUE_SPKR_VOLUME, &dwTmp))
-		SpkrSetVolume(dwTmp, GetPropertySheet().GetVolumeMax());
-
-	if(REGLOAD(REGVALUE_MB_VOLUME, &dwTmp))
-		GetCardMgr().GetMockingboardCardMgr().SetVolume(dwTmp, GetPropertySheet().GetVolumeMax());
-
 	if(REGLOAD(REGVALUE_SAVE_STATE_ON_EXIT, &dwTmp))
 		g_bSaveStateOnExit = dwTmp ? true : false;
 
@@ -286,7 +280,11 @@ void LoadConfiguration(bool loadImages)
 		}
 	}
 
-	//
+	if(REGLOAD(REGVALUE_SPKR_VOLUME, &dwTmp))
+		SpkrSetVolume(dwTmp, GetPropertySheet().GetVolumeMax());
+
+	if(REGLOAD(REGVALUE_MB_VOLUME, &dwTmp))
+		GetCardMgr().GetMockingboardCardMgr().SetVolume(dwTmp, GetPropertySheet().GetVolumeMax());
 
 	// Load save-state pathname *before* inserting any harddisk/disk images (for both init & reinit cases)
 	// NB. inserting harddisk/disk can change snapshot pathname


### PR DESCRIPTION
It was set at the maximum level rather than the MockingBoard volume.

At the same time, I have removed some redundant checks.