### PR TITLE
Debugger: Fix right arrow follow bytes marked up as data. (#1382)

### DIFF
--- a/docs/Debugger_Changelog.txt
+++ b/docs/Debugger_Changelog.txt
@@ -1,4 +1,15 @@
 /*
+2.9.4.1 Fixed right arrow follow data
+    Example:
+        222A:2C 22 34
+        DA 222A
+        R PC 222A
+        Right-Arrow
+    And
+        2220:41 42 42 00
+        ASC 2220:2220+3
+        R PC 2220
+        Right-Arrow
 2.9.4.0 Fixed right arrow follow branch address when target branch address was negative ($81 .. $FF)
     Example:
         2FE:90 81

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -52,7 +52,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #define MAKE_VERSION(a,b,c,d) ((a<<24) | (b<<16) | (c<<8) | (d))
 
 	// See /docs/Debugger_Changelog.txt for full details
-	const int DEBUGGER_VERSION = MAKE_VERSION(2,9,4,0);
+	const int DEBUGGER_VERSION = MAKE_VERSION(2,9,4,1);
 
 
 // Public _________________________________________________________________________________________

--- a/source/Debugger/Debugger_Assembler.cpp
+++ b/source/Debugger/Debugger_Assembler.cpp
@@ -822,12 +822,26 @@ bool _6502_GetTargets (WORD nAddress, int *pTargetPartial_, int *pTargetPartial2
 //===========================================================================
 bool _6502_GetTargetAddress ( const WORD & nAddress, WORD & nTarget_ )
 {
-	int iOpcode;
-	int iOpmode;
-	int nOpbytes;
-	iOpcode = _6502_GetOpmodeOpbyte( nAddress, iOpmode, nOpbytes );
-
-	// Composite string that has the target nAddress
+	      int              iOpcode;
+	      int              iOpmode;
+	      AddressingMode_e eOpmode;
+	      int              nOpbytes;
+	const DisasmData_t    *pDisasmData = NULL;
+	iOpcode = _6502_GetOpmodeOpbyte( nAddress, iOpmode, nOpbytes, &pDisasmData );
+	eOpmode = (AddressingMode_e) iOpmode;
+	if (eOpmode == AM_DATA)
+	{
+		// We have pure data, such as a string, that has no target address
+		// TODO: UI: We should flash the cursor line red to signal the user that we can't follow a nonexistent target address.
+		return false;
+	}
+	else
+	if (pDisasmData && nOpbytes)
+	{
+		// User marked bytes up as custom data
+		nTarget_ = pDisasmData->nTargetAddress;
+		return true;
+	}
 
 	if ((iOpmode != AM_IMPLIED) &&
 		(iOpmode != AM_1) &&


### PR DESCRIPTION
This was similar to #1451 via `_6502_GetTargetAddress()`.

Add two repo cases:

```
        222A:2C 22 34
        DA 222A
        R PC 222A
        Right-Arrow
```
and
```
        2220:41 42 42 00
        ASC 2220:2220+3
        R PC 2220
        Right-Arrow
```