### PR TITLE
Debugger: Added: QoL right arrow on RTS to use the stack return address

### DIFF
--- a/docs/Debugger_Changelog.txt
+++ b/docs/Debugger_Changelog.txt
@@ -1,5 +1,13 @@
 /*
-2.9.4.1 Fixed right arrow follow data
+2.9.4.2 Added: QoL right arrow on RTS to use the stack return address (GH #1456)
+    Example:
+       100:61 FA
+       1FD:FD FE FF 00
+       R PC FBFC
+       R S FD   ; FFFF sans overflow
+       R S FE   ; 6200 with overflow
+       R S FF   ; FA62 with overflow
+2.9.4.1 Fixed: Right arrow follow bytes marked up as data (GH #1455)
     Example:
         222A:2C 22 34
         DA 222A
@@ -10,7 +18,7 @@
         ASC 2220:2220+3
         R PC 2220
         Right-Arrow
-2.9.4.0 Fixed right arrow follow branch address when target branch address was negative ($81 .. $FF)
+2.9.4.0 Fixed: Right arrow follow branch address when target branch address was negative ($81 .. $FF) (GH #1451)
     Example:
         2FE:90 81
         2FE:90 FF

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -52,7 +52,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #define MAKE_VERSION(a,b,c,d) ((a<<24) | (b<<16) | (c<<8) | (d))
 
 	// See /docs/Debugger_Changelog.txt for full details
-	const int DEBUGGER_VERSION = MAKE_VERSION(2,9,4,1);
+	const int DEBUGGER_VERSION = MAKE_VERSION(2,9,4,2);
 
 
 // Public _________________________________________________________________________________________


### PR DESCRIPTION
Small QoL when tracing into a function. Can use `->` on a function's `RTS` to move to the return address.

@tomcw  We have a few ways of handling the edge case of the stack wrap-around -- maybe something we might want to re-factor in the furture? I'm _not_ worrying about [micro-optimizations](https://godbolt.org/) since it is an edge case and this is good enough for now.

```c
#include <stdint.h>

// 
// int RetLo = ReadByteFromMemory( ((nStackAddr + 0) & _6502_STACK_END) | _6502_STACK_BEGIN );
// int RetHi = ReadByteFromMemory( ((nStackAddr + 1) & _6502_STACK_END) | _6502_STACK_BEGIN );
// nReturnAddr = (RetHi << 8) | RetLo;
uint16_t foo( uint16_t s)
{
    uint16_t lo = ((s+0) & 0x1FF) | 0x100;
    uint16_t hi = ((s+1) & 0x1FF) | 0x100;
    uint16_t addr = (hi << 8) | lo;
    return addr;
}

//	*pTargetPartial_  = _6502_STACK_BEGIN + ((sp+1) & 0xFF);
//	*pTargetPartial2_ = _6502_STACK_BEGIN + ((sp+2) & 0xFF);
// 	nTarget16 = ReadByteFromMemory(*pTargetPartial_) + (ReadByteFromMemory(*pTargetPartial2_) << 8);
uint16_t bar( uint16_t s )
{
    uint16_t lo = 0x100 + ((s + 0) & 0xFF);
    uint16_t hi = 0x100 + ((s + 1) & 0xFF);
    uint16_t addr = (hi << 8) | lo;
    return addr;
}

uint16_t qaz( uint16_t s)
{
    uint16_t lo = 0x100 + ((s+0) & 0xFF);
    uint16_t hi = 0x100 + ((s+1) & 0xFF);
    uint16_t addr = (hi << 8) | lo;
    return addr;
}
```

Generates:

```asm
s$ = 8
unsigned short foo(unsigned short) PROC                                 ; foo, COMDAT
        mov     eax, 255                      ; 000000ffH
        mov     edx, 256                      ; 00000100H
        and     cx, ax
        movzx   eax, cx
        ror     ax, 8
        add     ax, dx
        xor     ax, cx
        or      ax, dx
        ret     0
unsigned short foo(unsigned short) ENDP                                 ; foo

s$ = 8
unsigned short bar(unsigned short) PROC                                 ; bar, COMDAT
        mov     eax, 255                      ; 000000ffH
        mov     r8d, 256                      ; 00000100H
        and     cx, ax
        mov     edx, 65280                                ; 0000ff00H
        movzx   eax, cx
        add     cx, r8w
        ror     ax, 8
        add     ax, r8w
        and     ax, dx
        or      ax, cx
        ret     0
unsigned short bar(unsigned short) ENDP                                 ; bar

s$ = 8
unsigned short qaz(unsigned short) PROC                                 ; qaz, COMDAT
        mov     eax, 255                      ; 000000ffH
        mov     r8d, 256                      ; 00000100H
        and     cx, ax
        mov     edx, 65280                                ; 0000ff00H
        movzx   eax, cx
        add     cx, r8w
        ror     ax, 8
        add     ax, r8w
        and     ax, dx
        or      ax, cx
        ret     0
unsigned short qaz(unsigned short) ENDP                                 ; qaz
```

And with gcc

```asm
foo(unsigned short):
        lea     eax, [rdi+1]
        movzx   edi, dil
        sal     eax, 8
        or      eax, edi
        or      ah, 1
        ret
bar(unsigned short):
        lea     eax, [rdi+1]
        movzx   edi, dil
        sal     eax, 8
        add     di, 256
        or      eax, edi
        ret
qaz(unsigned short):
        lea     eax, [rdi+1]
        movzx   edi, dil
        sal     eax, 8
        add     di, 256
        or      eax, edi
        ret
```