### PR TITLE
Debugger output error levels

### DIFF
--- a/docs/Debugger_Changelog.txt
+++ b/docs/Debugger_Changelog.txt
@@ -1,4 +1,22 @@
 /*
+2.9.3.4 Added: LOG to display debugger's current output level.
+2.9.3.3 Fixed: VERSION is always displayed regardless of console output level.
+2.9.3.2 Fixed: Duplicate symbols' address is displayed as an error.
+2.9.3.1 Added: STARTUP to re-load debugger symbol files.
+2.9.3.0 Added: LOG to control debugger's console output level verbosity.
+    No parameters will display the current level.
+    Examples of valid parameters:
+      LOG NONE
+      LOG ERROR
+      LOG WARN
+      LOG INFO
+      LOG DEFAULT
+      LOG ALL
+      LOG OFF
+      LOG ON
+
+2.9.2.8 Released with AppleWin 1.30.21.0
+
 2.9.2.8 Fixed: Debugger mem copy when source end address is less than the source start address copies too many bytes.
     Example:
         2000<6000.6ffm

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -23,7 +23,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 /* Description: Debugger
  *
- * Author: Copyright (C) 2006-2010 Michael Pohoreski
+ * Author: Copyright (C) 2006-2025 Michael Pohoreski
  */
 
 // disable warning C4786: symbol greater than 255 character:
@@ -6178,6 +6178,37 @@ Update_t CmdOutputEcho (int nArgs)
 	return ConsoleUpdate();
 }
 
+//===========================================================================
+Update_t CmdOutputLog (int nArgs)
+{
+	int iParam;
+
+	if (nArgs == 1)
+	{
+		int nFound = FindParam( g_aArgs[ 1 ].sArg, MATCH_EXACT, iParam, _PARAM_LOG_BEGIN, _PARAM_LOG_END );
+		if (nFound)
+		{
+			int eLevel = iParam - _PARAM_LOG_BEGIN;
+			if ((eLevel >= ConsoleOutputLevel_e::CONSOLE_OUTPUT_LEVEL_NONE)
+			&&  (eLevel <= ConsoleOutputLevel_e::CONSOLE_OUTPUT_LEVEL_ALL ))
+			{
+				ConsoleOutputLevelSet( (ConsoleOutputLevel_e)eLevel );
+			}
+		}
+	}
+	else
+	{
+		// Display the current console ouput level logging
+		// We need to push/pop the current level since we also need to display this
+		ConsoleOutputLevel_e eLevel = ConsoleOutputLevelGet();
+		ConsoleOutputLevelSet( ConsoleOutputLevel_e::CONSOLE_OUTPUT_LEVEL_ALL );
+			iParam = _PARAM_LOG_BEGIN + eLevel;
+			ConsolePrintFormat( "Output level set to " CHC_COMMAND "%s", g_aParameters[ iParam ].m_sName );
+		ConsoleOutputLevelSet( eLevel );
+	}
+
+	return ConsoleUpdate();
+}
 
 enum PrintState_e
 {	  PS_LITERAL
@@ -9052,7 +9083,7 @@ void DebugInitialize ()
 		}
 	}
 
-	ConsoleSetOutputLevel( ConsoleOutputLevel_e::CONSOLE_OUTPUT_LEVEL_ALL );
+	ConsoleOutputLevelSet( ConsoleOutputLevel_e::CONSOLE_OUTPUT_LEVEL_ALL );
 
 	CmdMOTD(0);
 }

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -6208,7 +6208,7 @@ Update_t CmdOutputLog (int nArgs)
 	const char *aHelp[ NUM_OUTPUT_LOG_HELP ] =
 	{
 		CHC_ERROR "Invalid parameter"                    , // NOTE: Intentionally ignore extra param
-		CHC_INFO  "Output level set to " CHC_COMMAND "%s"
+		CHC_INFO  "Verbosity level set to " CHC_COMMAND "%s"
 	};
 	const char *pHelp = NULL;
 
@@ -6235,8 +6235,7 @@ Update_t CmdOutputLog (int nArgs)
 	}
 	else
 	{
-		// TODO: Display all valid params
-		return Help_Arg_1( CMD_OUTPUT_LOG );
+		return Help_Arg_1( CMD_OUTPUT_LOG ); // Display all valid params
 	}
 
 	if (pHelp)

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -6191,8 +6191,8 @@ Usage:
 	LOG DEFAULT
 	LOG ALL
 
-	LOG OFF
-	LOG ON
+	LOG OFF  // command alias for NONE
+	LOG ON   // command alias for ALL
 */
 //===========================================================================
 Update_t CmdOutputLog (int nArgs)

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -52,7 +52,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #define MAKE_VERSION(a,b,c,d) ((a<<24) | (b<<16) | (c<<8) | (d))
 
 	// See /docs/Debugger_Changelog.txt for full details
-	const int DEBUGGER_VERSION = MAKE_VERSION(2,9,2,8);
+	const int DEBUGGER_VERSION = MAKE_VERSION(2,9,3,4);
 
 
 // Public _________________________________________________________________________________________
@@ -6178,6 +6178,22 @@ Update_t CmdOutputEcho (int nArgs)
 	return ConsoleUpdate();
 }
 
