### PR TITLE
Replace some BOOL usages with proper bool

### DIFF
--- a/source/Common.h
+++ b/source/Common.h
@@ -233,7 +233,7 @@ inline bool IsApple2PlusOrClone(eApple2Type type)	// Apple ][,][+,][J-Plus or cl
 
 inline bool IsAppleIIe(eApple2Type type)			// Apple //e,Enhanced//e or clone //e,Enhanced//e
 {
-	return type & APPLE2E_MASK;
+	return (type & APPLE2E_MASK) != 0;
 }
 
 inline bool IsAppleIIeOrAbove(eApple2Type type)		// Apple //e,Enhanced//e,//c or clone //e,Enhanced//e

--- a/source/Configuration/Config.cpp
+++ b/source/Configuration/Config.cpp
@@ -194,7 +194,7 @@ void CConfigNeedingRestart::Reload()
 	m_uSaveLoadStateMsg = 0;
 	m_saveStateOnExit = GetSaveStateOnExit();
 	char ciderPressPathname[MAX_PATH];
-	RegLoadString(REG_CONFIG, REGVALUE_CIDERPRESSLOC, 1, ciderPressPathname, MAX_PATH, "");
+	RegLoadString(REG_CONFIG, REGVALUE_CIDERPRESSLOC, true, ciderPressPathname, MAX_PATH, "");
 	m_ciderPressPathname = ciderPressPathname;
 	m_enableTheFreezesF8Rom = GetPropertySheet().GetTheFreezesF8Rom();
 	m_gameIOConnectorType = GetCopyProtectionDongleType();

--- a/source/Configuration/PageAdvanced.cpp
+++ b/source/Configuration/PageAdvanced.cpp
@@ -219,10 +219,10 @@ void CPageAdvanced::ApplyConfigAfterClose()
 		m_PropertySheetHelper.SaveStateUpdate();
 	}
 
-	RegSaveString(REG_CONFIG, REGVALUE_CIDERPRESSLOC, 1, m_PropertySheetHelper.GetConfigNew().m_ciderPressPathname.c_str());
+	RegSaveString(REG_CONFIG, REGVALUE_CIDERPRESSLOC, true, m_PropertySheetHelper.GetConfigNew().m_ciderPressPathname);
 
 	SetSaveStateOnExit(m_PropertySheetHelper.GetConfigNew().m_saveStateOnExit);
-	REGSAVE(REGVALUE_SAVE_STATE_ON_EXIT, m_PropertySheetHelper.GetConfigNew().m_saveStateOnExit ? 1 : 0);
+	REGSAVE(REGVALUE_SAVE_STATE_ON_EXIT, m_PropertySheetHelper.GetConfigNew().m_saveStateOnExit);
 
 	// Save the copy protection dongle type
 	SetCopyProtectionDongleType(m_PropertySheetHelper.GetConfigNew().m_gameIOConnectorType);

