### PR TITLE
Debugger: Fix right arrow follow branch address

### DIFF
--- a/docs/Debugger_Changelog.txt
+++ b/docs/Debugger_Changelog.txt
@@ -1,4 +1,11 @@
 /*
+2.9.4.0 Fixed right arrow follow branch address when target branch address was negative ($81 .. $FF)
+    Example:
+        2FE:90 81
+        2FE:90 FF
+
+2.9.3.4 Released with AppleWin 1.31.0.0
+
 2.9.3.4 Added: LOG to display debugger's current output level.
 2.9.3.3 Fixed: VERSION is always displayed regardless of console output level.
 2.9.3.2 Fixed: Duplicate symbols' address is displayed as an error.

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -52,7 +52,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #define MAKE_VERSION(a,b,c,d) ((a<<24) | (b<<16) | (c<<8) | (d))
 
 	// See /docs/Debugger_Changelog.txt for full details
-	const int DEBUGGER_VERSION = MAKE_VERSION(2,9,3,4);
+	const int DEBUGGER_VERSION = MAKE_VERSION(2,9,4,0);
 
 
 // Public _________________________________________________________________________________________

--- a/source/Debugger/Debugger_Assembler.cpp
+++ b/source/Debugger/Debugger_Assembler.cpp
@@ -782,7 +782,7 @@ bool _6502_GetTargets (WORD nAddress, int *pTargetPartial_, int *pTargetPartial2
 				if (nTarget8 <= _6502_BRANCH_POS)
 					*pTargetPointer_ += nTarget8; // +
 				else
-					*pTargetPointer_ -= nTarget8; // -
+					*pTargetPointer_ -= (256 - nTarget8); // -  Two's complement
 
 				*pTargetPointer_ &= _6502_MEM_END;
 


### PR DESCRIPTION
Simple fix for Fix right arrow follow branch address when target branch ad…dress was negative ($81 .. $FF)