+/*
+Description:
+	Set the debugger's "error level logging" aka the console output level
+Usage:
+	LOG
+
+	LOG NONE
+	LOG ERROR
+	LOG WARN
+	LOG INFO
+	LOG DEFAULT
+	LOG ALL
+
+	LOG OFF
+	LOG ON
+*/
 //===========================================================================
 Update_t CmdOutputLog (int nArgs)
 {

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -6183,6 +6183,25 @@ Update_t CmdOutputLog (int nArgs)
 {
 	int iParam;
 
+	enum OutputLogHelp_e
+	{
+		  OUTPUT_HELP_INVALID_PARAM
+		, OUTPUT_HELP_CURRENT_LEVEL
+		, NUM_OUTPUT_LOG_HELP
+	};
+	const char *aHelp[ NUM_OUTPUT_LOG_HELP ] =
+	{
+		CHC_ERROR "Invalid parameter"                    , // NOTE: Intentionally ignore extra param
+		CHC_INFO  "Output level set to " CHC_COMMAND "%s"
+	};
+	const char *pHelp = NULL;
+
+	if (!nArgs)
+	{
+		// Display the current console ouput level logging
+		pHelp = aHelp[ OUTPUT_HELP_CURRENT_LEVEL ];
+	}
+	else
 	if (nArgs == 1)
 	{
 		int nFound = FindParam( g_aArgs[ 1 ].sArg, MATCH_EXACT, iParam, _PARAM_LOG_BEGIN, _PARAM_LOG_END );
@@ -6195,15 +6214,23 @@ Update_t CmdOutputLog (int nArgs)
 				ConsoleOutputLevelSet( (ConsoleOutputLevel_e)eLevel );
 			}
 		}
+		else
+			pHelp = aHelp[ OUTPUT_HELP_INVALID_PARAM ];
 	}
 	else
 	{
-		// Display the current console ouput level logging
-		// We need to push/pop the current level since we also need to display this
+		// TODO: Display all valid params
+		return Help_Arg_1( CMD_OUTPUT_LOG );
+	}
+
+	if (pHelp)
+	{
+		// We need to push/pop the current output level since
+		// we need to display an output message and it could be muted with the current setting
 		ConsoleOutputLevel_e eLevel = ConsoleOutputLevelGet();
 		ConsoleOutputLevelSet( ConsoleOutputLevel_e::CONSOLE_OUTPUT_LEVEL_ALL );
 			iParam = _PARAM_LOG_BEGIN + eLevel;
-			ConsolePrintFormat( "Output level set to " CHC_COMMAND "%s", g_aParameters[ iParam ].m_sName );
+			ConsolePrintFormat( pHelp, g_aParameters[ iParam ].m_sName );
 		ConsoleOutputLevelSet( eLevel );
 	}
 
@@ -9035,7 +9062,7 @@ void DebugInitialize ()
 			int nLen = strlen( pHelp ) + 2;
 			if (nLen > (CONSOLE_WIDTH-1))
 			{
-				ConsoleBufferPushFormat( "Warning: %s help is %d chars", pHelp, nLen );
+				ConsoleBufferPushFormat( CHC_WARNING "Warning: %s help is %d chars", pHelp, nLen );
 			}
 		}
 	}

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -8847,11 +8847,7 @@ void DebugDestroy ()
 //	DeleteObject(g_hFontDebugger);
 //	DeleteObject(g_hFontWebDings);
 
-	// TODO: Symbols_Clear()
-	for ( int iTable = 0; iTable < NUM_SYMBOL_TABLES; iTable++ )
-	{
-		_CmdSymbolsClear( (SymbolTable_Index_e) iTable );
-	}
+	SymbolsClear();
 	// TODO: DataDisassembly_Clear()
 
 	ReleaseConsoleFontDC();
@@ -8934,32 +8930,7 @@ void DebugInitialize ()
 	memset( g_aZeroPagePointers, 0, MAX_ZEROPAGE_POINTERS * sizeof(ZeroPagePointers_t));
 	g_nZeroPagePointers = 0;
 
-	// Load Main, Applesoft, and User Symbols
-	g_bSymbolsDisplayMissingFile = false;
-
-	g_iCommand = CMD_SYMBOLS_ROM;
-	CmdSymbolsLoad(0);
-
-	g_iCommand = CMD_SYMBOLS_APPLESOFT;
-	CmdSymbolsLoad(0);
-
-	// 2.9.2.5 Added: Symbol table A2_DOS33.SYM2
-	g_iCommand = CMD_SYMBOLS_DOS33;
-	CmdSymbolsLoad(0);
-
-	// ,0x7,0xFF // Treat zero-page as data
-	// $00 GOWARM   JSR ...
-	// $01 LOC1 DW
-	// $03 GOSTROUT JSR ...
-	// $07..$B0
-	// $B1 CHRGET
-	// $C8
-	// $C9 RNDSEED DW
-	// $D0..$FF
-
-	g_iCommand = CMD_SYMBOLS_USER_1;
-	CmdSymbolsLoad(0);
-
+	CmdDebugStartup(0);
 	g_bSymbolsDisplayMissingFile = true;
 
 #if OLD_FONT
@@ -9081,6 +9052,8 @@ void DebugInitialize ()
 		}
 	}
 
+	ConsoleSetOutputLevel( ConsoleOutputLevel_e::CONSOLE_OUTPUT_LEVEL_ALL );
+
 	CmdMOTD(0);
 }
 
@@ -9089,6 +9062,44 @@ void DebugReset (void)
 {
 	g_videoScannerDisplayInfo.Reset();
 	g_LBR = LBR_UNDEFINED;
+}
+
+
+// Load debugger script files
+// Called from DebugInitialize()
+// User can also call
+//===========================================================================
+Update_t CmdDebugStartup (int nArgs)
+{
+	SymbolsClear();
+
+	// Load Main, Applesoft, and User Symbols
+	g_bSymbolsDisplayMissingFile = false;
+
+	g_iCommand = CMD_SYMBOLS_ROM;
+	CmdSymbolsLoad(0);
+
+	g_iCommand = CMD_SYMBOLS_APPLESOFT;
+	CmdSymbolsLoad(0);
+
+	// 2.9.2.5 Added: Symbol table A2_DOS33.SYM2
+	g_iCommand = CMD_SYMBOLS_DOS33;
+	CmdSymbolsLoad(0);
+
+	// ,0x7,0xFF // Treat zero-page as data
+	// $00 GOWARM   JSR ...
+	// $01 LOC1 DW
+	// $03 GOSTROUT JSR ...
+	// $07..$B0
+	// $B1 CHRGET
+	// $C8
+	// $C9 RNDSEED DW
+	// $D0..$FF
+
+	g_iCommand = CMD_SYMBOLS_USER_1;
+	CmdSymbolsLoad(0);
+
+	return UPDATE_NOTHING;
 }
 
 // Add character to the input line