--- a/source/Configuration/PageConfig.cpp
+++ b/source/Configuration/PageConfig.cpp
@@ -307,7 +307,7 @@ void CPageConfig::ApplyConfigAfterClose()
 {
 	Win32Frame& win32Frame = Win32Frame::GetWin32Frame();
 
-	const BOOL bNewConfirmReboot = m_PropertySheetHelper.GetConfigNew().m_confirmReboot ? 1 : 0;
+	const bool bNewConfirmReboot = m_PropertySheetHelper.GetConfigNew().m_confirmReboot;
 	if (win32Frame.g_bConfirmReboot != bNewConfirmReboot)
 	{
 		REGSAVE(REGVALUE_CONFIRM_REBOOT, bNewConfirmReboot);
@@ -372,7 +372,7 @@ void CPageConfig::ApplyConfigAfterClose()
 	const bool bNewFSSubunitStatus = m_PropertySheetHelper.GetConfigNew().m_fullScreen_ShowSubunitStatus;
 	if (win32Frame.GetFullScreenShowSubunitStatus() != bNewFSSubunitStatus)
 	{
-		REGSAVE(REGVALUE_FS_SHOW_SUBUNIT_STATUS, bNewFSSubunitStatus ? 1 : 0);
+		REGSAVE(REGVALUE_FS_SHOW_SUBUNIT_STATUS, bNewFSSubunitStatus);
 		win32Frame.SetFullScreenShowSubunitStatus(bNewFSSubunitStatus);
 
 		if (win32Frame.IsFullScreen())
@@ -385,7 +385,7 @@ void CPageConfig::ApplyConfigAfterClose()
 	if (GetCardMgr().GetDisk2CardMgr().GetEnhanceDisk() != bNewEnhanceDisk)
 	{
 		GetCardMgr().GetDisk2CardMgr().SetEnhanceDisk(bNewEnhanceDisk);
-		REGSAVE(REGVALUE_ENHANCE_DISK_SPEED, bNewEnhanceDisk ? 1 : 0);
+		REGSAVE(REGVALUE_ENHANCE_DISK_SPEED, bNewEnhanceDisk);
 	}
 
 	const UINT newScrollLockToggle = m_PropertySheetHelper.GetConfigNew().m_scrollLockToggle;

--- a/source/Configuration/PageSlots.cpp
+++ b/source/Configuration/PageSlots.cpp
@@ -701,7 +701,7 @@ void CPageSlots::DlgDisk2OK(HWND hWnd)
 
 		if (win32Frame.GetWindowedModeShowDiskiiStatus() != bNewDiskiiStatus)
 		{
-			REGSAVE(REGVALUE_SHOW_DISKII_STATUS, bNewDiskiiStatus ? 1 : 0);
+			REGSAVE(REGVALUE_SHOW_DISKII_STATUS, bNewDiskiiStatus);
 			win32Frame.SetWindowedModeShowDiskiiStatus(bNewDiskiiStatus);
 
 			if (!win32Frame.IsFullScreen())

--- a/source/Configuration/PropertySheetHelper.cpp
+++ b/source/Configuration/PropertySheetHelper.cpp
@@ -148,7 +148,7 @@ void CPropertySheetHelper::SetSlot(UINT slot, SS_CARDTYPE newCardType)
 std::string CPropertySheetHelper::BrowseToFile(HWND hWindow, const char* pszTitle, const char* REGVALUE, const char* FILEMASKS)
 {
 	char szFilename[MAX_PATH];
-	RegLoadString(REG_CONFIG, REGVALUE, 1, szFilename, MAX_PATH, "");
+	RegLoadString(REG_CONFIG, REGVALUE, true, szFilename, MAX_PATH, "");
 	std::string pathname = szFilename;
 
 	OPENFILENAME ofn;
@@ -179,7 +179,7 @@ void CPropertySheetHelper::SaveStateUpdate()
 	if (m_bSSNewFilename)
 	{
 		Snapshot_SetFilename(m_szSSNewFilename, m_szSSNewDirectory);
-		RegSaveString(REG_CONFIG, REGVALUE_SAVESTATE_FILENAME, 1, Snapshot_GetPathname());
+		RegSaveString(REG_CONFIG, REGVALUE_SAVESTATE_FILENAME, true, Snapshot_GetPathname());
 	}
 }
 
@@ -400,7 +400,7 @@ void CPropertySheetHelper::ApplyNewConfigForRestart()
 		REGSAVE(REGVALUE_THE_FREEZES_F8_ROM, m_ConfigNew.m_enableTheFreezesF8Rom);
 
 	if (CONFIG_CHANGED(m_NoSlotClock))
-		REGSAVE(REGVALUE_NO_SLOT_CLOCK, m_ConfigNew.m_NoSlotClock ? 1 : 0);
+		REGSAVE(REGVALUE_NO_SLOT_CLOCK, m_ConfigNew.m_NoSlotClock);
 }
 
 // Called from Snapshot_LoadState_v2()
@@ -435,7 +435,7 @@ void CPropertySheetHelper::ApplyNewConfigFromSnapshot()
 	SetRamWorksMemorySize(config.m_RamWorksMemorySize);
 	REGSAVE(REGVALUE_VIDEO_REFRESH_RATE, config.m_videoRefreshRate);
 	//REGSAVE(REGVALUE_THE_FREEZES_F8_ROM, config.m_bEnableTheFreezesF8Rom);	// Not currently in save-state
-	REGSAVE(REGVALUE_NO_SLOT_CLOCK, config.m_NoSlotClock ? 1 : 0);
+	REGSAVE(REGVALUE_NO_SLOT_CLOCK, config.m_NoSlotClock);
 }
 
 // Called when PSPs are created

--- a/source/Core.cpp
+++ b/source/Core.cpp
@@ -264,7 +264,7 @@ bool CheckOldAppleWinVersion(void)
 {
 	const int VERSIONSTRING_SIZE = 16;
 	char szOldAppleWinVersion[VERSIONSTRING_SIZE + 1];
-	RegLoadString(REG_CONFIG, REGVALUE_VERSION, TRUE, szOldAppleWinVersion, VERSIONSTRING_SIZE, "");
+	RegLoadString(REG_CONFIG, REGVALUE_VERSION, true, szOldAppleWinVersion, VERSIONSTRING_SIZE, "");
 	const bool bShowAboutDlg = (g_VERSIONSTRING != szOldAppleWinVersion);
 
 	// version: xx.yy.zz.ww

--- a/source/Debugger/Debug.cpp
+++ b/source/Debugger/Debug.cpp
@@ -4824,7 +4824,7 @@ Update_t CmdMemoryLoad (int nArgs)
 
 			memcpy(pMemBankBase + nAddressStart, pMemory.get() + nAddressStart, nAddressLen);
 
-			MemUpdatePaging(TRUE);
+			MemUpdatePaging(true);
 		}
 		else
 		{

--- a/source/Disk.cpp
+++ b/source/Disk.cpp
@@ -79,7 +79,7 @@ Disk2InterfaceCard::Disk2InterfaceCard(UINT slot) :
 	uint32_t tmp;
 	std::string regSection = RegGetConfigSlotSection(m_slot);
 	const uint32_t kForce13SectorFirmware_Default = 0;
-	RegLoadValue(regSection.c_str(), REGVALUE_DISKII_13_SECTOR_FIRMWARE, TRUE, &tmp, kForce13SectorFirmware_Default);
+	RegLoadValue(regSection.c_str(), REGVALUE_DISKII_13_SECTOR_FIRMWARE, true, &tmp, kForce13SectorFirmware_Default);
 	m_force13SectorFirmware = tmp ? true : false;
 
 	ResetLogicStateSequencer();
@@ -208,7 +208,7 @@ void Disk2InterfaceCard::LoadLastDiskImage(const int drive)
 	char pathname[MAX_PATH];
 
 	std::string regSection = RegGetConfigSlotSection(m_slot);
-	if (RegLoadString(regSection.c_str(), regKey.c_str(), TRUE, pathname, MAX_PATH, "") && (pathname[0] != 0))
+	if (RegLoadString(regSection.c_str(), regKey.c_str(), true, pathname, MAX_PATH, "") && (pathname[0] != 0))
 	{
 		m_saveDiskImage = false;
 		ImageError_e error = InsertDisk(drive, pathname, IMAGE_USE_FILES_WRITE_PROTECT_STATUS, IMAGE_DONT_CREATE);
@@ -232,7 +232,7 @@ void Disk2InterfaceCard::SaveLastDiskImage(const int drive)
 		return;
 
 	std::string regSection = RegGetConfigSlotSection(m_slot);
-	RegSaveValue(regSection.c_str(), REGVALUE_CARD_TYPE, TRUE, CT_Disk2);
+	RegSaveValue(regSection.c_str(), REGVALUE_CARD_TYPE, true, CT_Disk2);
 
 	const std::string regKey = (drive == DRIVE_1)
 		? REGVALUE_LAST_DISK_1
@@ -240,7 +240,7 @@ void Disk2InterfaceCard::SaveLastDiskImage(const int drive)
 
 	const std::string& pathName = DiskGetFullPathName(drive);
 
-	RegSaveString(regSection.c_str(), regKey.c_str(), TRUE, pathName);
+	RegSaveString(regSection.c_str(), regKey.c_str(), true, pathName);
 
 	//
 
@@ -253,7 +253,7 @@ void Disk2InterfaceCard::SaveLastDiskImage(const int drive)
 	if (slash != std::string::npos)
 	{
 		const std::string dirName = pathName.substr(0, slash + 1);
-		RegSaveString(REG_PREFS, REGVALUE_PREF_START_DIR, 1, dirName);
+		RegSaveString(REG_PREFS, REGVALUE_PREF_START_DIR, true, dirName);
 	}
 }
 
@@ -1844,7 +1844,7 @@ bool Disk2InterfaceCard::UserSelectNewDiskImageOnly(const int drive, LPCSTR pszF
 
 	StringCbCopy(filename, MAX_PATH, pszFilename);
 
-	RegLoadString(REG_PREFS, REGVALUE_PREF_START_DIR, 1, directory, MAX_PATH, "");
+	RegLoadString(REG_PREFS, REGVALUE_PREF_START_DIR, true, directory, MAX_PATH, "");
 	std::string title = StrFormat("Select Disk Image For Drive %d", drive + 1);
 
 	OPENFILENAME ofn;
@@ -2068,7 +2068,7 @@ void Disk2InterfaceCard::Set13SectorFirmware(const bool is13Sector)
 	m_force13SectorFirmware = is13Sector;
 
 	std::string regSection = RegGetConfigSlotSection(m_slot);
-	RegSaveValue(regSection.c_str(), REGVALUE_DISKII_13_SECTOR_FIRMWARE, TRUE, is13Sector ? 1 : 0);
+	RegSaveValue(regSection.c_str(), REGVALUE_DISKII_13_SECTOR_FIRMWARE, true, is13Sector);
 }
 
 bool Disk2InterfaceCard::GetFirmware(WORD lpNameId, BYTE* pDst)

--- a/source/FrameBase.cpp
+++ b/source/FrameBase.cpp
@@ -9,7 +9,7 @@ FrameBase::FrameBase()
 {
 	g_hFrameWindow = (HWND)0;
 	g_bConfirmReboot = kConfirmReboot_Default;
-	g_bMultiMon = 0; // OFF = load window position & clamp initial frame to screen, ON = use window position as is
+	g_bMultiMon = false; // OFF = load window position & clamp initial frame to screen, ON = use window position as is
 	g_bFreshReset = false;
 	g_hInstance = (HINSTANCE)0;
 	g_bDisplayPrintScreenFileName = false;

--- a/source/FrameBase.h
+++ b/source/FrameBase.h
@@ -2,7 +2,7 @@
 
 #include "Video.h"
 
-const BOOL kConfirmReboot_Default = TRUE;
+constexpr bool kConfirmReboot_Default = true;
 
 class NetworkBackend;
 class SoundBuffer;
@@ -16,8 +16,8 @@ public:
 
 	HINSTANCE  g_hInstance;
 	HWND       g_hFrameWindow;
-	BOOL       g_bConfirmReboot; // saved PageConfig REGSAVE
-	BOOL       g_bMultiMon;
+	bool       g_bConfirmReboot; // saved PageConfig REGSAVE
+	bool       g_bMultiMon;
 	bool       g_bFreshReset;
 
 	virtual void Initialize(bool resetVideoState) = 0;

--- a/source/Harddisk.cpp
+++ b/source/Harddisk.cpp
@@ -185,7 +185,7 @@ HarddiskInterfaceCard::HarddiskInterfaceCard(UINT slot) :
 
 	uint32_t tmp;
 	std::string regSection = RegGetConfigSlotSection(m_slot);
-	RegLoadValue(regSection.c_str(), REGVALUE_HDC_FIRMWARE, TRUE, &tmp, HdcDefault);
+	RegLoadValue(regSection.c_str(), REGVALUE_HDC_FIRMWARE, true, &tmp, HdcDefault);
 	m_useHdcFirmwareMode = (HdcMode)tmp;
 }
 
@@ -215,7 +215,7 @@ void HarddiskInterfaceCard::SetHdcFirmwareMode(HdcMode hdcMode)
 	m_useHdcFirmwareMode = hdcMode;
 
 	std::string regSection = RegGetConfigSlotSection(m_slot);
-	RegSaveValue(regSection.c_str(), REGVALUE_HDC_FIRMWARE, TRUE, (UINT)m_useHdcFirmwareMode);
+	RegSaveValue(regSection.c_str(), REGVALUE_HDC_FIRMWARE, true, m_useHdcFirmwareMode);
 }
 
 void HarddiskInterfaceCard::InitializeIO(LPBYTE pCxRomPeripheral)
@@ -316,7 +316,7 @@ void HarddiskInterfaceCard::LoadLastDiskImage(const int drive)
 	char pathname[MAX_PATH];
 
 	std::string regSection = RegGetConfigSlotSection(m_slot);
-	if (RegLoadString(regSection.c_str(), regKey.c_str(), TRUE, pathname, MAX_PATH, "") && (pathname[0] != 0))
+	if (RegLoadString(regSection.c_str(), regKey.c_str(), true, pathname, MAX_PATH, "") && (pathname[0] != 0))
 	{
 		m_saveDiskImage = false;
 		bool res = Insert(drive, pathname);
@@ -340,12 +340,12 @@ void HarddiskInterfaceCard::SaveLastDiskImage(const int drive)
 		return;
 
 	std::string regSection = RegGetConfigSlotSection(m_slot);
-	RegSaveValue(regSection.c_str(), REGVALUE_CARD_TYPE, TRUE, CT_GenericHDD);
+	RegSaveValue(regSection.c_str(), REGVALUE_CARD_TYPE, true, CT_GenericHDD);
 
 	const std::string regKey = std::string(REGVALUE_LAST_HARDDISK_) + (char)('1' + drive);
 	const std::string& pathName = HarddiskGetFullPathName(drive);
 
-	RegSaveString(regSection.c_str(), regKey.c_str(), TRUE, pathName);
+	RegSaveString(regSection.c_str(), regKey.c_str(), true, pathName);
 
 	//
 
@@ -358,7 +358,7 @@ void HarddiskInterfaceCard::SaveLastDiskImage(const int drive)
 	if (slash != std::string::npos)
 	{
 		const std::string dirName = pathName.substr(0, slash + 1);
-		RegSaveString(REG_PREFS, REGVALUE_PREF_HDV_START_DIR, 1, dirName);
+		RegSaveString(REG_PREFS, REGVALUE_PREF_HDV_START_DIR, true, dirName);
 	}
 }
 
@@ -489,7 +489,7 @@ bool HarddiskInterfaceCard::UserSelectNewDiskImageOnly(const int drive, LPCSTR p
 
 	StringCbCopy(filename, MAX_PATH, pszFilename);
 
-	RegLoadString(REG_PREFS, REGVALUE_PREF_HDV_START_DIR, 1, directory, MAX_PATH, "");
+	RegLoadString(REG_PREFS, REGVALUE_PREF_HDV_START_DIR, true, directory, MAX_PATH, "");
 	std::string title = StrFormat("Select HDV Image For HDD %d", drive + 1);
 
 	OPENFILENAME ofn;
@@ -1042,7 +1042,7 @@ BYTE HarddiskInterfaceCard::GetProDOSBlockDeviceUnit(void)
 
 HardDiskDrive* HarddiskInterfaceCard::GetUnit(void)
 {
-	const bool isSmartPortCmd = m_command & SP_Cmd_base;
+	const bool isSmartPortCmd = !!(m_command & SP_Cmd_base);
 
 	if (!isSmartPortCmd)
 		return &m_hardDiskDrive[GetProDOSBlockDeviceUnit()];
@@ -1473,7 +1473,7 @@ bool HarddiskInterfaceCard::LoadSnapshot(YamlLoadHelper& yamlLoadHelper, UINT ve
 		userSelectedImageFolder |= LoadSnapshotHDDUnit(yamlLoadHelper, i, version);
 
 	if (!userSelectedImageFolder)
-		RegSaveString(REG_PREFS, REGVALUE_PREF_HDV_START_DIR, 1, Snapshot_GetPath());
+		RegSaveString(REG_PREFS, REGVALUE_PREF_HDV_START_DIR, true, Snapshot_GetPath());
 
 	GetFrame().FrameRefreshStatus(DRAW_LEDS | DRAW_DISK_STATUS);
 

--- a/source/LanguageCard.cpp
+++ b/source/LanguageCard.cpp
@@ -308,7 +308,7 @@ bool LanguageCardSlot0::LoadSnapshot(YamlLoadHelper& yamlLoadHelper, UINT versio
 
 	yamlLoadHelper.PopMap();
 
-	// NB. MemUpdatePaging(TRUE) called at end of Snapshot_LoadState_v2()
+	// NB. MemUpdatePaging(true) called at end of Snapshot_LoadState_v2()
 
 	return true;
 }
@@ -329,7 +329,7 @@ Saturn128K::Saturn128K(UINT slot, UINT banks)
 	if (banks == 0)
 	{
 		std::string regSection = RegGetConfigSlotSection(m_slot);
-		RegLoadValue(regSection.c_str(), REGVALUE_SATURN_NUM_BANKS, TRUE, &m_uSaturnTotalBanks, kMaxSaturnBanks);
+		RegLoadValue(regSection.c_str(), REGVALUE_SATURN_NUM_BANKS, true, &m_uSaturnTotalBanks, kMaxSaturnBanks);
 	}
 
 	for (UINT i=0; i<kMaxSaturnBanks; i++)
@@ -542,7 +542,7 @@ bool Saturn128K::LoadSnapshot(YamlLoadHelper& yamlLoadHelper, UINT version)
 
 	// NB. MemInitializeFromSnapshot() called at end of Snapshot_LoadState_v2():
 	// . SetMemMainLanguageCard() for the slot/card that last set the 16KB LC bank
-	// . MemUpdatePaging(TRUE)
+	// . MemUpdatePaging(true)
 
 	return true;
 }
@@ -582,7 +582,7 @@ void Saturn128K::SetSaturnMemorySize(uint8_t banks)
 	m_uSaturnTotalBanks = banks;
 
 	std::string regSection = RegGetConfigSlotSection(m_slot);
-	RegSaveValue(regSection.c_str(), REGVALUE_SATURN_NUM_BANKS, TRUE, m_uSaturnTotalBanks);
+	RegSaveValue(regSection.c_str(), REGVALUE_SATURN_NUM_BANKS, true, m_uSaturnTotalBanks);
 }
 
 uint8_t Saturn128K::GetSaturnMemorySizeSlot0()
@@ -608,7 +608,7 @@ void Saturn128K::SetSaturnMemorySizeSlot0(uint8_t banks)
 * . TODO: assist with debugger's display of "sNN" for active 16K bank
 */
 
-// Only called by ResetPaging(BOOL initialize)
+// Only called by ResetPaging(bool initialize)
 // NB. Individual cards (LC or Saturn) are reset via GetCardMgr().Reset()
 void LanguageCardManager::Reset(const bool powerCycle /*=false*/)
 {
@@ -671,7 +671,7 @@ void LanguageCardManager::SetMemMode(const uint8_t slot)
 			card.SetMainMemLanguageCardMemory();
 	}
 
-	MemUpdatePaging(0);	// Initialize=0
+	MemUpdatePaging(false /*Initialize*/);
 }
 
 void LanguageCardManager::SetMemModeFromSnapshot(void)

--- a/source/Memory.cpp
+++ b/source/Memory.cpp
@@ -248,7 +248,7 @@ static LPBYTE	pCxRomPeripheral	= NULL;
 static LPBYTE g_pMemMainLanguageCard = NULL;
 
 static uint32_t   g_memmode = LanguageCardUnit::kMemModeInitialState;
-static BOOL    modechanging = 0;				// An Optimisation: means delay calling UpdatePaging() for 1 instruction
+static bool    modechanging = false;				// An Optimisation: means delay calling UpdatePaging() for 1 instruction
 
 static UINT    memrompages = 1;
 
@@ -426,7 +426,7 @@ void SetRamWorksMemorySize(UINT banks, bool updateRegistry/*=true*/)
 void SetRegistryAuxNumberOfBanks(void)
 {
 	std::string regSection = RegGetConfigSlotSection(SLOT_AUX);
-	RegSaveValue(regSection.c_str(), REGVALUE_AUX_NUM_BANKS, TRUE, g_uMaxExBanks);
+	RegSaveValue(regSection.c_str(), REGVALUE_AUX_NUM_BANKS, true, g_uMaxExBanks);
 }
 
 UINT GetRamWorksActiveBank(void)
@@ -1300,20 +1300,20 @@ void SetMemMode(uint32_t uNewMemMode)
 
 //===========================================================================
 
-static void ResetPaging(BOOL initialize);
-static void UpdatePaging(BOOL initialize);
+static void ResetPaging(bool initialize);
+static void UpdatePaging(bool initialize);
 
 // Call by:
 // . CtrlReset() Soft-reset (Ctrl+Reset) for //e
 void MemResetPaging()
 {
-	ResetPaging(FALSE);	// Initialize=0
+	ResetPaging(false /*Initialize*/);
 }
 
 // Call by:
-// . MemResetPaging() -> ResetPaging(FALSE)
-// . MemReset()       -> ResetPaging(TRUE)
-static void ResetPaging(BOOL initialize)
+// . MemResetPaging() -> ResetPaging(false)
+// . MemReset()       -> ResetPaging(true)
+static void ResetPaging(bool initialize)
 {
 	GetCardMgr().GetLanguageCardMgr().Reset(initialize);
 	UpdatePaging(initialize);
@@ -1321,26 +1321,26 @@ static void ResetPaging(BOOL initialize)
 
 //===========================================================================
 
-static void UpdatePagingForAltRW(void);
+static void UpdatePagingForAltRW();
 
-void MemUpdatePaging(BOOL initialize)
+void MemUpdatePaging(bool initialize)
 {
 	UpdatePaging(initialize);
 }
 
-static void UpdatePaging(BOOL initialize)
+static void UpdatePaging(bool initialize)
 {
 	if (initialize)
 	{
 		// Importantly from:
-		// . MemReset() -> ResetPaging(TRUE)
-		// . MemInitializeFromSnapshot() -> MemUpdatePaging(TRUE);
+		// . MemReset() -> ResetPaging(true)
+		// . MemInitializeFromSnapshot() -> MemUpdatePaging(true);
 		g_isMemCacheValid = !(IsAppleIIe(GetApple2Type()) && (GetCardMgr().QueryAux() == CT_Empty || GetCardMgr().QueryAux() == CT_80Col));
 		if (g_forceAltCpuEmulation)
 			g_isMemCacheValid = false;
 	}
 
-	modechanging = 0;
+	modechanging = false;
 
 	// SAVE THE CURRENT PAGING SHADOW TABLE
 	LPBYTE oldshadow[256];
@@ -2256,13 +2256,13 @@ void MemInitializeFromSnapshot(void)
 		_ASSERT(g_eExpansionRomType == eExpRomPeripheral);
 
 		memcpy(pCxRomPeripheral + 0x800, g_SlotInfo[uSlot].expansionRom, FIRMWARE_EXPANSION_SIZE);
-		// NB. Copied to /mem/ by UpdatePaging(TRUE)
+		// NB. Copied to /mem/ by UpdatePaging(true)
 	}
 
 	GetCardMgr().GetLanguageCardMgr().SetMemModeFromSnapshot();
 
 	// Finally setup the paging tables
-	MemUpdatePaging(TRUE);
+	MemUpdatePaging(true);
 
 	//
 	// VidHD
@@ -2439,7 +2439,7 @@ void MemReset()
 	mem = memimage;
 
 	// INITIALIZE PAGING, FILLING IN THE 64K MEMORY IMAGE
-	ResetPaging(TRUE);		// Initialize=1, init g_memmode
+	ResetPaging(true /*Initialize*/);		// init g_memmode
 	MemAnnunciatorReset();
 
 	// INITIALIZE & RESET THE CPU
@@ -2556,7 +2556,7 @@ BYTE __stdcall MemSetPaging(WORD programcounter, WORD address, BYTE write, BYTE 
 				{
 					g_uActiveBank = value;
 					memaux = RWpages[g_uActiveBank];
-					UpdatePaging(FALSE);	// Initialize=FALSE
+					UpdatePaging(false /*Initialize*/);
 				}
 				break;
 #endif
@@ -2626,7 +2626,7 @@ BYTE __stdcall MemSetPaging(WORD programcounter, WORD address, BYTE write, BYTE 
 			}
 		}
 
-		UpdatePaging(0);	// Initialize=0
+		UpdatePaging(false /*Initialize*/);
 	}
 
 	// Replicate 80STORE, PAGE2 and HIRES to video sub-system
@@ -2677,7 +2677,7 @@ bool MemOptimizeForModeChanging(WORD programcounter, WORD address)
 		if ((address >= 4) && (address <= 5) &&									// Now:  RAMWRTOFF or RAMWRTON
 			((ReadUINT24FromMemory(programcounter) & 0x00FFFEFF) == 0x00C0028D))		// Next: STA $C002(RAMRDOFF) or STA $C003(RAMRDON)
 		{
-				modechanging = 1;
+				modechanging = true;
 				return true;
 		}
 
@@ -2687,7 +2687,7 @@ bool MemOptimizeForModeChanging(WORD programcounter, WORD address)
 			(((ReadUINT24FromMemory(programcounter) & 0x00FFFEFF) == 0x00C0048D) ||		// Next: STA $C004(RAMWRTOFF) or STA $C005(RAMWRTON)
 			 ((ReadUINT24FromMemory(programcounter) & 0x00FFFEFF) == 0x00C0028D)))		//    or STA $C002(RAMRDOFF)  or STA $C003(RAMRDON)
 		{
-				modechanging = 1;
+				modechanging = true;
 				return true;
 		}
 	}
