### PR TITLE
Fix edge case when formatting a 32 MB ProDOS volume. Fixes: GH #1469 32-MB HD creation.

### DIFF
--- a/source/ProDOS_FileSystem.h
+++ b/source/ProDOS_FileSystem.h
@@ -27,12 +27,13 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 // --- ProDOS Consts ---
 
-	const size_t PRODOS_BLOCK_SIZE   = 0x200; // 512 bytes/block
-	const size_t PRODOS_ROOT_BLOCK   = 2;
-	const int    PRODOS_ROOT_OFFSET  = PRODOS_ROOT_BLOCK * PRODOS_BLOCK_SIZE;
+	const size_t  PRODOS_MAX_BLOCKS   = 0xFFFF; // Volume total_blocks (32 MB volume is special. i.e. 140 KB = 280 Blocks, 800 KB = 1600 Blocks)
+	const size_t  PRODOS_BLOCK_SIZE   = 0x200;  // 512 bytes/block
+	const size_t  PRODOS_ROOT_BLOCK   = 2;
+	const int     PRODOS_ROOT_OFFSET  = PRODOS_ROOT_BLOCK * PRODOS_BLOCK_SIZE;
 
-	const int    PRODOS_MAX_FILENAME = 15;
-	const int    PRODOS_MAX_PATH     = 64; // TODO: Verify
+	const int     PRODOS_MAX_FILENAME = 15;
+	const int     PRODOS_MAX_PATH     = 64; // TODO: Verify
 
 	const uint8_t ACCESS_D = 0x80; // Can destroy
 	const uint8_t ACCESS_N = 0x40; // Can rename
@@ -300,8 +301,8 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 		memset( &pDiskBytes[ offset ], 0xFF, size );
 
 		// GH #1469 32-MB HD creation bug
-		volume->meta.total_blocks = (blocks > 0xFFFF) // ProDOS MAX VOLUME BLOCKS
-			? (uint16_t)0xFFFF
+		volume->meta.total_blocks = (blocks > PRODOS_MAX_BLOCKS)
+			? (uint16_t)PRODOS_MAX_BLOCKS
 			: (uint16_t)blocks
 			;
 		return (int)((size + PRODOS_BLOCK_SIZE - 1) / PRODOS_BLOCK_SIZE);


### PR DESCRIPTION
Sorry for typo in commit message. Fixed and forced pushed (this branch.)

Details in #1469