--- a/source/Debugger/Debugger_Commands.cpp
+++ b/source/Debugger/Debugger_Commands.cpp
@@ -215,12 +215,12 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 		{"NTSC"        , CmdNTSC              , CMD_NTSC                 , "Save/Load the NTSC palette"   },
 		{"TSAVE"       , CmdTextSave          , CMD_TEXT_SAVE            , "Save text screen"             },
 	// Output / Scripts
-		{"CALC"        , CmdOutputCalc        , CMD_OUTPUT_CALC          , "Display mini calc result"               },
-		{"ECHO"        , CmdOutputEcho        , CMD_OUTPUT_ECHO          , "Echo string to console"                 }, // or toggle command echoing"
-		{"LOG"         , CmdOutputLog         , CMD_OUTPUT_LOG           , "Set the console output level. Control which type of output is shown" },
-		{"PRINT"       , CmdOutputPrint       , CMD_OUTPUT_PRINT         , "Display string and/or hex values"       },
-		{"PRINTF"      , CmdOutputPrintf      , CMD_OUTPUT_PRINTF        , "Display formatted string"               },
-		{"RUN"         , CmdOutputRun         , CMD_OUTPUT_RUN           , "Run script file of debugger commands"   },
+		{"CALC"        , CmdOutputCalc        , CMD_OUTPUT_CALC          , "Display mini calc result"                    },
+		{"ECHO"        , CmdOutputEcho        , CMD_OUTPUT_ECHO          , "Echo string to console"                      }, // or toggle command echoing"
+		{"LOG"         , CmdOutputLog         , CMD_OUTPUT_LOG           , "Set the debugger verbosity level for output" },
+		{"PRINT"       , CmdOutputPrint       , CMD_OUTPUT_PRINT         , "Display string and/or hex values"            },
+		{"PRINTF"      , CmdOutputPrintf      , CMD_OUTPUT_PRINTF        , "Display formatted string"                    },
+		{"RUN"         , CmdOutputRun         , CMD_OUTPUT_RUN           , "Run script file of debugger commands"        },
 	// Source Level Debugging
 		{"SOURCE"      , CmdSource            , CMD_SOURCE               , "Starts/Stops source level debugging" },
 		{"SYNC"        , CmdSync              , CMD_SYNC                 , "Syncs the cursor to the source file" },
@@ -498,14 +498,14 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 		{"WINDOW"      , NULL, PARAM_CAT_WINDOW      },
 		{"ZEROPAGE"    , NULL, PARAM_CAT_ZEROPAGE    },
 // (Console) Output Levels
-		{"NONE"       , NULL, PARAM_LOG_NONE         },
-		{"ERROR"      , NULL, PARAM_LOG_ERROR        },
-		{"WARN"       , NULL, PARAM_LOG_WARN         },
-		{"INFO"       , NULL, PARAM_LOG_INFO         },
-		{"DEFAULT"    , NULL, PARAM_LOG_DEFAULT      },
-		{"ALL"        , NULL, PARAM_LOG_ALL          },
-		{"OFF"        , NULL, PARAM_LOG_NONE         }, // command alias for NONE
-		{"ON"         , NULL, PARAM_LOG_ALL          }, // command alias for ALL
+		{"NONE"       , NULL, PARAM_LOG_NONE        , "Show no output save for LOG status, VERSION, and MOTD" },
+		{"ERROR"      , NULL, PARAM_LOG_ERROR       , "Show errors only"                                      },
+		{"WARN"       , NULL, PARAM_LOG_WARN        , "Show warnings and errors"                              },
+		{"INFO"       , NULL, PARAM_LOG_INFO        , "Show info., warnings, and errors"                      },
+		{"DEFAULT"    , NULL, PARAM_LOG_DEFAULT     , "Show default messages, info., warnings, and errors"    },
+		{"ALL"        , NULL, PARAM_LOG_ALL         , "Show all messages"                                     },
+		{"OFF"        , NULL, PARAM_LOG_NONE        , "Alais for NONE -- show no output"                      }, // command alias for NONE
+		{"ON"         , NULL, PARAM_LOG_ALL         , "Alais for ALL -- show all output"                      }, // command alias for ALL
 // Memory
 		{"?"          , NULL, PARAM_MEM_SEARCH_WILD },
 //		{"*"          , NULL, PARAM_MEM_SEARCH_BYTE },

--- a/source/Debugger/Debugger_Commands.cpp
+++ b/source/Debugger/Debugger_Commands.cpp
@@ -504,8 +504,8 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 		{"INFO"       , NULL, PARAM_LOG_INFO        , "Show info., warnings, and errors"                      },
 		{"DEFAULT"    , NULL, PARAM_LOG_DEFAULT     , "Show default messages, info., warnings, and errors"    },
 		{"ALL"        , NULL, PARAM_LOG_ALL         , "Show all messages"                                     },