@@ -2705,7 +2705,7 @@ void MemAnnunciatorReset(void)
 	if (IsCopamBase64A(GetApple2Type()))
 	{
 		SetMemMode(g_memmode & ~(MF_ALTROM0|MF_ALTROM1));
-		UpdatePaging(FALSE);	// Initialize=FALSE
+		UpdatePaging(false /*Initialize*/);
 	}
 }
 
@@ -3101,7 +3101,7 @@ static SS_CARDTYPE MemLoadSnapshotAuxCommon(YamlLoadHelper& yamlLoadHelper, cons
 	GetCardMgr().InsertAux(cardType);
 
 	memaux = RWpages[g_uActiveBank];
-	// NB. MemUpdatePaging(TRUE) called at end of Snapshot_LoadState_v2()
+	// NB. MemUpdatePaging(true) called at end of Snapshot_LoadState_v2()
 
 	return cardType;
 }

--- a/source/Memory.h
+++ b/source/Memory.h
@@ -84,7 +84,7 @@ BYTE    MemReadFloatingBus(const BYTE highbit, const ULONG uExecutedCycles);
 BYTE    MemReadFloatingBusFromNTSC(void);
 void    MemReset ();
 void    MemResetPaging ();
-void    MemUpdatePaging(BOOL initialize);
+void    MemUpdatePaging(bool initialize);
 LPVOID	MemGetSlotParameters (UINT uSlot);
 void	MemAnnunciatorReset(void);
 bool    MemGetAnnunciator(UINT annunciator);

