### PR TITLE
fixes Scroll Lock link to Configuration help

### DIFF
--- a/help/keyboard.html
+++ b/help/keyboard.html
@@ -67,7 +67,7 @@
 			</p>
 		<p><span style="font-weight: bold;">Scroll Lock:</span><br>
 			<span style="font-style: italic;">Scroll Lock</span>
-			key can be configured to toggle normal/full-speed mode, or only enable full-speed when pressed. See <a href="cfg-input.html">Input</a> for configuring how <span style="font-style: italic;">Scroll Lock</span> behaves.
+			key can be configured to toggle normal/full-speed mode, or only enable full-speed when pressed. See <a href="cfg-config.html">Configuration Settings</a> for configuring how <span style="font-style: italic;">Scroll Lock</span> behaves.
 			NOTE:&nbsp;The status of the PC's
 			<span style="font-style: italic;">Scroll Lock</span>
 			LED is meaningless.</p>


### PR DESCRIPTION
The Scroll Lock section of the Keyboard help file was pointed to the wrong Configuration file.

I don't know how to build the help file, so this hasn't been tested.