-		{"OFF"        , NULL, PARAM_LOG_NONE        , "Alais for NONE -- show no output"                      }, // command alias for NONE
-		{"ON"         , NULL, PARAM_LOG_ALL         , "Alais for ALL -- show all output"                      }, // command alias for ALL
+		{"OFF"        , NULL, PARAM_LOG_NONE        , "Alias for NONE -- show no output"                      }, // command alias for NONE
+		{"ON"         , NULL, PARAM_LOG_ALL         , "Alias for ALL -- show all output"                      }, // command alias for ALL
 // Memory
 		{"?"          , NULL, PARAM_MEM_SEARCH_WILD },
 //		{"*"          , NULL, PARAM_MEM_SEARCH_BYTE },

--- a/source/Debugger/Debugger_Commands.cpp
+++ b/source/Debugger/Debugger_Commands.cpp
@@ -320,6 +320,8 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 		{"ZPL"         , CmdZeroPageList      , CMD_ZEROPAGE_POINTER_LIST  , "List all zero page pointers"            },
 //		{"ZPLOAD"      , CmdZeroPageLoad      , CMD_ZEROPAGE_POINTER_LOAD  , "Load zero page pointers"                }, // Cant use as param to ZP
 		{"ZPSAVE"      , CmdZeroPageSave      , CMD_ZEROPAGE_POINTER_SAVE  , "Save zero page pointers"                }, // due to symbol look-up
+	// Startup/Shutdown
+		{"STARTUP"     , CmdDebugStartup      , CMD_STARTUP              , "Run debugger startup scripts"          },
 
 //	{"TIMEDEMO",CmdTimeDemo, CMD_TIMEDEMO }, // CmdBenchmarkStart(), CmdBenchmarkStop()
 //	{"WC",CmdShowCodeWindow}, // Can't use since WatchClear

--- a/source/Debugger/Debugger_Commands.cpp
+++ b/source/Debugger/Debugger_Commands.cpp
@@ -20,7 +20,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 /* Description: Debugger commands
  *
- * Author: Copyright (C) 2011 - 2011 Michael Pohoreski
+ * Author: Copyright (C) 2011 - 2025 Michael Pohoreski
  */
 
 #include "StdAfx.h"
@@ -217,6 +217,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 	// Output / Scripts
 		{"CALC"        , CmdOutputCalc        , CMD_OUTPUT_CALC          , "Display mini calc result"               },
 		{"ECHO"        , CmdOutputEcho        , CMD_OUTPUT_ECHO          , "Echo string to console"                 }, // or toggle command echoing"
+		{"LOG"         , CmdOutputLog         , CMD_OUTPUT_LOG           , "Set the console output level. Control which type of output is shown" },
 		{"PRINT"       , CmdOutputPrint       , CMD_OUTPUT_PRINT         , "Display string and/or hex values"       },
 		{"PRINTF"      , CmdOutputPrintf      , CMD_OUTPUT_PRINTF        , "Display formatted string"               },
 		{"RUN"         , CmdOutputRun         , CMD_OUTPUT_RUN           , "Run script file of debugger commands"   },
@@ -496,6 +497,15 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 		{"WATCHES"     , NULL, PARAM_CAT_WATCHES     },
 		{"WINDOW"      , NULL, PARAM_CAT_WINDOW      },
 		{"ZEROPAGE"    , NULL, PARAM_CAT_ZEROPAGE    },
+// (Console) Output Levels
+		{"NONE"       , NULL, PARAM_LOG_NONE         },
+		{"ERROR"      , NULL, PARAM_LOG_ERROR        },
+		{"WARN"       , NULL, PARAM_LOG_WARN         },
+		{"INFO"       , NULL, PARAM_LOG_INFO         },
+		{"DEFAULT"    , NULL, PARAM_LOG_DEFAULT      },
+		{"ALL"        , NULL, PARAM_LOG_ALL          },
+		{"OFF"        , NULL, PARAM_LOG_NONE         }, // command alias for NONE
+		{"ON"         , NULL, PARAM_LOG_ALL          }, // command alias for ALL
 // Memory
 		{"?"          , NULL, PARAM_MEM_SEARCH_WILD },
 //		{"*"          , NULL, PARAM_MEM_SEARCH_BYTE },

--- a/source/Debugger/Debugger_Commands.cpp
+++ b/source/Debugger/Debugger_Commands.cpp
@@ -537,7 +537,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 //		{"SYMBOL1"    , NULL, PARAM_SYMBOL_1       }, //   -     x    code/data win   
 		{"SYMBOL2"    , NULL, PARAM_SYMBOL_2       }, //   -     x    code/data win   
 // Internal Consistency Check
-		{ DEBUGGER__PARAMS_VERIFY_TXT__, NULL, NUM_PARAMS     },
+		{ DEBUGGER__PARAMS_VERIFY_TXT__, NULL, NUM_PARAMS     }
 	};
 
 //===========================================================================

--- a/source/Debugger/Debugger_Console.cpp
+++ b/source/Debugger/Debugger_Console.cpp
@@ -70,12 +70,12 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 		conchar_t g_aConsoleDisplay[ CONSOLE_HEIGHT ][ CONSOLE_WIDTH ];
 
 	// Error Level
-//		ConsoleOutputLevel_e g_eConsoleOutputLevel = ConsoleOutputLevel_e::CONSOLE_OUTPUT_LEVEL_NONE;    // Show nothing
-//		ConsoleOutputLevel_e g_eConsoleOutputLevel = ConsoleOutputLevel_e::CONSOLE_OUTPUT_LEVEL_GENERIC; // Show generic only
-//		ConsoleOutputLevel_e g_eConsoleOutputLevel = ConsoleOutputLevel_e::CONSOLE_OUTPUT_LEVEL_INFO;    // Show info and below
+//		ConsoleOutputLevel_e g_eConsoleOutputLevel = ConsoleOutputLevel_e::CONSOLE_OUTPUT_LEVEL_NONE;	 // Show nothing
+		ConsoleOutputLevel_e g_eConsoleOutputLevel = ConsoleOutputLevel_e::CONSOLE_OUTPUT_LEVEL_ERROR;   // Show error and below
 //		ConsoleOutputLevel_e g_eConsoleOutputLevel = ConsoleOutputLevel_e::CONSOLE_OUTPUT_LEVEL_WARN;    // Show info and below