--- a/source/Mockingboard.cpp
+++ b/source/Mockingboard.cpp
@@ -102,16 +102,16 @@ MockingboardCard::MockingboardCard(UINT slot, SS_CARDTYPE type) : Card(type, slo
 		uint32_t type;
 		std::string regSection = RegGetConfigSlotSection(m_slot);
 		if (i == 0)
-			RegLoadValue(regSection.c_str(), REGVALUE_MOCKINGBOARD_SSI263_SOCKET0, TRUE, &type, kSSI263A_Default);
+			RegLoadValue(regSection.c_str(), REGVALUE_MOCKINGBOARD_SSI263_SOCKET0, true, &type, kSSI263A_Default);
 		else
-			RegLoadValue(regSection.c_str(), REGVALUE_MOCKINGBOARD_SSI263_SOCKET1, TRUE, &type, kSSI263B_Default);	// socket-1 for main SSI263
+			RegLoadValue(regSection.c_str(), REGVALUE_MOCKINGBOARD_SSI263_SOCKET1, true, &type, kSSI263B_Default);	// socket-1 for main SSI263
 		m_MBSubUnit[i].ssi263.SetType(SSI263Type(type));
 
 		if (i == 0)
 		{
 			uint32_t hasSC01;
 			std::string regSection = RegGetConfigSlotSection(m_slot);
-			RegLoadValue(regSection.c_str(), REGVALUE_MOCKINGBOARD_SC01, TRUE, &hasSC01, kSC01_Default == SC01 ? TRUE : FALSE);
+			RegLoadValue(regSection.c_str(), REGVALUE_MOCKINGBOARD_SC01, true, &hasSC01, kSC01_Default == SC01 ? TRUE : FALSE);
 			m_MBSubUnit[i].ssi263.SetSC01(hasSC01 ? SC01 : SSI263Empty);
 		}
 	}
@@ -136,9 +136,9 @@ void MockingboardCard::SetSocketSSI263(BYTE socket, SSI263Type type)
 
 	std::string regSection = RegGetConfigSlotSection(m_slot);
 	if (socket == 0)
-		RegSaveValue(regSection.c_str(), REGVALUE_MOCKINGBOARD_SSI263_SOCKET0, TRUE, type);
+		RegSaveValue(regSection.c_str(), REGVALUE_MOCKINGBOARD_SSI263_SOCKET0, true, type);
 	else
-		RegSaveValue(regSection.c_str(), REGVALUE_MOCKINGBOARD_SSI263_SOCKET1, TRUE, type);
+		RegSaveValue(regSection.c_str(), REGVALUE_MOCKINGBOARD_SSI263_SOCKET1, true, type);
 }
 
 void MockingboardCard::SetSocketSC01(SSI263Type type)
@@ -146,7 +146,7 @@ void MockingboardCard::SetSocketSC01(SSI263Type type)
 	m_MBSubUnit[0].ssi263.SetSC01(type);
 
 	std::string regSection = RegGetConfigSlotSection(m_slot);