-//		ConsoleOutputLevel_e g_eConsoleOutputLevel = ConsoleOutputLevel_e::CONSOLE_OUTPUT_LEVEL_ERROR;   // Show error and below
-		ConsoleOutputLevel_e g_eConsoleOutputLevel = ConsoleOutputLevel_e::CONSOLE_OUTPUT_LEVEL_ALL;
+//		ConsoleOutputLevel_e g_eConsoleOutputLevel = ConsoleOutputLevel_e::CONSOLE_OUTPUT_LEVEL_INFO;    // Show info and below
+//		ConsoleOutputLevel_e g_eConsoleOutputLevel = ConsoleOutputLevel_e::CONSOLE_OUTPUT_LEVEL_GENERIC; // Show generic and below
+//		ConsoleOutputLevel_e g_eConsoleOutputLevel = ConsoleOutputLevel_e::CONSOLE_OUTPUT_LEVEL_ALL;     // Show everything
 
 	// Input History
 		int   g_nHistoryLinesStart = 0;

--- a/source/Debugger/Debugger_Console.cpp
+++ b/source/Debugger/Debugger_Console.cpp
@@ -72,7 +72,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 	// Error Level
 //		ConsoleOutputLevel_e g_eConsoleOutputLevel = ConsoleOutputLevel_e::CONSOLE_OUTPUT_LEVEL_NONE;	 // Show nothing
 		ConsoleOutputLevel_e g_eConsoleOutputLevel = ConsoleOutputLevel_e::CONSOLE_OUTPUT_LEVEL_ERROR;   // Show error and below
-//		ConsoleOutputLevel_e g_eConsoleOutputLevel = ConsoleOutputLevel_e::CONSOLE_OUTPUT_LEVEL_WARN;    // Show info and below
+//		ConsoleOutputLevel_e g_eConsoleOutputLevel = ConsoleOutputLevel_e::CONSOLE_OUTPUT_LEVEL_WARN;    // Show warn and below
 //		ConsoleOutputLevel_e g_eConsoleOutputLevel = ConsoleOutputLevel_e::CONSOLE_OUTPUT_LEVEL_INFO;    // Show info and below
 //		ConsoleOutputLevel_e g_eConsoleOutputLevel = ConsoleOutputLevel_e::CONSOLE_OUTPUT_LEVEL_GENERIC; // Show generic and below
 //		ConsoleOutputLevel_e g_eConsoleOutputLevel = ConsoleOutputLevel_e::CONSOLE_OUTPUT_LEVEL_ALL;     // Show everything

--- a/source/Debugger/Debugger_Console.cpp
+++ b/source/Debugger/Debugger_Console.cpp
@@ -69,6 +69,14 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 		int       g_nConsoleDisplayWidth  = 0;
 		conchar_t g_aConsoleDisplay[ CONSOLE_HEIGHT ][ CONSOLE_WIDTH ];
 
+	// Error Level
+//		ConsoleOutputLevel_e g_eConsoleOutputLevel = ConsoleOutputLevel_e::CONSOLE_OUTPUT_LEVEL_NONE;    // Show nothing
+//		ConsoleOutputLevel_e g_eConsoleOutputLevel = ConsoleOutputLevel_e::CONSOLE_OUTPUT_LEVEL_GENERIC; // Show generic only
+//		ConsoleOutputLevel_e g_eConsoleOutputLevel = ConsoleOutputLevel_e::CONSOLE_OUTPUT_LEVEL_INFO;    // Show info and below
+//		ConsoleOutputLevel_e g_eConsoleOutputLevel = ConsoleOutputLevel_e::CONSOLE_OUTPUT_LEVEL_WARN;    // Show info and below
+//		ConsoleOutputLevel_e g_eConsoleOutputLevel = ConsoleOutputLevel_e::CONSOLE_OUTPUT_LEVEL_ERROR;   // Show error and below
+		ConsoleOutputLevel_e g_eConsoleOutputLevel = ConsoleOutputLevel_e::CONSOLE_OUTPUT_LEVEL_ALL;
+
 	// Input History
 		int   g_nHistoryLinesStart = 0;
 		int   g_nHistoryLinesTotal = 0; // number of commands entered

--- a/source/Debugger/Debugger_Console.h
+++ b/source/Debugger/Debugger_Console.h
@@ -23,13 +23,15 @@
 		CONSOLE_FIRST_LINE = 1, // where ConsoleDisplay is pushed up from
 	};
 
+	// Sorted by priority
+	// N.B. Keep in SYNC! _PARAM_LOG_BEGIN and ConsoleOutputLevel_e
 	enum ConsoleOutputLevel_e
 	{
 		 CONSOLE_OUTPUT_LEVEL_NONE    // log off (hide)
-		,CONSOLE_OUTPUT_LEVEL_GENERIC // TODO
-		,CONSOLE_OUTPUT_LEVEL_INFO	  // log info
-		,CONSOLE_OUTPUT_LEVEL_WARN    // log warn
 		,CONSOLE_OUTPUT_LEVEL_ERROR   // log error
+		,CONSOLE_OUTPUT_LEVEL_WARN    // log warn
+		,CONSOLE_OUTPUT_LEVEL_INFO    // log info
+		,CONSOLE_OUTPUT_LEVEL_DEFAULT // log default
 		,CONSOLE_OUTPUT_LEVEL_ALL     // log on	(show)
 	};
 
@@ -280,7 +282,7 @@
 
 		if (strText.length())
 		{
-			ConsoleOutputLevel_e eConsoleOutputLevel = CONSOLE_OUTPUT_LEVEL_GENERIC;
+			ConsoleOutputLevel_e eConsoleOutputLevel = ConsoleOutputLevel_e::CONSOLE_OUTPUT_LEVEL_DEFAULT;
 			const char *pHead = text;
 
 			while (*pHead && isspace( *pHead ))
@@ -288,14 +290,14 @@
 
 			if (*pHead == CONSOLE_COLOR_ESCAPE_CHAR)
 			{
-				if (pHead[1] == CHC_INFO   [1]) eConsoleOutputLevel = CONSOLE_OUTPUT_LEVEL_INFO ;
-				if (pHead[1] == CHC_WARNING[1]) eConsoleOutputLevel = CONSOLE_OUTPUT_LEVEL_WARN ;
-				if (pHead[1] == CHC_ERROR  [1]) eConsoleOutputLevel = CONSOLE_OUTPUT_LEVEL_ERROR;
+				if (pHead[1] == CHC_INFO   [1]) eConsoleOutputLevel = ConsoleOutputLevel_e::CONSOLE_OUTPUT_LEVEL_INFO ;
+				if (pHead[1] == CHC_WARNING[1]) eConsoleOutputLevel = ConsoleOutputLevel_e::CONSOLE_OUTPUT_LEVEL_WARN ;
+				if (pHead[1] == CHC_ERROR  [1]) eConsoleOutputLevel = ConsoleOutputLevel_e::CONSOLE_OUTPUT_LEVEL_ERROR;
 			}
 			if (eConsoleOutputLevel > g_eConsoleOutputLevel)
 				return;
 		}
-		ConsolePrint(strText.c_str());
+		ConsolePrint(text);
 	}
 	inline void ConsolePrintFormat( const char* pFormat, ... ) ATTRIBUTE_FORMAT_PRINTF(1, 2);
 	inline void ConsolePrintFormat( const char* pFormat, ... )

--- a/source/Debugger/Debugger_Console.h
+++ b/source/Debugger/Debugger_Console.h
@@ -23,7 +23,7 @@
 		CONSOLE_FIRST_LINE = 1, // where ConsoleDisplay is pushed up from
 	};
 
-	// Sorted by priority
+	// Sorted by priority from highest to lowest (least verbose to most verbose)
 	// N.B. Keep in SYNC! _PARAM_LOG_BEGIN and ConsoleOutputLevel_e
 	enum ConsoleOutputLevel_e
 	{

--- a/source/Debugger/Debugger_Console.h
+++ b/source/Debugger/Debugger_Console.h
@@ -362,14 +362,6 @@
 	Update_t ConsoleUpdate       ();
 	void     ConsoleFlush        ();
 
-	// ErrorLevel
-	inline void ConsoleSetOutputLevel (ConsoleOutputLevel_e eOutputLevel)
-	{
-		assert( eOutputLevel >= ConsoleOutputLevel_e::CONSOLE_OUTPUT_LEVEL_NONE );
-		assert( eOutputLevel <= ConsoleOutputLevel_e::CONSOLE_OUTPUT_LEVEL_ALL  );
-		g_eConsoleOutputLevel = eOutputLevel;
-	}
-
 	// Input
 	const char *ConsoleInputPeek      ();
 	bool     ConsoleInputClear     ();
@@ -381,6 +373,18 @@
 	void     ConsoleUpdateCursor( char ch );
 
 	Update_t ConsoleBufferTryUnpause (int nLines);
+
+	// Output Level
+	inline ConsoleOutputLevel_e ConsoleOutputLevelGet ()
+	{
+		return g_eConsoleOutputLevel;
+	}
+	inline void ConsoleOutputLevelSet (ConsoleOutputLevel_e eOutputLevel)
+	{
+		assert( eOutputLevel >= ConsoleOutputLevel_e::CONSOLE_OUTPUT_LEVEL_NONE );
+		assert( eOutputLevel <= ConsoleOutputLevel_e::CONSOLE_OUTPUT_LEVEL_ALL  );
+		g_eConsoleOutputLevel = eOutputLevel;
+	}
 
 	// Scrolling
 	Update_t ConsoleScrollHome   ();

--- a/source/Debugger/Debugger_Console.h
+++ b/source/Debugger/Debugger_Console.h
@@ -59,7 +59,7 @@
 	};
 	extern COLORREF g_anConsoleColor[ NUM_CONSOLE_COLORS ];
 
-	// Note: THe ` ~ key should always display ~ to prevent rendering errors
+	// Note: The [` ~] key should always display [~] to prevent rendering errors
 	#define CONSOLE_COLOR_ESCAPE_CHAR '`'
 	#define _CONSOLE_COLOR_MASK 0x7F
 

--- a/source/Debugger/Debugger_Help.cpp
+++ b/source/Debugger/Debugger_Help.cpp
@@ -1459,16 +1459,18 @@ Update_t CmdVersion (int nArgs)
 	int nFixMinor;
 	UnpackVersion( nVersion, nMajor, nMinor, nFixMajor, nFixMinor );
 