-	RegSaveValue(regSection.c_str(), REGVALUE_MOCKINGBOARD_SC01, TRUE, type == SC01 ? TRUE : FALSE);
+	RegSaveValue(regSection.c_str(), REGVALUE_MOCKINGBOARD_SC01, true, type == SC01);
 }
 
 //---------------------------------------------------------------------------
@@ -786,9 +786,9 @@ BYTE MockingboardCard::IOWriteInternal(WORD PC, WORD nAddr, BYTE bWrite, BYTE nV
 		if (m_phasorMode == PH_Mockingboard || m_phasorMode == PH_Phasor)	// No SSI263 for Echo+
 		{
 			// Confirmed that Phasor has no extra logic to map SSI263 (it's the same as Mockingboard's)
-			bool CS_SSI263_A = nAddr & 0x40;					// SSI263 at $Cn4x-Cn7x, $CnCx-CnFx
+			bool CS_SSI263_A = !!(nAddr & 0x40);					// SSI263 at $Cn4x-Cn7x, $CnCx-CnFx
 
-			bool CS_SSI263_B = nAddr & 0x20;					// SSI263 at $Cn2x-Cn3x, $Cn6x-Cn7x, $CnAx-CnBx, $CnEx-CnFx
+			bool CS_SSI263_B = !!(nAddr & 0x20);					// SSI263 at $Cn2x-Cn3x, $Cn6x-Cn7x, $CnAx-CnBx, $CnEx-CnFx
 
 			// NB. Mockingboard mode: writes to $Cn4x/SSI263 also get written to 1st 6522 (have confirmed on real Phasor h/w)
 			if (CS_SSI263_A)	// Primary SSI263

--- a/source/ParallelPrinter.cpp
+++ b/source/ParallelPrinter.cpp
@@ -170,7 +170,7 @@ void ParallelPrinterCard::SetFilename(const std::string& prtFilename)
 	else  //No registry entry is available
 	{
 		m_szPrintFilename = g_sProgramDir + DEFAULT_PRINT_FILENAME;
-		RegSaveString(REG_CONFIG, REGVALUE_PRINTER_FILENAME, 1, m_szPrintFilename);
+		RegSaveString(REG_CONFIG, REGVALUE_PRINTER_FILENAME, true, m_szPrintFilename);
 	}
 }
 
@@ -183,34 +183,34 @@ void ParallelPrinterCard::GetRegistryConfig(void)
 	uint32_t dwTmp;
 	char szFilename[MAX_PATH];
 
-	if (RegLoadValue(regSection.c_str(), REGVALUE_DUMP_TO_PRINTER, TRUE, &dwTmp))
+	if (RegLoadValue(regSection.c_str(), REGVALUE_DUMP_TO_PRINTER, true, &dwTmp))
 		SetDumpToPrinter(dwTmp ? true : false);
 
-	if (RegLoadValue(regSection.c_str(), REGVALUE_CONVERT_ENCODING, TRUE, &dwTmp))
+	if (RegLoadValue(regSection.c_str(), REGVALUE_CONVERT_ENCODING, true, &dwTmp))
 		SetConvertEncoding(dwTmp ? true : false);
 
-	if (RegLoadValue(regSection.c_str(), REGVALUE_FILTER_UNPRINTABLE, TRUE, &dwTmp))
+	if (RegLoadValue(regSection.c_str(), REGVALUE_FILTER_UNPRINTABLE, true, &dwTmp))
 		SetFilterUnprintable(dwTmp ? true : false);
 
-	if (RegLoadValue(regSection.c_str(), REGVALUE_PRINTER_APPEND, TRUE, &dwTmp))
+	if (RegLoadValue(regSection.c_str(), REGVALUE_PRINTER_APPEND, true, &dwTmp))
 		SetPrinterAppend(dwTmp ? true : false);
 
-	if (RegLoadString(regSection.c_str(), REGVALUE_PRINTER_FILENAME, 1, szFilename, MAX_PATH, ""))
+	if (RegLoadString(regSection.c_str(), REGVALUE_PRINTER_FILENAME, true, szFilename, MAX_PATH, ""))
 		SetFilename(szFilename);
 
-	if (RegLoadValue(regSection.c_str(), REGVALUE_PRINTER_IDLE_LIMIT, TRUE, &dwTmp))
+	if (RegLoadValue(regSection.c_str(), REGVALUE_PRINTER_IDLE_LIMIT, true, &dwTmp))
 		SetIdleLimit(dwTmp);
 }
 
 void ParallelPrinterCard::SetRegistryConfig(void)
 {
 	std::string regSection = RegGetConfigSlotSection(m_slot);
-	RegSaveValue(regSection.c_str(), REGVALUE_DUMP_TO_PRINTER, TRUE, GetDumpToPrinter() ? 1 : 0);
-	RegSaveValue(regSection.c_str(), REGVALUE_CONVERT_ENCODING, TRUE, GetConvertEncoding() ? 1 : 0);
-	RegSaveValue(regSection.c_str(), REGVALUE_FILTER_UNPRINTABLE, TRUE, GetFilterUnprintable() ? 1 : 0);
-	RegSaveValue(regSection.c_str(), REGVALUE_PRINTER_APPEND, TRUE, GetPrinterAppend() ? 1 : 0);
-	RegSaveString(regSection.c_str(), REGVALUE_PRINTER_FILENAME, TRUE, GetFilename());
-	RegSaveValue(regSection.c_str(), REGVALUE_PRINTER_IDLE_LIMIT, TRUE, GetIdleLimit());
+	RegSaveValue(regSection.c_str(), REGVALUE_DUMP_TO_PRINTER, true, GetDumpToPrinter());
+	RegSaveValue(regSection.c_str(), REGVALUE_CONVERT_ENCODING, true, GetConvertEncoding());
+	RegSaveValue(regSection.c_str(), REGVALUE_FILTER_UNPRINTABLE, true, GetFilterUnprintable());
+	RegSaveValue(regSection.c_str(), REGVALUE_PRINTER_APPEND, true, GetPrinterAppend());
+	RegSaveString(regSection.c_str(), REGVALUE_PRINTER_FILENAME, true, GetFilename());
+	RegSaveValue(regSection.c_str(), REGVALUE_PRINTER_IDLE_LIMIT, true, GetIdleLimit());
 }
 
 //===========================================================================

--- a/source/Registry.cpp
+++ b/source/Registry.cpp
@@ -34,36 +34,36 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 namespace _ini {
 	//===========================================================================
-	BOOL RegLoadString(LPCTSTR section, LPCTSTR key, BOOL /*peruser*/, LPTSTR buffer, uint32_t chars)
+	bool RegLoadString(LPCTSTR section, LPCTSTR key, bool /*peruser*/, LPTSTR buffer, uint32_t chars)
 	{
 		uint32_t n = GetPrivateProfileString(section, key, NULL, buffer, chars, g_sConfigFile.c_str());
 		return n > 0;
 	}
 
 	//===========================================================================
-	void RegSaveString(LPCTSTR section, LPCTSTR key, BOOL /*peruser*/, const std::string& buffer)
+	void RegSaveString(LPCTSTR section, LPCTSTR key, bool /*peruser*/, const std::string& buffer)
 	{
-		BOOL updated = WritePrivateProfileString(section, key, buffer.c_str(), g_sConfigFile.c_str());
+		bool updated = !!WritePrivateProfileString(section, key, buffer.c_str(), g_sConfigFile.c_str());
 		_ASSERT(updated || GetLastError() == 0);
 	}
 
 	//===========================================================================
-	void RegDeleteString(LPCTSTR section, BOOL /*peruser*/)
+	void RegDeleteString(LPCTSTR section, bool /*peruser*/)
 	{
-		BOOL updated = WritePrivateProfileString(section, NULL, NULL, g_sConfigFile.c_str());
+	    bool updated = !!WritePrivateProfileString(section, NULL, NULL, g_sConfigFile.c_str());
 		_ASSERT(updated || GetLastError() == 0);
 	}
 }
 
 //===========================================================================