-	ConsolePrintFormat("  Emulator:  %s%s%s (%d-bit build)    Debugger: %s%d.%d.%d.%d%s"
+	// Use ConsolePrint() like CmdMOTD does so the version is always displayed
+	std::string sText = StrFormat("  Emulator:  %s%s%s (%d-bit build)    Debugger: %s%d.%d.%d.%d%s"
 		, CHC_SYMBOL
 		, g_VERSIONSTRING.c_str()
 		, CHC_DEFAULT
 		, GetCompilationTarget()
-		//
+
 		, CHC_SYMBOL
 		, nMajor, nMinor, nFixMajor, nFixMinor
 		, CHC_DEFAULT
 	);
+	ConsolePrint( sText.c_str() );
 
 	if (nArgs)
 	{

--- a/source/Debugger/Debugger_Help.cpp
+++ b/source/Debugger/Debugger_Help.cpp
@@ -1370,6 +1370,15 @@ Update_t CmdHelpSpecific (int nArgs)
 			break;
 
 	// Misc
+		case CMD_OUTPUT_LOG:
+			// Display all the params so an user knows what options are available
+			ConsoleColorizePrint( " Usage: [ <cmd> ]" );
+			ConsoleBufferPush( "  Where <cmd> is one of:" );
+			for( int iParam = _PARAM_LOG_BEGIN; iParam < _PARAM_LOG_END; iParam++ )
+				ConsolePrintFormat( "%s%-7s%s: %s", CHC_STRING, g_aParameters[ iParam ].m_sName, CHC_DEFAULT,  g_aParameters[ iParam ].pHelpSummary );
+			ConsoleBufferPush(" No arguments will display the current debugger verbosity level" );
+			break;
+
 		case CMD_VERSION:
 			ConsoleColorizePrint( " Usage: [*]" );
 			ConsoleBufferPush( "  * Display extra internal stats" );

--- a/source/Debugger/Debugger_Symbols.cpp
+++ b/source/Debugger/Debugger_Symbols.cpp
@@ -870,6 +870,14 @@ Update_t _CmdSymbolsClear( SymbolTable_Index_e eSymbolTable )
 	return UPDATE_SYMBOLS;
 }
 
+//===========================================================================
+void SymbolsClear ()
+{
+	for ( int iTable = 0; iTable < NUM_SYMBOL_TABLES; iTable++ )
+	{
+		_CmdSymbolsClear( (SymbolTable_Index_e) iTable );
+	}
+}
 
 //===========================================================================
 void SymbolUpdate ( SymbolTable_Index_e eSymbolTable, const char *pSymbolName, WORD nAddress, bool bRemoveSymbol, bool bUpdateSymbol )

--- a/source/Debugger/Debugger_Symbols.cpp
+++ b/source/Debugger/Debugger_Symbols.cpp
@@ -723,16 +723,25 @@ int ParseSymbolTable(const std::string & pPathFileName, SymbolTable_Index_e eSym
 						, CHC_DEFAULT
 						, pPathFileName.c_str()
 					);
+					ConsolePrintFormat( "%s  %s$%s%04X %s%-31s%s"
+						, CHC_ERROR
+						, CHC_ARG_SEP
+						, CHC_ADDRESS
+						, nAddress
+						, CHC_SYMBOL
+						, sName
+						, CHC_DEFAULT
+					);
 				}
-
-				ConsolePrintFormat( "  %s$%s%04X %s%-31s%s"
-					, CHC_ARG_SEP
-					, CHC_ADDRESS
-					, nAddress
-					, CHC_SYMBOL
-					, sName
-					, CHC_DEFAULT
-				);
+				else
+					ConsolePrintFormat( "  %s$%s%04X %s%-31s%s"
+						, CHC_ARG_SEP
+						, CHC_ADDRESS
+						, nAddress
+						, CHC_SYMBOL
+						, sName
+						, CHC_DEFAULT
+					);
 			}
 	
 			// else // It is not a bug to have duplicate addresses by different names

--- a/source/Debugger/Debugger_Symbols.cpp
+++ b/source/Debugger/Debugger_Symbols.cpp
@@ -715,7 +715,7 @@ int ParseSymbolTable(const std::string & pPathFileName, SymbolTable_Index_e eSym
 				if ( !bDupSymbolHeader )
 				{
 					bDupSymbolHeader = true;
-					ConsolePrintFormat( " %sDup Symbol Name%s (%s%s%s) %s"
+					ConsolePrintFormat( "%s Dup Symbol Name%s (%s%s%s) %s"
 						, CHC_ERROR
 						, CHC_DEFAULT
 						, CHC_STRING

--- a/source/Debugger/Debugger_Symbols.h
+++ b/source/Debugger/Debugger_Symbols.h
@@ -8,6 +8,7 @@
 	Update_t _CmdSymbolsClear ( SymbolTable_Index_e eSymbolTable );
 	Update_t _CmdSymbolsListTables (int nArgs, int bSymbolTables );
 	Update_t _CmdSymbolsUpdate ( int nArgs, int bSymbolTables );
+	void SymbolsClear ();
 
 	bool _CmdSymbolList_Address2Symbol ( int nAddress   , int bSymbolTables );
 	bool _CmdSymbolList_Symbol2Address ( LPCTSTR pSymbol, int bSymbolTables );

--- a/source/Debugger/Debugger_Types.h
+++ b/source/Debugger/Debugger_Types.h
@@ -277,11 +277,11 @@
 
 	struct Command_t
 	{
-		char         m_sName[ MAX_COMMAND_LEN ];
-		CmdFuncPtr_t pFunction;
-		int          iCommand;     // offset (enum) for direct command name lookup
-		const char   *pHelpSummary; // 1 line help summary
-//		Hash_t       m_nHash; // TODO
+		char          m_sName[ MAX_COMMAND_LEN ];
+		CmdFuncPtr_t  pFunction;
+		int           iCommand;     // offset (enum) for direct command name lookup
+		const char   *pHelpSummary; // 1 line help summary. It CAN be used for PARAMs.
+//		Hash_t        m_nHash; // TODO
 	};
 
 	// Commands sorted by Category

--- a/source/Debugger/Debugger_Types.h
+++ b/source/Debugger/Debugger_Types.h
@@ -438,7 +438,7 @@
 		, CMD_HELP_SPECIFIC
 		, CMD_VERSION
 		, CMD_MOTD // Message of the Day
-// Memory		
+// Memory
 		, CMD_MEMORY_COMPARE
 
 		, CMD_MEM_MINI_DUMP_HEX_1 // Mini Memory Dump 1
@@ -1517,7 +1517,7 @@ const	DisasmData_t* pDisasmData; // If != NULL then bytes are marked up as data 
 	, _PARAM_WINDOW_END
 	,  PARAM_WINDOW_NUM = _PARAM_WINDOW_END - _PARAM_WINDOW_BEGIN
 
-		, NUM_PARAMS = _PARAM_WINDOW_END // Daisy Chain
+		, NUM_PARAMS = _PARAM_WINDOW_END  // Daisy Chain
 
 // Aliases (actuall names)
 //		,PARAM_DISASM = PARAM_CODE_1

--- a/source/Debugger/Debugger_Types.h
+++ b/source/Debugger/Debugger_Types.h
@@ -582,6 +582,9 @@
 //		, CMD_ZEROPAGE_POINTER_LOAD
 		, CMD_ZEROPAGE_POINTER_SAVE
 
+// Startup/Shutdown
+		, CMD_STARTUP
+
 		, NUM_COMMANDS
 
 		, _CMD_MEM_MINI_DUMP_HEX_1_1 // Memory Dump
@@ -848,6 +851,8 @@
 	Update_t CmdZeroPageSave       (int nArgs);
 	Update_t CmdZeroPagePointer    (int nArgs);
 
+// Startup/Shutdown
+	Update_t CmdDebugStartup       (int nArgs);
 
 // Cursor _________________________________________________________________________________________
 	enum Cursor_Align_e

--- a/source/Debugger/Debugger_Types.h
+++ b/source/Debugger/Debugger_Types.h
@@ -471,6 +471,7 @@
 // Output
 		, CMD_OUTPUT_CALC
 		, CMD_OUTPUT_ECHO
+		, CMD_OUTPUT_LOG
 		, CMD_OUTPUT_PRINT
 		, CMD_OUTPUT_PRINTF
 		, CMD_OUTPUT_RUN
@@ -741,6 +742,7 @@
 // Output/Scripts
 	Update_t CmdOutputCalc         (int nArgs);
 	Update_t CmdOutputEcho         (int nArgs);
+	Update_t CmdOutputLog          (int nArgs);
 	Update_t CmdOutputPrint        (int nArgs);
 	Update_t CmdOutputPrintf       (int nArgs);
 	Update_t CmdOutputRun          (int nArgs);
@@ -1464,7 +1466,18 @@ const	DisasmData_t* pDisasmData; // If != NULL then bytes are marked up as data 
 	, _PARAM_HELPCATEGORIES_END
 	,  PARAM_HELPCATEGORIES_NUM = _PARAM_HELPCATEGORIES_END - _PARAM_HELPCATEGORIES_BEGIN
 
-	, _PARAM_MEM_SEARCH_BEGIN = _PARAM_HELPCATEGORIES_END  // Daisy Chain
+	, _PARAM_LOG_BEGIN = _PARAM_HELPCATEGORIES_END // Daisy Chain
+		// Console Output Levels aka Error Levels
+		, PARAM_LOG_NONE = _PARAM_LOG_BEGIN
+		, PARAM_LOG_GENERIC
+		, PARAM_LOG_INFO
+		, PARAM_LOG_WARN
+		, PARAM_LOG_ERROR
+		, PARAM_LOG_ALL
+	, _PARAM_LOG_END
+	,  PARAM_LOG_NUM = _PARAM_LOG_END - _PARAM_LOG_BEGIN
+
+	, _PARAM_MEM_SEARCH_BEGIN = _PARAM_LOG_END  // Daisy Chain
 		, PARAM_MEM_SEARCH_WILD = _PARAM_MEM_SEARCH_BEGIN
 //		, PARAM_MEM_SEARCH_BYTE
 	, _PARAM_MEM_SEARCH_END

--- a/source/Debugger/Debugger_Types.h
+++ b/source/Debugger/Debugger_Types.h
@@ -1468,12 +1468,14 @@ const	DisasmData_t* pDisasmData; // If != NULL then bytes are marked up as data 
 
 	, _PARAM_LOG_BEGIN = _PARAM_HELPCATEGORIES_END // Daisy Chain
 		// Console Output Levels aka Error Levels
-		, PARAM_LOG_NONE = _PARAM_LOG_BEGIN
-		, PARAM_LOG_GENERIC
-		, PARAM_LOG_INFO
-		, PARAM_LOG_WARN
+		, PARAM_LOG_NONE = _PARAM_LOG_BEGIN  // N.B. Keep in SYNC! _PARAM_LOG_BEGIN and ConsoleOutputLevel_e
 		, PARAM_LOG_ERROR
+		, PARAM_LOG_WARN
+		, PARAM_LOG_INFO
+		, PARAM_LOG_DEFAULT
 		, PARAM_LOG_ALL
+		, PARAM_LOG_OFF // command alias for NONE
+		, PARAM_LOG_ON  // command alias for ALL
 	, _PARAM_LOG_END
 	,  PARAM_LOG_NUM = _PARAM_LOG_END - _PARAM_LOG_BEGIN
 


### PR DESCRIPTION
See #1420 and #1421 for details.

@tomcw I'm very happy with this functionality. I can control the amount of debugger startup spam `LOG *` , view the current level, and easily reload the debugger symbol files `STARTUP`.

I think we're good to merge?