-BOOL RegLoadString (LPCTSTR section, LPCTSTR key, BOOL peruser, LPTSTR buffer, uint32_t chars)
+bool RegLoadString (LPCTSTR section, LPCTSTR key, bool peruser, LPTSTR buffer, uint32_t chars)
 {
 	if (!g_sConfigFile.empty())
 		return _ini::RegLoadString(section, key, peruser, buffer, chars);
 
 	std::string fullkeyname = std::string("Software\\AppleWin\\CurrentVersion\\") + section;
 
-	BOOL success = FALSE;
+	bool success = false;
 	HKEY keyhandle;
 	LSTATUS status = RegOpenKeyEx(
 		(peruser ? HKEY_CURRENT_USER : HKEY_LOCAL_MACHINE),
@@ -77,7 +77,7 @@ BOOL RegLoadString (LPCTSTR section, LPCTSTR key, BOOL peruser, LPTSTR buffer, u
 		DWORD size = chars;
 		status = RegQueryValueEx(keyhandle, key, NULL, &type, (LPBYTE)buffer, &size);
 		if (status == 0 && size != 0)
-			success = TRUE;
+			success = true;
 	}
 
 	RegCloseKey(keyhandle);
@@ -86,36 +86,36 @@ BOOL RegLoadString (LPCTSTR section, LPCTSTR key, BOOL peruser, LPTSTR buffer, u
 }
 
 //===========================================================================
-BOOL RegLoadString (LPCTSTR section, LPCTSTR key, BOOL peruser, LPTSTR buffer, uint32_t chars, LPCTSTR defaultValue)
+bool RegLoadString (LPCTSTR section, LPCTSTR key, bool peruser, LPTSTR buffer, uint32_t chars, LPCTSTR defaultValue)
 {
-	BOOL success = RegLoadString(section, key, peruser, buffer, chars);
+	bool success = RegLoadString(section, key, peruser, buffer, chars);
 	if (!success)
 		StringCbCopy(buffer, chars, defaultValue);
 	return success;
 }
 
 //===========================================================================
-BOOL RegLoadValue (LPCTSTR section, LPCTSTR key, BOOL peruser, uint32_t* value) {
+bool RegLoadValue (LPCTSTR section, LPCTSTR key, bool peruser, uint32_t* value) {
 	char buffer[32];
 	if (!RegLoadString(section, key, peruser, buffer, 32))
 	{
-		return FALSE;
+		return false;
 	}
 
 	*value = (uint32_t)atoi(buffer);
-	return TRUE;
+	return true;
 }
 
 //===========================================================================
-BOOL RegLoadValue (LPCTSTR section, LPCTSTR key, BOOL peruser, uint32_t* value, uint32_t defaultValue) {
-	BOOL success = RegLoadValue(section, key, peruser, value);
+bool RegLoadValue (LPCTSTR section, LPCTSTR key, bool peruser, uint32_t* value, uint32_t defaultValue) {
+	bool success = RegLoadValue(section, key, peruser, value);
 	if (!success)
 		*value = defaultValue;
 	return success;
 }
 
 //===========================================================================
-void RegSaveString (LPCTSTR section, LPCTSTR key, BOOL peruser, const std::string & buffer) {
+void RegSaveString (LPCTSTR section, LPCTSTR key, bool peruser, const std::string & buffer) {
 	if (!g_sConfigFile.empty())
 		return _ini::RegSaveString(section, key, peruser, buffer);
 
@@ -147,12 +147,6 @@ void RegSaveString (LPCTSTR section, LPCTSTR key, BOOL peruser, const std::strin
 }
 
 //===========================================================================
-void RegSaveValue (LPCTSTR section, LPCTSTR key, BOOL peruser, uint32_t value) {
-	std::string strValue = StrFormat("%d", value);
-	RegSaveString(section, key, peruser, strValue.c_str());
-}
-
-//===========================================================================
 static inline std::string RegGetSlotSection(UINT slot)
 {
 	if (slot == GAME_IO_CONNECTOR)
@@ -170,7 +164,7 @@ std::string RegGetConfigSlotSection(UINT slot)
 
 void RegDeleteConfigSlotSection(UINT slot)
 {
-	BOOL peruser = TRUE;
+	constexpr bool peruser = true;
 
 	if (!g_sConfigFile.empty())
 	{
@@ -207,7 +201,7 @@ void RegSetConfigSlotNewCardType(UINT slot, SS_CARDTYPE type)
 	std::string regSection;
 	regSection = RegGetConfigSlotSection(slot);
 
-	RegSaveValue(regSection.c_str(), REGVALUE_CARD_TYPE, TRUE, type);
+	RegSaveValue(regSection.c_str(), REGVALUE_CARD_TYPE, true, type);
 }
 
 void RegSetConfigGameIOConnectorNewDongleType(UINT slot, DONGLETYPE type)
@@ -221,5 +215,5 @@ void RegSetConfigGameIOConnectorNewDongleType(UINT slot, DONGLETYPE type)
 	std::string regSection;
 	regSection = RegGetConfigSlotSection(slot);
 
-	RegSaveValue(regSection.c_str(), REGVALUE_GAME_IO_TYPE, TRUE, type);
+	RegSaveValue(regSection.c_str(), REGVALUE_GAME_IO_TYPE, true, type);
 }

--- a/source/Registry.h
+++ b/source/Registry.h
@@ -1,17 +1,43 @@
 #pragma once
 #include "Card.h"
 #include "CopyProtectionDongles.h"
+#include <string>
+#include <type_traits>
 
-#define  REGLOAD(a, b)				RegLoadValue(REG_CONFIG, (a), TRUE, (b))
-#define  REGLOAD_DEFAULT(a, b, c)	RegLoadValue(REG_CONFIG, (a), TRUE, (b), (c))
-#define  REGSAVE(a, b)				RegSaveValue(REG_CONFIG, (a), TRUE, (b))
+bool RegLoadString (LPCTSTR section, LPCTSTR key, bool peruser, LPTSTR buffer, uint32_t chars);
+bool RegLoadString (LPCTSTR section, LPCTSTR key, bool peruser, LPTSTR buffer, uint32_t chars, LPCTSTR defaultValue);
+bool RegLoadValue (LPCTSTR section, LPCTSTR key, bool peruser, uint32_t* value);
+bool RegLoadValue (LPCTSTR section, LPCTSTR key, bool peruser, uint32_t* value, uint32_t defaultValue);
 
-BOOL RegLoadString (LPCTSTR section, LPCTSTR key, BOOL peruser, LPTSTR buffer, uint32_t chars);
-BOOL RegLoadString (LPCTSTR section, LPCTSTR key, BOOL peruser, LPTSTR buffer, uint32_t chars, LPCTSTR defaultValue);
-BOOL RegLoadValue (LPCTSTR section, LPCTSTR key, BOOL peruser, uint32_t* value);
-BOOL RegLoadValue (LPCTSTR section, LPCTSTR key, BOOL peruser, uint32_t* value, uint32_t defaultValue);
-void RegSaveString (LPCTSTR section, LPCTSTR key, BOOL peruser, const std::string & buffer);
-void RegSaveValue (LPCTSTR section, LPCTSTR key, BOOL peruser, uint32_t value);
+inline bool REGLOAD(LPCTSTR a, uint32_t* b) {
+    return RegLoadValue(REG_CONFIG, a, true, b);
+}
+inline bool REGLOAD_DEFAULT(LPCTSTR a, uint32_t* b, uint32_t c) {
+    return RegLoadValue(REG_CONFIG, a, true, b, c);
+}
+
+void RegSaveString(LPCTSTR section, LPCTSTR key, bool peruser, const std::string & buffer);
+template<typename V, typename std::enable_if_t<std::is_same_v<V, bool>, int> = 0>
+void RegSaveValue(LPCTSTR section, LPCTSTR key, bool peruser, V value) {
+    RegSaveString(section, key, peruser, value ? "1" : "0");
+}
+template<typename V, typename std::enable_if_t<std::is_signed_v<V> && !std::is_same_v<V, bool>, int> = 0>
+void RegSaveValue(LPCTSTR section, LPCTSTR key, bool peruser, V value) {
+    RegSaveString(section, key, peruser, std::to_string(value));
+}
+template<typename V, typename std::enable_if_t<std::is_unsigned_v<V> && !std::is_same_v<V, bool>, int> = 0>
+void RegSaveValue(LPCTSTR section, LPCTSTR key, bool peruser, V value) {
+    RegSaveValue<typename std::make_signed_t<V>>(section, key, peruser, value);
+}
+template<typename V, typename std::enable_if_t<std::is_enum_v<V>, int> = 0>
+void RegSaveValue(LPCTSTR section, LPCTSTR key, bool peruser, V value) {
+    RegSaveValue<typename std::underlying_type_t<V>>(section, key, peruser, value);
+}
+
+template<typename V>
+inline void REGSAVE(LPCTSTR a, const V & b) {
+    RegSaveValue(REG_CONFIG, a, true, b);
+}
 
 std::string RegGetConfigSlotSection(UINT slot);
 void RegDeleteConfigSlotSection(UINT slot);

--- a/source/SerialComms.cpp
+++ b/source/SerialComms.cpp
@@ -97,7 +97,7 @@ CSuperSerialCard::CSuperSerialCard(UINT slot) :
 	const size_t SERIALCHOICE_ITEM_LENGTH = 12;
 	char serialPortName[SERIALCHOICE_ITEM_LENGTH];
 	std::string regSection = RegGetConfigSlotSection(m_slot);
-	RegLoadString(regSection.c_str(), REGVALUE_SERIAL_PORT_NAME, TRUE, serialPortName, sizeof(serialPortName), "");
+	RegLoadString(regSection.c_str(), REGVALUE_SERIAL_PORT_NAME, true, serialPortName, sizeof(serialPortName), "");
 
 	SetSerialPortName(serialPortName);
 }
@@ -1398,7 +1398,7 @@ void CSuperSerialCard::SetSerialPortName(const char* pSerialPortName)
 void CSuperSerialCard::SetRegistrySerialPortName(void)
 {
 	std::string regSection = RegGetConfigSlotSection(m_slot);
-	RegSaveString(regSection.c_str(), REGVALUE_SERIAL_PORT_NAME, TRUE, GetSerialPortName());
+	RegSaveString(regSection.c_str(), REGVALUE_SERIAL_PORT_NAME, true, GetSerialPortName());
 }
 
 //===========================================================================

--- a/source/Tfe/PCapBackend.cpp
+++ b/source/Tfe/PCapBackend.cpp
@@ -65,7 +65,7 @@ int PCapBackend::receive(const int size, uint8_t * rxframe)
 
 bool PCapBackend::isValid()
 {
-    return m_tfePcapFP;
+    return !!m_tfePcapFP;
 }
 
 void PCapBackend::update(const ULONG /* nExecutedCycles */)
@@ -111,14 +111,14 @@ const char * PCapBackend::tfe_lib_version(void)
 void PCapBackend::SetRegistryInterface(UINT slot, const std::string& name)
 {
     std::string regSection = RegGetConfigSlotSection(slot);
-    RegSaveString(regSection.c_str(), REGVALUE_UTHERNET_INTERFACE, TRUE, name);
+    RegSaveString(regSection.c_str(), REGVALUE_UTHERNET_INTERFACE, true, name);
 }
 
 std::string PCapBackend::GetRegistryInterface(UINT slot)
 {
     char interfaceName[MAX_PATH];
     std::string regSection = RegGetConfigSlotSection(slot);
-    RegLoadString(regSection.c_str(), REGVALUE_UTHERNET_INTERFACE, TRUE, interfaceName, sizeof(interfaceName), "");
+    RegLoadString(regSection.c_str(), REGVALUE_UTHERNET_INTERFACE, true, interfaceName, sizeof(interfaceName), "");
     return interfaceName;
 }
 

--- a/source/Uthernet2.cpp
+++ b/source/Uthernet2.cpp
@@ -604,7 +604,7 @@ void Uthernet2::receiveOnePacketRaw()
         const uint8_t mr = myMemory[socket0.registerAddress + W5100_SN_MR];
 
         // see if MAC RAW filters or not
-        const bool filterMAC = mr & W5100_SN_MR_MF;
+        const bool filterMAC = !!(mr & W5100_SN_MR_MF);
         if (!filterMAC)
         {
             acceptAll = true;
@@ -951,7 +951,7 @@ void Uthernet2::openSocket(const size_t i)
 
     const uint8_t mr = myMemory[socket.registerAddress + W5100_SN_MR];
     const uint8_t protocol = mr & W5100_SN_MR_PROTO_MASK;
-    const bool virtual_dns = protocol & W5100_SN_VIRTUAL_DNS;
+    const bool virtual_dns = !!(protocol & W5100_SN_VIRTUAL_DNS);
 
     // if virtual_dns is requested, but not enabled, we cannot handle it here.
     if (virtual_dns && !myVirtualDNSEnabled)
@@ -1659,7 +1659,7 @@ bool Uthernet2::LoadSnapshot(YamlLoadHelper &yamlLoadHelper, UINT version)
 void Uthernet2::SetRegistryVirtualDNS(UINT slot, const bool enabled)
 {
     const std::string regSection = RegGetConfigSlotSection(slot);
-    RegSaveValue(regSection.c_str(), REGVALUE_UTHERNET_VIRTUAL_DNS, TRUE, enabled);
+    RegSaveValue(regSection.c_str(), REGVALUE_UTHERNET_VIRTUAL_DNS, true, enabled);
 }
 
 bool Uthernet2::GetRegistryVirtualDNS(UINT slot)
@@ -1671,6 +1671,6 @@ bool Uthernet2::GetRegistryVirtualDNS(UINT slot)
     // (except for the initial value of PTIMER which is anyway never used)
 
     uint32_t enabled = 1;
-    RegLoadValue(regSection.c_str(), REGVALUE_UTHERNET_VIRTUAL_DNS, TRUE, &enabled);
+    RegLoadValue(regSection.c_str(), REGVALUE_UTHERNET_VIRTUAL_DNS, true, &enabled);
     return enabled != 0;
 }

--- a/source/Utilities.cpp
+++ b/source/Utilities.cpp
@@ -166,7 +166,7 @@ void LoadConfiguration(bool loadImages)
 
 	uint32_t copyProtectionDongleType;
 	std::string regSection = RegGetConfigSlotSection(GAME_IO_CONNECTOR);
-	if (RegLoadValue(regSection.c_str(), REGVALUE_GAME_IO_TYPE, TRUE, &copyProtectionDongleType))
+	if (RegLoadValue(regSection.c_str(), REGVALUE_GAME_IO_TYPE, true, &copyProtectionDongleType))
 		SetCopyProtectionDongleType((DONGLETYPE)copyProtectionDongleType);
 	else
 		SetCopyProtectionDongleType(DT_EMPTY);
@@ -223,7 +223,7 @@ void LoadConfiguration(bool loadImages)
 	{
 		std::string regSection = RegGetConfigSlotSection(slot);
 
-		if (RegLoadValue(regSection.c_str(), REGVALUE_CARD_TYPE, TRUE, &dwTmp))
+		if (RegLoadValue(regSection.c_str(), REGVALUE_CARD_TYPE, true, &dwTmp))
 		{
 			if (slot == SLOT0)
 				SetExpansionMemType((SS_CARDTYPE)dwTmp, false);
@@ -238,7 +238,7 @@ void LoadConfiguration(bool loadImages)
 			// Legacy:
 			if (slot == SLOT3)
 			{
-				RegLoadString(REG_CONFIG, REGVALUE_UTHERNET_INTERFACE, 1, szFilename, MAX_PATH, "");
+				RegLoadString(REG_CONFIG, REGVALUE_UTHERNET_INTERFACE, true, szFilename, MAX_PATH, "");
 				// copy it to the new location
 				PCapBackend::SetRegistryInterface(slot, szFilename);
 
@@ -261,14 +261,14 @@ void LoadConfiguration(bool loadImages)
 	{
 		std::string regSection = RegGetConfigSlotSection(SLOT_AUX);
 
-		if (RegLoadValue(regSection.c_str(), REGVALUE_CARD_TYPE, TRUE, &dwTmp))
+		if (RegLoadValue(regSection.c_str(), REGVALUE_CARD_TYPE, true, &dwTmp))
 		{
 			SS_CARDTYPE type = (SS_CARDTYPE)dwTmp;
 			const bool noUpdateRegistry = false;
 			GetCardMgr().InsertAux(type, noUpdateRegistry);
 			SetExpansionMemType(type, noUpdateRegistry);
 
-			RegLoadValue(regSection.c_str(), REGVALUE_AUX_NUM_BANKS, TRUE, &dwTmp, kDefaultExMemoryBanksRealRW3);
+			RegLoadValue(regSection.c_str(), REGVALUE_AUX_NUM_BANKS, true, &dwTmp, kDefaultExMemoryBanksRealRW3);
 			SetRamWorksMemorySize(dwTmp, noUpdateRegistry);
 		}
 		else	// new install or legacy
@@ -287,12 +287,12 @@ void LoadConfiguration(bool loadImages)
 
 	// Load save-state pathname *before* inserting any harddisk/disk images (for both init & reinit cases)
 	// NB. inserting harddisk/disk can change snapshot pathname
-	RegLoadString(REG_CONFIG, REGVALUE_SAVESTATE_FILENAME, 1, szFilename, MAX_PATH, "");	// Can be pathname or just filename
+	RegLoadString(REG_CONFIG, REGVALUE_SAVESTATE_FILENAME, true, szFilename, MAX_PATH, "");	// Can be pathname or just filename
 	Snapshot_SetFilename(szFilename);	// If not in Registry than default will be used (ie. g_sCurrentDir + default filename)
 
 	//
 
-	RegLoadString(REG_PREFS, REGVALUE_PREF_HDV_START_DIR, 1, szFilename, MAX_PATH, "");
+	RegLoadString(REG_PREFS, REGVALUE_PREF_HDV_START_DIR, true, szFilename, MAX_PATH, "");
 	if (szFilename[0] == '\0')
 		GetCurrentDirectory(sizeof(szFilename), szFilename);
 	SetCurrentImageDir(szFilename);
@@ -314,7 +314,7 @@ void LoadConfiguration(bool loadImages)
 	//
 
 	// Current/Starting Dir is the "root" of where the user keeps their disk images
-	RegLoadString(REG_PREFS, REGVALUE_PREF_START_DIR, 1, szFilename, MAX_PATH, "");
+	RegLoadString(REG_PREFS, REGVALUE_PREF_START_DIR, true, szFilename, MAX_PATH, "");
 	if (szFilename[0] == '\0')
 		GetCurrentDirectory(sizeof(szFilename), szFilename);
 	SetCurrentImageDir(szFilename);
@@ -338,7 +338,7 @@ void LoadConfiguration(bool loadImages)
 		GetFrame().SetViewportScale(dwTmp);
 
 	if (REGLOAD(REGVALUE_CONFIRM_REBOOT, &dwTmp))
-		GetFrame().g_bConfirmReboot = dwTmp;
+		GetFrame().g_bConfirmReboot = !!dwTmp;
 }
 
 static std::string GetFullPath(LPCSTR szFileName)

--- a/source/Windows/AppleWin.cpp
+++ b/source/Windows/AppleWin.cpp
@@ -916,7 +916,7 @@ static void RepeatInitialization(void)
 		if (!AboutDlg())
 			g_cmdLine.bShutdown = true;											// Close everything down
 		else
-			RegSaveString(REG_CONFIG, REGVALUE_VERSION, TRUE, g_VERSIONSTRING);	// Only save version after user accepts license
+			RegSaveString(REG_CONFIG, REGVALUE_VERSION, true, g_VERSIONSTRING);	// Only save version after user accepts license
 	}
 
 	if (g_bCapturePrintScreenKey)

--- a/source/Windows/WinFrame.cpp
+++ b/source/Windows/WinFrame.cpp
@@ -1063,8 +1063,8 @@ LRESULT Win32Frame::WndProc(
         SetNormalMode();
       if (!IsIconic(window))
         GetWindowRect(window,&framerect);
-      RegSaveValue(REG_PREFS, REGVALUE_PREF_WINDOW_X_POS, 1, framerect.left);
-      RegSaveValue(REG_PREFS, REGVALUE_PREF_WINDOW_Y_POS, 1, framerect.top);
+      RegSaveValue(REG_PREFS, REGVALUE_PREF_WINDOW_X_POS, true, framerect.left);
+      RegSaveValue(REG_PREFS, REGVALUE_PREF_WINDOW_Y_POS, true, framerect.top);
       FrameReleaseDC();
       SetUsingCursor(FALSE);
       if (helpquit) {
@@ -2166,7 +2166,7 @@ void Win32Frame::ProcessDiskPopupMenu(HWND hwnd, POINT pt, const int iDrive)
 	RegLoadString(
 		"Configuration",
 		REGVALUE_CIDERPRESSLOC,
-		1,
+		true,
 		PathToCiderPress,
 		MAX_PATH,
 		"C:\\Program Files\\faddenSoft\\CiderPress\\CiderPress.exe");
@@ -2179,10 +2179,10 @@ void Win32Frame::ProcessDiskPopupMenu(HWND hwnd, POINT pt, const int iDrive)
 
 	const char REG_KEY_DISK_PREFRENCES[] = "Preferences"; // NOTE: Keep in sync with REG_KEY_DISK_PREFRENCES and UtilPopup_Toggle
 
-	RegLoadValue( REG_KEY_DISK_PREFRENCES, REGVALUE_PREF_NEW_DISK_COPY_BASIC     , TRUE, &bNewDiskCopyBASIC     );
-	RegLoadValue( REG_KEY_DISK_PREFRENCES, REGVALUE_PREF_NEW_DISK_COPY_BITSY_BOOT, TRUE, &bNewDiskCopyBitsyBoot );
-	RegLoadValue( REG_KEY_DISK_PREFRENCES, REGVALUE_PREF_NEW_DISK_COPY_BITSY_BYE , TRUE, &bNewDiskCopyBitsyBye  );
-	RegLoadValue( REG_KEY_DISK_PREFRENCES, REGVALUE_PREF_NEW_DISK_COPY_PRODOS_SYS, TRUE, &bNewDiskCopyProDOS    );
+	RegLoadValue( REG_KEY_DISK_PREFRENCES, REGVALUE_PREF_NEW_DISK_COPY_BASIC     , true, &bNewDiskCopyBASIC     );
+	RegLoadValue( REG_KEY_DISK_PREFRENCES, REGVALUE_PREF_NEW_DISK_COPY_BITSY_BOOT, true, &bNewDiskCopyBitsyBoot );
+	RegLoadValue( REG_KEY_DISK_PREFRENCES, REGVALUE_PREF_NEW_DISK_COPY_BITSY_BYE , true, &bNewDiskCopyBitsyBye  );
+	RegLoadValue( REG_KEY_DISK_PREFRENCES, REGVALUE_PREF_NEW_DISK_COPY_PRODOS_SYS, true, &bNewDiskCopyProDOS    );
 
 	class UtilPopup_Toggle
 	{
@@ -2196,7 +2196,7 @@ void Win32Frame::ProcessDiskPopupMenu(HWND hwnd, POINT pt, const int iDrive)
 				RegSaveValue(
 					"Preferences", // NOTE: Keep in sync with REG_KEY_DISK_PREFRENCES and UtilPopup_Toggle
 					pKey,
-					TRUE,
+					true,
 					*pVal
 				);
 			}
@@ -2443,7 +2443,7 @@ void Win32Frame::ProcessDiskPopupMenu(HWND hwnd, POINT pt, const int iDrive)
 
 			if (nRes)
 			{
-				New_DOSProDOS_Disk(pTitle, pathname, nDiskSize, bIsDOS33, bNewDiskCopyBitsyBoot, bNewDiskCopyBitsyBye, bNewDiskCopyBASIC, bNewDiskCopyProDOS, this);
+				New_DOSProDOS_Disk(pTitle, pathname, nDiskSize, bIsDOS33, !!bNewDiskCopyBitsyBoot, !!bNewDiskCopyBitsyBye, !!bNewDiskCopyBASIC, !!bNewDiskCopyProDOS, this);
 			}
 		}
 	}
@@ -3067,7 +3067,7 @@ void Win32Frame::FrameCreateWindow(void)
 	{
 		const int nXScreen = GetSystemMetrics(SM_CXSCREEN) - nWidth;
 
-		if (RegLoadValue(REG_PREFS, REGVALUE_PREF_WINDOW_X_POS, 1, (uint32_t*)&nXPos))
+		if (RegLoadValue(REG_PREFS, REGVALUE_PREF_WINDOW_X_POS, true, (uint32_t*)&nXPos))
 		{
 			if ((nXPos > nXScreen) && !g_bMultiMon)
 				nXPos = -1;	// Not fully visible, so default to centre position
@@ -3082,7 +3082,7 @@ void Win32Frame::FrameCreateWindow(void)
 	{
 		const int nYScreen = GetSystemMetrics(SM_CYSCREEN) - nHeight;
 
-		if (RegLoadValue(REG_PREFS, REGVALUE_PREF_WINDOW_Y_POS, 1, (uint32_t*)&nYPos))
+		if (RegLoadValue(REG_PREFS, REGVALUE_PREF_WINDOW_Y_POS, true, (uint32_t*)&nYPos))
 		{
 			if ((nYPos > nYScreen) && !g_bMultiMon)
 				nYPos = -1;	// Not fully visible, so default to centre position


### PR DESCRIPTION
1. Registry functions
  The set of functions are changed to consistently use bool arguments.
  The macros are changed to inline functions to improve type checking.
  `RegSaveValue()` are overloaded with help of templates to reduce typecasting at call sites.
  For instance, bool value would be converted consistently instead of relying on call sites to convert bool to int values.
2. Memory functions
  BOOL usages were unnecessary. Mostly internal usages which can simply be bool.
3. FrameBase
  Some member variables are changed to bool. BOOL was used because of those Registry functions.

Additional changes:
- Some expressions are forced to be bool when assigning to bool variables.